### PR TITLE
Improve `connects()` helpers in connects.stanza

### DIFF
--- a/components/texas-instruments/ISO1540.stanza
+++ b/components/texas-instruments/ISO1540.stanza
@@ -18,18 +18,16 @@ public pcb-component component :
   manufacturer = "Texas Instruments"
   mpn = "ISO1540DR"
   description = "2.5-kVrms isolated bidirectional clock, bidirectional I2C isolator"
+  port p: i2c[[1 2]]
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir]
-    [GND1    | 4            | Down    ]
-    [GND2    | 5            | Down    ]
-    [SCL1    | 3            | Left    ]
-    [SCL2    | 6            | Right   ]
-    [SDA1    | 2            | Left    ]
-    [SDA2    | 7            | Right   ]
-    [VCC1    | 1            | Up      ]
-    [VCC2    | 8            | Up      ]
+    [GND1     | 4            | Down    ]
+    [GND2     | 5            | Down    ]
+    [p[1].scl | 3            | Left    ]
+    [p[2].scl | 6            | Right   ]
+    [p[1].sda | 2            | Left    ]
+    [p[2].sda | 7            | Right   ]
+    [VCC1     | 1            | Up      ]
+    [VCC2     | 8            | Up      ]
   make-box-symbol()
   assign-landpattern(soic127p-landpattern(8))
-
-public pcb-module module :
-  inst c : component

--- a/tests/test-connects.stanza
+++ b/tests/test-connects.stanza
@@ -1,0 +1,75 @@
+#use-added-syntax(jitx, tests)
+defpackage ocdb/tests/connects: 
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/connects
+  import ocdb/bundles
+
+defn expect-fatal (body:() -> ?):
+  var caught? = false
+  execute-with-error-handler(
+    body,
+    fn (): caught? = true
+  )
+  #EXPECT(caught?)
+
+deftest(ocdb, connects) test-connect-i2c-isolation:
+  pcb-module M1:
+    port p: i2c[[1, 2]]
+    #EXPECT(connect-i2c-isolation(p[1], p[2]) is-not False)
+  
+  pcb-module M2:
+    port p: i2c[[1, 2]]
+    #EXPECT(connect-i2c-isolation(p[1], p[2], M1) is-not False)
+
+  pcb-module M3:
+    port x: i2c
+    port y: gpio
+    var caught? = false
+    within expect-fatal():
+      connect-i2c-isolation(x, y)
+     
+  for mod in [M1, M2, M3] do:
+    print-def(mod)
+
+deftest(ocdb, connects) test-connect-phy:
+  pcb-module M1:
+    port x: rgmii
+    port y: ethernet-1000
+    #EXPECT(connect-phy(x, y) is-not False)
+  pcb-module M2:
+    port x: rgmii
+    port y: gpio
+    within expect-fatal():
+      connect-phy(x, y)
+  pcb-module M3:
+    port x: gpio
+    port y: ethernet-1000
+    within expect-fatal():
+      connect-phy(x, y)
+  for mod in [M1, M2, M3] do:
+    print-def(mod)
+
+deftest(ocdb, connects) test-connect-ft2332:
+  pcb-module M1:
+    port x: usb-2
+    port y: uart-with([`dtr, `rts])
+    #EXPECT(connect-ft232(x, y) is-not False)
+
+  pcb-module M2:
+    port x: usb-2
+    port y: gpio
+    within expect-fatal():
+      connect-ft232(x, y)
+
+  pcb-module M3:
+    port x: gpio
+    port y: uart-with([`dtr, `rts])
+    within expect-fatal():
+      connect-ft232(x, y)
+    
+  for mod in [M1, M2, M3] do:
+    print-def(mod)
+    

--- a/tests/test-debug-utils.stanza
+++ b/tests/test-debug-utils.stanza
@@ -10,7 +10,6 @@ defpackage ocdb/tutorial :
   import ocdb/tests/default-harness
   import ocdb/pinspec
   import ocdb/land-patterns
-  import ocdb/connects
   import ocdb/generator-utils
   import ocdb/debug-utils
   import ocdb/generic-components

--- a/utils/connects.stanza
+++ b/utils/connects.stanza
@@ -44,7 +44,7 @@ defn ensure-bundles!<?T> (
           name(b? as Bundle) when b? is-not False else false
         ]
       )
-    fatal(buf) ; todo error or exception here?
+    fatal(to-string(buf)) ; todo error or exception here?
     false
   else:
     ; good to go, call the body and return

--- a/utils/connects.stanza
+++ b/utils/connects.stanza
@@ -12,41 +12,89 @@ defpackage ocdb/connects :
   import ocdb/bundles
   import ocdb/symbols
   import ocdb/box-symbol
+  import lang-utils
 
