### PR TITLE
Added transformations for pads, and helpers for creating soldermask layers l…

### DIFF
--- a/.github/jitx-client/scripts/evaluate_pcb_objects.py
+++ b/.github/jitx-client/scripts/evaluate_pcb_objects.py
@@ -158,15 +158,13 @@ def parse_package_name(file: File):
 
     raise Exception("No defpackage statement")
 
-def write_stanza_dot_proj(package_infos: List[PackageInfo]):
-    file = [PACKAGE_TEMPLATE.format(package_name=TEST_ENTRYPOINT_PACKAGE_NAME,
+def write_stanza_dot_proj():
+    file = ['include "../open-components-database/stanza.proj"',
+            PACKAGE_TEMPLATE.format(package_name=TEST_ENTRYPOINT_PACKAGE_NAME,
                                     file_name=TEST_ENTRYPOINT_FILE_NAME)]
     for top_level in TopLevel:
         file.append(PACKAGE_TEMPLATE.format(package_name=test_package_name(top_level),
                                             file_name=test_file_name(top_level)))
-    for info in package_infos:
-        file.append(PACKAGE_TEMPLATE.format(package_name=info.package_name, file_name=info.file_name))
-
     write_output_file("stanza.proj", file)
 
 def format_file_template(file_template: File, **kwargs):
@@ -202,7 +200,6 @@ def generate_deftest(argument: Optional[str], test_suffix: str):
 
 if __name__ == "__main__":
     os.makedirs(OUTPUT_DIRECTORY, exist_ok=True)
-    package_infos = []
     evaluated_excluded_files = [ROOT_DIRECTORY + file for file in EXCLUDED_FILES]
     # Should use Jinja2 templating engine
     test_files = {top_level: format_file_template(TEST_FILE_HEADER, package_name=test_package_name(top_level)) for top_level in TopLevel}
@@ -217,7 +214,6 @@ if __name__ == "__main__":
                 pcb_objects = parse_pcb_objects(file, file_path)
                 if pcb_objects:
                     package_name = parse_package_name(file)
-                    package_infos.append(PackageInfo(package_name, PREFIX_FILE_NAME + file_path))
                     for pcb_object in pcb_objects:
                         if pcb_object.arguments is None:
                             generate_deftest(None, "")
@@ -229,7 +225,7 @@ if __name__ == "__main__":
                                     test_suffix = str(idx)
                                 generate_deftest(argument, test_suffix)
 
-    write_stanza_dot_proj(package_infos)
+    write_stanza_dot_proj()
     write_output_file(TEST_ENTRYPOINT_FILE_NAME, generate_test_entrypoint_file())
     for top_level, test_file in test_files.items():
         write_output_file(test_file_name(top_level), test_file)

--- a/designs/smd-landpatterns.stanza
+++ b/designs/smd-landpatterns.stanza
@@ -1,0 +1,36 @@
+; Demonstration of transforming landpatterns to use soldermask-defined pads
+#use-added-syntax(jitx)
+defpackage demo:
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/defaults
+  import ocdb/box-symbol
+  import ocdb/land-patterns
+
+; A BGA package with 100 pins
+pcb-landpattern my-landpattern:
+  make-bga-pkg(
+    1.0, ; pitch:Double, 
+    0.5; pad-diam:Double, 
+    [4, 4]; n-pads:[Int Int], 
+    [5.0, 5.0]; courtyard:[Double Double],
+    false ; omit-pads:Tuple<Ref>|False
+  )
+  ref-label()
+
+pcb-component my-component (smd?:True|False):
+  ; ocdb/landpatterns/soldermask-defined is a transformation on pads and landpatterns
+  ; to convert into "soldermask defined" pads (SMD) where the soldermask opening is smaller
+  ; than the copper layer beneath them.
+  val lp = soldermask-defined(my-landpattern) when smd? else my-landpattern
+  assign-landpattern(lp)
+  make-box-symbol()
+
+pcb-module main-module:
+  inst smd-cmp:  my-component(true)
+  inst nsmd-cmp: my-component(false)
+
+make-default-board(main-module, 4, 10.0, 10.0)
+view-board()

--- a/stanza.proj
+++ b/stanza.proj
@@ -2,6 +2,8 @@
 ; Land pattern and symbol utilities 
 ;====================================
 package ocdb/land-patterns defined-in "utils/land-patterns.stanza"
+package ocdb/land-patterns/ipc-helpers defined-in "utils/land-patterns/ipc-helpers.stanza"
+package ocdb/land-patterns/leads defined-in "utils.land-patterns/ipc-helpers.stanza"
 package ocdb/symbols defined-in "utils/symbols.stanza"
 package ocdb/symbol-utils defined-in "utils/symbol-utils.stanza"
 package ocdb/box-symbol defined-in "utils/box-symbol.stanza"

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -11,5 +11,7 @@ public var MIN-PKG = "0201"
 public var DESIGN-QUANTITY = 100
 public var PREFERRED-MOUNTING = "smd" ; values in ["smd", "through-hole"]
 public var MIN-CAP-VOLTAGE = 10.0 ; Minimum voltage to allow for capacitors
+public var SOLDERMASK-EXPANSION = 0.15
+
 ; For consolidation
 ;public var PREFERRED-MANUFACTURERS = ["Yageo", "Panasonic Electronic Components", "Vishay Dale", "TE Connectivity Passive Product"]

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -5,7 +5,9 @@ defpackage ocdb/land-patterns :
   import math
   import jitx
   import jitx/fonts
-  import jitx/commands
+  import jitx/commands with:
+    prefix(pad) => def-
+  import ocdb/design-vars
 
 ; ====== Argument constraint Helpers ===========================================
 defn ensure-even-positive! (value: Int, name: String):
@@ -24,6 +26,65 @@ public defn ref-label () :
   ref-label(0.0, 0.0)
 
 ; ====== Land pattern utilities ===============================================
+; Apply a shape to the soldermask layer of a pcb-pad. 
+public defn apply-soldermask (mask-shape:Shape):
+  inside pcb-pad:
+    layer(SolderMask(Top)) = mask-shape
+    if pad-type(self) == TH:
+      layer(SolderMask(Bottom)) = mask-shape
+
+; Create the soldermask layers based on the pad shape, using a fixed factor.
+; when expand? is true the soldermask shape is computed with expand(), else it is
+; computed with offset()
+public defn apply-soldermask (amount:Double, expand?:True|False):
+  val func = expand when expand? else offset
+  inside pcb-landpattern:
+    apply-soldermask(func(pad-shape(self), amount))
+
+; Apply a default soldermask layer to a pcb-pad, using the SOLDERMASK-EXPANSION
+; design variable and offset() method.
+public defn apply-soldermask ():
+  apply-soldermask(SOLDERMASK-EXPANSION, false)
+
+; A "solder mask defined pad" is one where the soldermask opening is smaller than 
+; the pad shape. This method takes a pad as an argument and converts it into a 
+; soldermask-defined version based on its soldermask layer, if it exists, or the
+; pad shape if it does not.
+public defn soldermask-defined (p:Pad):
+  ; extract the pad data before conversion
+  val name_   = name(p)
+  val shape_  = pad-shape(p)
+  val type_   = pad-type(p)
+  val layers_ = layers(p)
+  val mask?   = find({specifier(_) is SolderMask}, layers_)
+  
+  ; special case: the mask is smaller than the shape already
+  if (mask? is-not False) and 
+     (min-width([shape_]) > min-width([shape $ (mask? as LayerShape)])) :
+    p
+  else :
+    pcb-pad SMD-p:
+      name  = to-string("%_, SMD" % [name_])
+      type  = type_
+      shape = shape_
+      apply-soldermask(0.85, true)
+      for layer_ in filter({specifier(_) is-not SolderMask}, layers_) do:
+        layer(specifier(layer_)) = shape(layer_)
+    SMD-p
+
+; Convert a landpattern to solder mask defined. Geoms will be ignored. 
+public defn soldermask-defined (lp:LandPattern):
+  val name_   = name(lp)
+  pcb-landpattern SMD-l:
+    name = to-string("%_, soldermask defined" % [name_])
+
+    for pad_ in pads(lp) do:
+      pad (ref(pad_)): soldermask-defined(def-pad(pad_)) at pose(pad_)
+      
+    for layer_ in layers(lp) do:
+      layer(specifier(layer_)) = shape(layer_)
+  SMD-l
+
 public pcb-pad smd-pad (anchor:Anchor, w:Double, h:Double) :
   name = to-string("%_x%_ %_ SMD Pad" % [w,h,anchor])
   type = SMD
@@ -39,15 +100,15 @@ public pcb-pad bga-pad (d:Double) :
   layer(SolderMask(Top)) = Circle(d / 2.0)
 
 public pcb-pad top-smd-testpoint-pad (d:Double) :
-  name = to-string("Test Point Pad")
-  type = SMD
+  name  = to-string("Test Point Pad")
+  type  = SMD
   shape = Circle(d / 2.0)
   layer(Paste(Top)) = Circle(d / 2.0)
   layer(SolderMask(Top)) = Circle(d / 2.0)
 
 public pcb-pad btm-smd-testpoint-pad (d:Double) :
-  name = to-string("Test Point Pad")
-  type = SMD
+  name  = to-string("Test Point Pad")
+  type  = SMD
   shape = Circle(d / 2.0)
   layer(Paste(Bottom)) = Circle(d / 2.0)
   layer(SolderMask(Bottom)) = Circle(d / 2.0)
@@ -59,8 +120,8 @@ public defn btm-smd-testpoint-pad () :
   btm-smd-testpoint-pad(2.0)
 
 public pcb-pad testpoint-pad (d:Double) :
-  name = to-string("%_  Testpoint Pad" % [d])
-  type = SMD
+  name  = to-string("%_  Testpoint Pad" % [d])
+  type  = SMD
   shape = Circle(d / 2.0)
   layer(SolderMask(Top)) = Circle(d / 2.0)
     
@@ -318,6 +379,19 @@ public defn make-two-pin-landpattern (Z:Double, G:Double, X:Double, w:Double, h:
     if courtyard? : 
       layer(Courtyard(Top)) = Rectangle(w, h)
 
+; A generic pad transformation helper
+public defn pad-transformation (
+  lp: LandPattern,
+  xform: (LandPatternPad) -> False|Pad,
+) -> LandPattern :
+  pcb-landpattern new-lp:
+    for pad_ in pads(lp) do:
+      val def = 
+        match(xform(pad_)):
+          (p:Pad): p
+          (_:False): def-pad(pad_)
+      pad (ref(pad_)): def at pose(pad_)
+  new-lp
 
 public defn make-two-pin-landpattern (Z:Double, G:Double, X:Double, w:Double, h:Double):
   make-two-pin-landpattern(Z,G,X,w,h,true,false)

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -52,23 +52,18 @@ public defn apply-soldermask ():
 ; pad shape if it does not.
 public defn soldermask-defined (p:Pad):
   ; extract the pad data before conversion
-  val name_   = name(p)
-  val shape_  = pad-shape(p)
-  val type_   = pad-type(p)
-  val layers_ = layers(p)
-  val mask?   = find({specifier(_) is SolderMask}, layers_)
-  
+  val mask?   = find({specifier(_) is SolderMask}, layers(p))  
   ; special case: the mask is smaller than the shape already
   if (mask? is-not False) and 
-     (min-width([shape_]) > min-width([shape $ (mask? as LayerShape)])) :
+     (min-width([pad-shape(p)]) > min-width([shape $ (mask? as LayerShape)])) :
     p
   else :
     pcb-pad SMD-p:
-      name  = to-string("%_, SMD" % [name_])
-      type  = type_
-      shape = shape_
+      name  = to-string("%_, SMD" % [name(p)])
+      type  = pad-type(p)
+      shape = pad-shape(p)
       apply-soldermask(0.85, true)
-      for layer_ in filter({specifier(_) is-not SolderMask}, layers_) do:
+      for layer_ in filter({specifier(_) is-not SolderMask}, layers(p)) do:
         layer(specifier(layer_)) = shape(layer_)
     SMD-p
 

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -69,9 +69,8 @@ public defn soldermask-defined (p:Pad):
 
 ; Convert a landpattern to solder mask defined. Geoms will be ignored. 
 public defn soldermask-defined (lp:LandPattern):
-  val name_   = name(lp)
   pcb-landpattern SMD-l:
-    name = to-string("%_, soldermask defined" % [name_])
+    name = to-string("%_, soldermask defined" % [name(lp)])
 
     for pad_ in pads(lp) do:
       pad (ref(pad_)): soldermask-defined(def-pad(pad_)) at pose(pad_)

--- a/utils/land-patterns/ipc-helpers.stanza
+++ b/utils/land-patterns/ipc-helpers.stanza
@@ -47,7 +47,7 @@ public pcb-struct ocdb/land-patterns/packages/LeadFillets:
   toe:Double  ; space away from the component towards the board
   heel:Double ; space towards the component
   side:Double ; space on the edges of the lead
-  courtyard-excess:Double ; TOOD: find out what this means and how to use it
+  courtyard-excess:Double ; additional area to add to the courtyard 
 
 ; Compute the LeadFillets of a lead type
 public defn lead-fillets (lead-type) -> LeadFillets:

--- a/utils/land-patterns/ipc-helpers.stanza
+++ b/utils/land-patterns/ipc-helpers.stanza
@@ -1,0 +1,314 @@
+#use-added-syntax(jitx)
+;==============================================================================
+;========================== Lead Helpers and Definitions ======================
+;==============================================================================
+defpackage ocdb/land-patterns/leads:
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/design-vars
+
+;TODO:
+;  - BGA (table 3-17)
+;  - PSON/PQFN/DFN (table 3-18)
+;  - OSCCC (table 3-19)
+;  - CGA/LGA (table 3-21)
+
+; LeadType is a helper enum for various kinds of leads and terminations on 
+; components. It is used to configure their generated land patterns.
+public pcb-enum ocdb/land-patterns/leads/LeadType:
+  SmallFlatRibbonLLeads,  ; Flat ribbon L leads for pitch less than 0.0625mm
+  SmallGullWingLeads,     ; Gull wwing leads with pitch less than 0.0625mm
+  BigFlatRibbonLLeads,    ; Flat ribbon L leads for pitch greater than 0.0625mm
+  BigGullWingLeads,       ; GullWing leads for pitch greater than 0.0625mm
+  JLeads,                 ; J Leads
+  SmallRectangularLeads,  ; Leads for rectangular components (chip capacitors, resistors, inductors) smaller than 0601
+  BigRectangularLeads,    ; Leads for rectangular components (chip capacitors, resistors, inductors) 0601 or larger
+  CylindricalLeads,       ; Cylindrical end cap leads
+  LeadlessChipCarrierLeads, ; Lead less chip carrier leads
+  ConcaveChipArrayLeads,    ; Concave chip array leads
+  ConvexChipArrayLeads,     ; Convex chip array leads
+  FlatChipArrayLeads,       ; Flat chip array leads
+  ButtJointLeads,           ; Butt joint leads
+  InwardFlatRibbonLLeads,   ; Inward flat ribbons L leads
+  FlatLugLeads,             ; flat lug leads
+  QuadFlatNoLeads,          ; quad flat components without leads
+  SmallOutlineNoLeads,      ; small outline packages without leads
+  SmallOutlineFlatLeads,    ; small outline flat leads
+  ShortTwoPinCrystalLeads,  ; two pin crystal components shorter than 10mm
+  ShortAluminumElectrolyticLeads, ; electrolytic capacitor shorter than 10mm
+  TallTwoPinCrystalLeads,         ; two pin crystal components 10mm or taller
+  TallAluminumElectrolyticLeads,  ; electrolytic capacitor 10mm or taller
+
+; LeadFillets are extra spacing along the sides of a lead when generating a land for 
+; a component's leads.
+public pcb-struct ocdb/land-patterns/packages/LeadFillets:
+  toe:Double  ; space away from the component towards the board
+  heel:Double ; space towards the component
+  side:Double ; space on the edges of the lead
+  courtyard-excess:Double ; TOOD: find out what this means and how to use it
+
+; Compute the LeadFillets of a lead type
+public defn lead-fillets (lead-type) -> LeadFillets:
+  lead-fillets(lead-type, DESIGN-PRODUCIBILITY)
+
+; Compute the LeadFillets of a lead type, given a design producability level.
+public defn lead-fillets (lead-type:LeadType, p:DesignProducability) -> LeadFillets:
+  match(lead-type):
+    (_:SmallFlatRibbonLLeads): flat-ribbon-L(p, 0.0)
+    (_:SmallGullWingLeads): gull-wing-leads(p, 0.0)
+    (_:BigFlatRibbonLLeads): flat-ribbon-L(p, 1.0)
+    (_:BigGullWingLeads): gull-wing-leads(p, 1.0)
+    (_:JLeads): j-leads(p)
+    (_:BigRectangularLeads): big-rectangular(p)
+    (_:SmallRectangularLeads): small-rectangular(p)
+    (_:CylindricalLeads): cylindrical(p)
+    (_:LeadlessChipCarrierLeads): leadless-chip-carrier(p)
+    (_:ConcaveChipArrayLeads): concave-chip-array(p)
+    (_:ConvexChipArrayLeads): convex-chip-array(p)
+    (_:FlatChipArrayLeads): flat-chip-array(p)
+    (_:ButtJointLeads): butt-joints(p)
+    (_:InwardFlatRibbonLLeads): inward-flat-ribbon-l-leads(p)
+    (_:FlatLugLeads): flat-lug-leads(p)
+    (_:QuadFlatNoLeads): quad-flat-no-lead(p)
+    (_:SmallOutlineNoLeads): small-outline-no-lead(p)
+    (_:SmallOutlineFlatLeads): small-outline-flat-lead(p)
+    (_:ShortTwoPinCrystalLeads): two-pin-crystal(p, 0.0)
+    (_:ShortAluminumElectrolyticLeads): aluminum-electrolytic(p, 0.0)
+    (_:TallTwoPinCrystalLeads): two-pin-crystal(p, 11.0)
+    (_:TallAluminumElectrolyticLeads): two-pin-crystal(p, 11.0)
+
+;==============================================================================
+;============================ LeadFillet tables ===============================
+;==============================================================================
+protected defn flat-ribbon-L (p:DesignProducability, pitch:Double):
+  if pitch > 0.0625:
+    switch(p):
+      LevelA: LeadFillets(0.55, 0.45, 0.05, 0.5)
+      LevelB: LeadFillets(0.35, 0.35, 0.03, 0.25)
+      LevelC: LeadFillets(0.15, 0.25, 0.01, 0.1)
+  else:
+    switch(p):
+      LevelA: LeadFillets(0.55, 0.45, 0.01  0.5)
+      LevelB: LeadFillets(0.35, 0.35, -0.02 0.25)
+      LevelC: LeadFillets(0.15, 0.25, -0.04 0.1)
+
+protected defn gull-wing-leads (p:DesignProducability, pitch:Double):
+  flat-ribbon-L(p, pitch)
+
+protected defn j-leads (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.55, 0.10, 0.05 ,0.5)
+    LevelB: LeadFillets(0.35, 0.00, 0.03 ,0.25)
+    LevelC: LeadFillets(0.15, -0.10, 0.01,0.1)
+
+; components bigger than 0601
+protected defn big-rectangular (p:DesignProducability): 
+  switch(p):
+    LevelA: LeadFillets(0.55, 0.00, 0.05 ,0.5)
+    LevelB: LeadFillets(0.35, 0.00, 0.00 ,0.25)
+    LevelC: LeadFillets(0.15, 0.00, -0.05, 0.1)
+
+; rectangular components smaller than 0601
+protected defn small-rectangular (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.30, 0.00, 0.05 ,0.5)
+    LevelB: LeadFillets(0.20, 0.00, 0.00 ,0.25)
+    LevelC: LeadFillets(0.10, 0.00, -0.05, 0.1)
+
+protected defn cylindrical (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.60, 0.20, 0.10, 0.5)
+    LevelB: LeadFillets(0.40, 0.10, 0.05, 0.25)
+    LevelC: LeadFillets(0.20, 0.02, 0.01, 0.1)
+
+protected defn leadless-chip-carrier (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.65, 0.25, 0.05, 0.5)
+    LevelB: LeadFillets(0.55, 0.15, -0.05, 0.25)
+    LevelC: LeadFillets(0.45, 0.05, -0.15, 0.1)
+
+protected defn concave-chip-array (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.55, -0.05, -0.05, 0.5)
+    LevelB: LeadFillets(0.45, -0.07, -0.07, 0.25)
+    LevelC: LeadFillets(0.35, -0.20, -0.10, 0.1)
+
+protected defn convex-chip-array (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.55, -0.05, -0.05, 0.5)
+    LevelB: LeadFillets(0.45, -0.07, -0.07, 0.25)
+    LevelC: LeadFillets(0.35, -0.20, -0.10, 0.1)
+
+protected defn flat-chip-array (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.55, -0.05, -0.05, 0.5)
+    LevelB: LeadFillets(0.45, -0.07, -0.07, 0.25)
+    LevelC: LeadFillets(0.35, -0.20, -0.10, 0.1)
+
+protected defn butt-joints (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(1.0, 1.0, 0.3, 1.5)
+    LevelB: LeadFillets(0.8, 0.8, 0.2, 0.8)
+    LevelC: LeadFillets(0.6, 0.6, 0.1, 0.2)
+
+protected defn inward-flat-ribbon-l-leads (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.25, 0.8, 0.01, 0.5)
+    LevelB: LeadFillets(0.15, 0.5, -0.05, 0.25)
+    LevelC: LeadFillets(0.07, 0.2, -0.10, 0.1)
+
+protected defn flat-lug-leads (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.55, 0.45, 0.05, 0.5)
+    LevelB: LeadFillets(0.35, 0.35, 0.03, 0.25)
+    LevelC: LeadFillets(0.15, 0.25, 0.01, 0.1)
+
+protected defn quad-flat-no-lead (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.4, 0.00, -0.04, 0.5)
+    LevelB: LeadFillets(0.3, 0.00, -0.04, 0.25)
+    LevelC: LeadFillets(0.2, 0.00, -0.04, 0.1)
+
+protected defn small-outline-no-lead (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.4, 0.00, -0.04, 0.5)
+    LevelB: LeadFillets(0.3, 0.00, -0.04, 0.25)
+    LevelC: LeadFillets(0.2, 0.00, -0.04, 0.1)
+
+protected defn small-outline-flat-lead (p:DesignProducability):
+  switch(p):
+    LevelA: LeadFillets(0.3, 0.00,  0.05, 0.2)
+    LevelB: LeadFillets(0.2, 0.00,  0.00, 0.15)
+    LevelC: LeadFillets(0.1, 0.00, -0.05, 0.1)
+
+protected defn two-pin-crystal (p:DesignProducability, height:Double):
+  if height < 10.0:
+    switch(p):
+      LevelA: LeadFillets(0.7,  0.00, 0.5, 1.0)
+      LevelB: LeadFillets(0.5, -0.10, 0.4, 0.5)
+      LevelC: LeadFillets(0.3, -0.20, 0.3, 0.25)
+  else:
+    switch(p):
+      LevelA: LeadFillets(1.0,  0.00, 0.6, 1.0)
+      LevelB: LeadFillets(0.7, -0.05, 0.5, 0.5)
+      LevelC: LeadFillets(0.4, -0.10, 0.4, 0.25)
+
+protected defn aluminum-electrolytic (p:DesignProducability, height:Double):
+  two-pin-crystal(p, height)
+
+;==============================================================================
+;========================== Main Helpers ======================================
+;==============================================================================
+defpackage ocdb/land-patterns/ipc-helpers:
+  import core
+  import collections
+  import math
+  import jitx
+  import jitx/commands
+  import ocdb/design-vars
+  import ocdb/land-patterns/leads
+  import ocdb/land-patterns/packages
+
+; Component tolerances, defined by component manufacturers.
+public pcb-struct ocdb/land-patterns/ipc-helpers/ComponentTolerance:
+  width: Double,      ; tolerance on the width of a land pattern
+  length:Double,      ; tolerance on the length of a land pattern
+  lead-widths:Double, ; tolerance on the terminations or leads of a land pattern
+
+; A single value and its tolerance
+public pcb-struct ocdb/land-patterns/ipc-helpers/SingleTolerance:
+  value:Double, 
+  tolerance:Double, ; TODO with: ensure => non-negative! and less than value
+
+; A set of manufacturing tolerances
+public pcb-struct ocdb/land-patterns/ipc-helpers/ManufacturerTolerances:
+  fabrication:Double,       ; unilateral profile tolerance for the printed board land pattern 
+  placement-accuracy:Double ; diameter of true position placement accuracy to the center of the land pattern
+
+; A single value and its tolerance
+public pcb-struct ocdb/land-patterns/ipc-helpers/SingleTolerance:
+  nominal-value:Double, 
+  tolerance:Double, ; TODO with: ensure => non-negative! and less than value
+
+; Return the minimum value for a value with some tolerance
+public defn min (s:SingleTolerance) -> Double: 
+  value(s) - tolerance(s)
+
+; Return the maximum value for a value with some tolerance
+public defn max (s:SingleTolerance) -> Double: 
+  value(s) + tolerance(s)
+
+; Find the RMS sum of many tolerances. This operation is non-commutative and non-associative, so 
+; it should be called once when working with tolerances.
+public defn sum (s:Seqable<SingleTolerance>) -> SingleTolerance:
+  var nom = 0.0
+  var tol = 0.0
+  for t in s do:
+    nom = nom + value(t)
+    tol = tol + tolerance(s) * tolerance(s)
+  SingleTolerance(nom, sqrt(tol))
+
+;==============================================================================
+; Value References:
+;
+; Z: Double,  ; overall length of the landpattern
+; G: Double,  ; distance between pads
+; X: Double,  ; width of the landpattern
+; L: Double,  ; overall length of the component
+; S: Double,  ; distance between component terminations
+; W: Double,  ; width of the lead or termination
+; Jt: Double, ; solder fillet at toe
+; Jh: Double, ; solder fillet at heel
+; Js: Double, ; solder fillet at side
+; Cl: Double, ; length tolerance
+; Cs: Double, ; tolerance on distance between component terminations
+; Cw: Double, ; tolerance on lead width
+; F: Double,  ; printed board fabrication tolerances
+; P: Double,  ; part placement tolerance
+;==============================================================================
+
+; Computes the dimensions of a land pattern, returning: [Dims, Double]
+; where the first result is (X, Z) and the second is G.
+public defn land-pattern-dimensions (
+  land-pattern-dims: Dims             ; Dims(X, Z), nominal land pattern dimensions
+  lead-dims: Dims                     ; Dims(W, T), nominal lead/termination dimensions
+  distance-between-lands: Double,     ; G, the space between pads
+  lead-fillets: LeadFillets       ; J
+  component-tolerance: ComponentTolerance   ; C
+  manufacturer-tolerance: ManufacturerTolerances ; F, P
+):
+  defn formula (a, b, c) -> Double:
+    val F = fabrication(manufacturer-tolerance)
+    val P = placement-accuracy(manufacturer-tolerance)
+    sum([SingleTolerance(a, c), SingleTolerance(b, F, SingleTolerance(b, P)])
+
+  val Lmin = y(land-pattern-dims) - length(component-tolerance)
+  val Lmax = y(land-pattern-dims) + length(component-tolerance)
+  val Smax = Lmax - 2. * (y(lead-dims) - lead-widths(component-tolerance))
+  val Wmin = x(lead-dims) - lead-widths(tolerance)
+  val Xmax = formula(Wmin, side(lead-fillets), width(tolerance)) ; TODO sanity check this. The formula does not make sense.
+  val Zmax = formula(Lmin, toe(lead-fillets), length(component-tolerance))
+  val Gmin = formula(Smax, - heel(lead-fillets), lead-widths(component-tolerance))
+
+  [Dims(Xmax, Zmax), Gmin]
+
+; Computes the dimensions of a land pattern, return: [Dims, Double] where the first
+; result is (X, Z) and the second is G. Assumes the manufacturing tolerances are 
+; defaults TODO: pick sensible defaults or introspect design rules
+public defn land-pattern-dimensions (
+  land-pattern-dims: Dims, 
+  lead-dims: Dims,
+  distance-between-lands:Double,
+  lead-fillets:LeadFillets,
+  component-tolerances:ComponentTolerance
+):
+  land-pattern-dimensions(
+    land-pattern-dims, 
+    lead-dims, 
+    distance-between-lands, 
+    lead-filets,
+    component-tolerances, 
+    ManufacturerTolerances(0.0, 0.0)) ; todo: reasonable defaults or pull from design rules
+


### PR DESCRIPTION
New Design, `designs/smd-landpatterns.stanza`. This demonstrates how to call `soldermask-defined`. 

New API methods:

- `soldermask-defined`: transform a `LandPattern` or `Pad`, returning a new definition of either using soldermask defined pads. Geom statements are unsupported. 
- `apply-soldermask`: helpers for creating the soldermask layers of a component, with several configurations. 

Usage of the soldermask helpers is as follows:

```stanza
pcb-pad my-pad: 
  val pad-shape: Capsule(1.0, 1.0)
  shape = pad-shape
  type = TH
  layer(Cutout()) = Circle(0.25)
  apply-soldermask(pad-shape)
```

The soldermask will by applied on both `Top` and `Bottom` if the pad is TH, else it will be only applied to the `Top` layer. 

```stanza
pcb-pad my-pad:
  shape = Rectangle(1.0, 1.0)
  type = SMD
  apply-soldermask(0.1, false)
```
The soldermask will be applied with a 0.1 mm offset to the pad shape.

```stanza
pcb-pad my-pad:
  shape = Rectangle(1.0, 1.0)
  type = SMD
  apply-soldermask(1.1, true)
```

The soldermask will be applied with the pad shape, expanded by a factor of 1.1. 

```stanza
pcb-pad my-pad:
  shape = Rectangle(1.0, 1.0)
  type = SMD
  apply-soldermask()
```

The soldermask will be applied with the default offset, defined in design-vars.stanza. 