### PR TITLE
Parse switch statements in macros to get example inputs

### DIFF
--- a/.github/jitx-client/scripts/evaluate_pcb_objects.py
+++ b/.github/jitx-client/scripts/evaluate_pcb_objects.py
@@ -138,13 +138,15 @@ def choose_pcb_object_arguments(arg_name: str, arg_type: str, file: File, line_n
         while cursor < len(file) and file[cursor][0] in ("\n", " ", ";") :
             cursor += 1
 
-        function_code = [l := remove_comment(line) for line in file[line_number + 1:cursor] if not re.match(" *\n", l)]
+        function_code = [l for line in file[line_number + 1:cursor] if not re.match(" *\n", (l := remove_comment(line)))]
         for line_idx, line in enumerate(function_code[:-1]) :
             #if re.match("[^;]*switch\({arg_name}\)\n".format(arg_name=arg_name), file[cursor]):
             if f"switch({arg_name})" in line :
                 if (m := re.match(f" *({VALUE_REGEX}) *:", function_code[line_idx + 1])):
-                    print(f"Switch parsing failure: can't retrieve example value in\n```\n{line + function_code[line_idx + 1]}\n```")
                     return [m.group(1)]
+                else:
+                    print(f"Switch parsing failure: can't retrieve example value in\n```\n{line + function_code[line_idx + 1]}\n```")
+                    break
 
         return [TYPE_SAMPLE[arg_type]]
 

--- a/.github/jitx-client/scripts/evaluate_pcb_objects.py
+++ b/.github/jitx-client/scripts/evaluate_pcb_objects.py
@@ -60,7 +60,7 @@ def or_regex(strings: Iterable[str]) -> str:
 
 PACKAGE_REGEX = "[\w!?/-]+"
 VARIABLE_REGEX = "[\w!?-]+"
-VALUE_REGEX = '[-+.!?"\w\d]+'
+VALUE_REGEX = "[-+.!?\"'\w\d]+"
 TYPE_SAMPLE = {
     "Char": '"c"',
     "String": '"hello world"',
@@ -133,8 +133,27 @@ def choose_pcb_object_arguments(arg_name: str, arg_type: str, file: File, line_n
             else:
                 raise TestAnnotationError(number)
     else:
+        cursor = line_number + 1
+        # Detect function body
+        while cursor < len(file) and file[cursor][0] in ("\n", " ", ";") :
+            cursor += 1
+
+        function_code = [l := remove_comment(line) for line in file[line_number + 1:cursor] if not re.match(" *\n", l)]
+        for line_idx, line in enumerate(function_code[:-1]) :
+            #if re.match("[^;]*switch\({arg_name}\)\n".format(arg_name=arg_name), file[cursor]):
+            if f"switch({arg_name})" in line :
+                if (m := re.match(f" *({VALUE_REGEX}) *:", function_code[line_idx + 1])):
+                    print(f"Switch parsing failure: can't retrieve example value in\n```\n{line + function_code[line_idx + 1]}\n```")
+                    return [m.group(1)]
+
         return [TYPE_SAMPLE[arg_type]]
 
+def remove_comment(line: str) -> str :
+    idx = line.find(';')
+    if idx >= 0:
+        return line[:idx] + "\n"
+    else:
+        return line
 
 def parse_pcb_objects(file: File, file_path: str) -> List[PcbObject]:
     objects = []

--- a/.github/jitx-client/scripts/evaluate_pcb_objects.py
+++ b/.github/jitx-client/scripts/evaluate_pcb_objects.py
@@ -140,7 +140,6 @@ def choose_pcb_object_arguments(arg_name: str, arg_type: str, file: File, line_n
 
         function_code = [l for line in file[line_number + 1:cursor] if not re.match(" *\n", (l := remove_comment(line)))]
         for line_idx, line in enumerate(function_code[:-1]) :
-            #if re.match("[^;]*switch\({arg_name}\)\n".format(arg_name=arg_name), file[cursor]):
             if f"switch({arg_name})" in line :
                 if (m := re.match(f" *({VALUE_REGEX}) *:", function_code[line_idx + 1])):
                     return [m.group(1)]

--- a/components/analog-devices/ADM7150.stanza
+++ b/components/analog-devices/ADM7150.stanza
@@ -21,9 +21,6 @@ doc: \<s>
 `v-out` is the specified output voltage of the voltage regulator in volts. Valid values are `3.0`, `3.3`, and `5.0`.
 <s>
 
-;<test>
-v-out: 3.3
-<test>
 public pcb-component component (v-out:Double) :
   name = "ADM7150"
   manufacturer = "Analog Devices"

--- a/components/analog-devices/ADM7154.stanza
+++ b/components/analog-devices/ADM7154.stanza
@@ -14,9 +14,6 @@ defpackage ocdb/analog-devices/ADM7154:
   import ocdb/symbols
   import ocdb/box-symbol
 
-;<test>
-v-out: 2.5
-<test>
 public pcb-component component (v-out:Double) :
   name = "ADM7154"
   description = "600 mA, Ultralow Noise, High PSRR, RF Linear Regulator"

--- a/components/idt/5PB11xx.stanza
+++ b/components/idt/5PB11xx.stanza
@@ -13,9 +13,6 @@ defpackage ocdb/idt/5PB11xx:
   import ocdb/symbols
   import ocdb/box-symbol
 
-;<test>
-n: 8
-<test>
 public pcb-component component (n:Int) :
   description = "1.8V to 3.3V LVCMOS High Performance Clock Buffer Family"
   manufacturer = "IDT"

--- a/components/keystone/500xx.stanza
+++ b/components/keystone/500xx.stanza
@@ -12,9 +12,6 @@ defpackage ocdb/keystone/500xx:
   import ocdb/bundles
   import ocdb/symbols
 
-;<test>
-color: "red"
-<test>
 public pcb-component component (color:String) :
   name = "500xx"
   manufacturer = "Keystone Electronics"

--- a/components/pomona/1581.stanza
+++ b/components/pomona/1581.stanza
@@ -12,9 +12,6 @@ defpackage ocdb/pomona/1581 :
   import ocdb/bundles
   import ocdb/symbols
 
-;<test>
-color: "black"
-<test>
 public pcb-component component (color:String) :
   pin p
   manufacturer = "Pomona"

--- a/components/texas-instruments/SN74LVC245A.stanza
+++ b/components/texas-instruments/SN74LVC245A.stanza
@@ -13,9 +13,6 @@ defpackage ocdb/texas-instruments/SN74LVC245A :
   import ocdb/checks
   import ocdb/box-symbol
 
-;<test>
-pkg-dwg: "DW"
-<test>
 public pcb-component component (pkg-dwg:String) :
   name = "SN74LVC245A"
   manufacturer = "Texas Instruments"

--- a/components/texas-instruments/TLV743P.stanza
+++ b/components/texas-instruments/TLV743P.stanza
@@ -13,9 +13,6 @@ defpackage ocdb/texas-instruments/TLV743P :
   import ocdb/symbols
   import ocdb/box-symbol
 
-;<test>
-v-out: 1.5
-<test>
 public pcb-component component (v-out:Double) :
   pin en
   pin gnd

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -361,8 +361,9 @@ public defn make-ipc-two-pin-landpattern (part-name:String, courtyard?:True|Fals
 public defn make-ipc-two-pin-landpattern (part-name:String) :
   make-ipc-two-pin-landpattern(part-name, true, false)
 
+; last 3 are made up
 ;<test>
-part-name: "01005" "008004" "006003" "01007" "5040" ; last 3 are made up
+part-name: "01005" "008004" "006003" "01007" "5040"
 <test>
 public pcb-landpattern ipc-two-pin-landpattern (part-name:String) :
   make-ipc-two-pin-landpattern(part-name, true, false)

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -358,14 +358,11 @@ public defn make-ipc-two-pin-landpattern (part-name:String, courtyard?:True|Fals
     external-names = ([part-name])
     ref-label()
 
-;<test>
-part-name: "008004" "006003" "01007" "5040" ; last 3 are made up
-<test>
 public defn make-ipc-two-pin-landpattern (part-name:String) :
   make-ipc-two-pin-landpattern(part-name, true, false)
 
 ;<test>
-part-name: "01005"
+part-name: "01005" "008004" "006003" "01007" "5040" ; last 3 are made up
 <test>
 public pcb-landpattern ipc-two-pin-landpattern (part-name:String) :
   make-ipc-two-pin-landpattern(part-name, true, false)

--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -384,9 +384,6 @@ public pcb-symbol diode-rgb-led :
   unit-ref([1.0, 2.0])
   unit-val([1.0, 1.5])
 
-;<test>
-bjt-type: "pnp"
-<test>
 public pcb-symbol bjt-sym (bjt-type:String) :
   pin e at unit-point(1.0, -1.0)
   pin c at unit-point(1.0, 1.0)


### PR DESCRIPTION
If no annotation is detected, parses switch statements to infer macro argument in input values: will detect the value of the first case of the switch statements in the tested macros.

Example with strings and doubles:
```
  val [code spice-code] = switch(v-out) :
    1.5 : ["15" "TLV74315P"]
    2.5 : ["25" "TLV74325P"]
    3.3 : ["33" "TLV74333P"]
```
and
```
  mpn = switch(color) :
    "red"    : "5000"
    "black"  : "5001"
    "white"  : "5002"
    "orange" : "5003"
    "yellow" : "5004"
```
![image](https://user-images.githubusercontent.com/17492851/122157726-36e22e00-ce20-11eb-9b95-8f3ea47e9632.png)


Removes comments and then removes resulting empty lines to handle:
```
  val         [mpn               pkg-type    dir-p oen-p A-p                              B-p                              vcc-p gnd-p pkg] =
    switch(pkg-dwg) :
    ; "DB"  : ["SN74LVC245ADBR"  "SSOP"      1     19    [2, 3, 4, 5, 6, 7, 8, 9]         [18, 17, 16, 15, 14, 13, 12, 11] 20    10    ssop-landpattern(20) ]
    ; "DGV" : ["SN74LVC245ADGVR" "TVSOP"     1     19    [2, 3, 4, 5, 6, 7, 8, 9]         [18, 17, 16, 15, 14, 13, 12, 11] 20    10    tvsop-landpattern(20) ]
      "DW"  : ["SN74LVC245ADWR"  "SOIC"      1     19    [2, 3, 4, 5, 6, 7, 8, 9]         [18, 17, 16, 15, 14, 13, 12, 11] 20    10    soic127p-landpattern(20) ]
    ; "N"   : ["SN74LVC245AN"    "PDIP"      1     19    [2, 3, 4, 5, 6, 7, 8, 9]         [18, 17, 16, 15, 14, 13, 12, 11] 20    10    pdip-landpattern(20) ]
    ; "NS"  : ["SN74LVC245ANSR"  "SO"        1     19    [2, 3, 4, 5, 6, 7, 8, 9]         [18, 17, 16, 15, 14, 13, 12, 11] 20    10    so-landpattern(20) ]
    ; "PW"  : ["SN74LVC245APW"   "TSSOP"     1     19    [2, 3, 4, 5, 6, 7, 8, 9]         [18, 17, 16, 15, 14, 13, 12, 11] 20    10    tssop-landpattern(20) ]
    ; "RGY" : ["SN74LVC245ARGYR" "VQFN"      1     19    [2, 3, 4, 5, 6, 7, 8, 9]         [18, 17, 16, 15, 14, 13, 12, 11] 20    10    vqfn-landpattern(20) ]
    ; "ZQN" : ["SN74LVC245AZQNR" "BGA-MICRO" "A2"  "A4"  ["A1" "B3" "B1" "C2" "C1" "D3" "D1" "E2"] ["B4" "B2" "C4" "C3" "D4" "D2" "E4" "E3"] "A3"  "E1"  make-bga-pkg(0.65, 0.4, [4, 5], [3.1, 4.1]) ]
```
![image](https://user-images.githubusercontent.com/17492851/122157611-fd112780-ce1f-11eb-87a0-ccb65cc1ed1b.png)

Else, skips the test and prints it in CI logs