-public defn connect-isolate (a:JITXObject, b:JITXObject) :
-  inside pcb-module :
-    eval-when true :
-      match(port-type(a), port-type(b)) :
-        (pa:Bundle, pb:Bundle) :
-          if pa == i2c and pb == i2c :
-            inst buf : ocdb/texas-instruments/ISO1540/component
-            net (a.sda, buf.SDA1)
-            net (a.scl, buf.SCL1)
-            net (b.sda, buf.SDA2)
-            net (b.scl, buf.SCL2)
-            property(buf.VCC1.requires-power) = true
-            property(buf.VCC1.power-request) = [3.3 0.3 0.05]
+; Helper function to check if the ports have bundles and their assigned
+; bundle matches what we expect
+defn ensure-bundles!<?T> (
+  body: () -> ?T, 
+  ports:Seqable<JITXObject>, 
+  bundles:Seqable<Bundle>,
+  action) -> False|T:
+  ; collect the mismatched bundles from ports
+  val errors = 
+    for (p in ports, b in bundles) seq?:
+      match(port-type(p)):
+        (b?:Bundle):
+          if b? != b:
+            One([p, b, b?])  ; case 1: ports exist but do not match
+          else:
+            None()           ; case 2: ports exist and match, we're good to go
+        (_:?):
+          One([p, b, false]) ; case 3: port is not a bundle
+  
+  ; error if not empty
+  if not empty?(errors):
+    val buf = StringBuffer()
+    println(buf, "Could not %_. Bundles did not match." % [action])
+    for [p, b, b?] in errors do:
+      println(IndentedStream(buf), 
+        "Expected %_ for port %_. Found %_." % [
+          name(b), ref(p), 
+          name(b? as Bundle) when b? is-not False else false
+        ]
+      )
+    fatal(buf) ; todo error or exception here?
+    false
+  else:
+    ; good to go, call the body and return
+    body()
 
+; Connect two i2c lines with a buffer. 
+public defn connect-i2c-isolation (
+  x:JITXObject,
+  y:JITXObject,
+  buffer:Instantiable
+):
+  within ensure-bundles!([x, y], [i2c, i2c], "call connect-isolation"):
+    inside pcb-module:
+      public inst buf: buffer
+      net (x, buf.p[1])
+      net (y, buf.p[2])
+      buf
+
+; Connect to i2c lines with a buffer, using a default component (TI ISO1540)
+public defn connect-i2c-isolation (
+  x:JITXObject,
+  y:JITXObject,
+):
+  inside pcb-module:
+    val buf = connect-i2c-isolation(x, y, ocdb/texas-instruments/ISO1540/component)
+    match(buf:Instance):
+      property(buf.VCC1.requires-power) = true
+      property(buf.VCC1.power-request) = [3.3 0.3 0.05]
+    buf
+    
+; Wrapper around connect-i2c-isolation for backwards compatibility
+public defn connect-isolate (a:JITXObject, b:JITXObject):
+  connect-i2c-isolation(a, b)
+
+; Connect PHY using a default component (Marvell 8831510-A0-NNB2C000)
 public defn connect-phy (x:JITXObject, y:JITXObject) :
-  inside pcb-module :
-    eval-when true :
-      match(port-type(x), port-type(y)) :
-        (px:Bundle, py:Bundle) :
-          if px == rgmii and py == ethernet-1000 :
-            inst phy : ocdb/marvell/88E1510-A0-NNB2C000/module
-            net (x, phy.rgmii)
-            net (y.mdi, phy.mdi)
-            schematic-group(phy) = phy
+  within ensure-bundles!([x, y], [rgmii, ethernet-1000], "call connect-phy"):
+    inside pcb-module:
+      public inst phy : ocdb/marvell/88E1510-A0-NNB2C000/module
+      net (x, phy.rgmii)
+      net (y.mdi, phy.mdi)
+      schematic-group(phy) = phy
+      phy
 
+; Connect USB-2 over UART using FT232 USB to serial interface
 public defn connect-ft232 (x:JITXObject, y:JITXObject) :
-  inside pcb-module :
-    match(port-type(x), port-type(y)) :
-      (px:Bundle, py:Bundle) :
-        if px == usb-2 and py == uart-with([`dtr `rts]) :
-          public inst xcvr : ocdb/future-designs/FT232RL/module
-          net (x, xcvr.usb-2)
-          net (y.tx, xcvr.uart.rx)
-          net (y.rx, xcvr.uart.tx)
-          net (y.dtr, xcvr.uart.dtr)
-          net (y.rts, xcvr.uart.rts)
-          schematic-group(xcvr) = xcvr
+  within ensure-bundles!([x, y], [usb-2, uart-with([`dtr, `rts])],  "call connect-ft32"):
+    inside pcb-module :
+      public inst xcvr : ocdb/future-designs/FT232RL/module
+      net (x, xcvr.usb-2)
+      net (y, xcvr.uart)
+      schematic-group(xcvr) = xcvr
+      xcvr

--- a/utils/connects.stanza
+++ b/utils/connects.stanza
@@ -33,22 +33,19 @@ defn ensure-bundles!<?T> (
         (_:?):
           One([p, b, false]) ; case 3: port is not a bundle
   
-  ; error if not empty
-  if not empty?(errors):
+  if empty?(errors):
+    body()
+  else:
     val buf = StringBuffer()
     println(buf, "Could not %_. Bundles did not match." % [action])
     for [p, b, b?] in errors do:
       println(IndentedStream(buf), 
         "Expected %_ for port %_. Found %_." % [
           name(b), ref(p), 
-          name(b? as Bundle) when b? is-not False else false
+          name(b? as Bundle) when b? is-not False else port-type(p)
         ]
       )
-    fatal(to-string(buf)) ; todo error or exception here?
-    false
-  else:
-    ; good to go, call the body and return
-    body()
+    fatal(to-string(buf))
 
 ; Connect two i2c lines with a buffer. 
 public defn connect-i2c-isolation (


### PR DESCRIPTION
- refactored ISO1540 to contain i2c ports explicitly
- refactored connects.stanza to check port bundles and print all mismatches 
- added unit tests for connects 
