### PR TITLE
Work in progress for adding new bundle types

### DIFF
--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -12,22 +12,128 @@ defn diff-pair-pins () :
     pin N
     pin P
 
+; Bundles ordered Alphabetically
+public pcb-bundle ac-single :
+  pin hot
+  pin neutral
+  pin earth
+
+public pcb-bundle adc :
+  pin adc
+
+public pcb-bundle adc-diff :
+  port adc : diff-pair
+
+public pcb-bundle banked-io (bank:String):
+  pin gpio
+
+public pcb-bundle bus(n:int) :  ;#################################
+  port bus : pin[n]
+
+public pcb-bundle can :
+  port can : diff-pair
+
+public pcb-bundle crystal :
+  pin cin
+  pin cout
+
+public pcb-bundle dac-diff :
+  port dac : diff-pair
+
+public pcb-bundle dac :
+  pin dac
+
+public pcb-bundle dcmi-embedded(n:int) : ;choose pclk or xclk or both #### This code needs to select pclk / xclk / pclk & xclk as well as specify size of bus
+  pin pclk
+  pin xclk option
+  port d: d[n]
+
+public pcb-bundle dcmi-external(n:int) : ;#################################
+  pin pclk
+  pin xclk option
+  pin hsync
+  pin vsync
+  port d: d[n]
+
+public pcb-bundle diff-bus(n:int) : ;##########################################
+  port bus[n] : diff-pair-pins()
+
 public pcb-bundle diff-pair :
   diff-pair-pins()
 
-public pcb-bundle lvds : 
-  diff-pair-pins()
+public pcb-bundle digital-in :
+  pin digital-in
 
-public pcb-bundle SPST :
-  pin p
-  pin t
+public pcb-bundle digital-out :
+  pin digital-out
 
-public pcb-bundle power :
-  pin vdd
-  pin gnd
+public pcb-bundle ethernet-100 :
+  port tx : diff-pair
+  port rx : diff-pair
+  
+public pcb-bundle ethernet-100-shield :
+  port tx : diff-pair
+  port rx : diff-pair
+  pin shield
+
+public pcb-bundle ethernet-1000 :
+  port mdi : diff-pair[4]
 
 public pcb-bundle fpga-diff : 
   diff-pair-pins()
+
+public pcb-bundle fpga-io :
+  pin io
+
+public pcb-bundle gpio :
+  pin gpio
+
+public pcb-bundle hdmi : 
+  port data[3]: shield-diff-pair
+  port clock: shield-diff-pair
+  port i2c: i2c
+  port power: power
+  pin heac: diff-pair
+
+public pcb-bundle hdmi-cec : 
+  port data[3]: shield-diff-pair
+  port clock: shield-diff-pair
+  port i2c: i2c
+  port power: power
+  pin heac: diff-pair
+  pin cec
+
+public pcb-bundle high-freq-oscillator : 
+  pin oin
+  pin oout
+
+public pcb-bundle i2c :
+  pin sda
+  pin scl
+
+public pcb-bundle i2s-fd-mck : ; full duplex with manager clock
+  pin ck
+  pin dmi ; serial data manager in
+  pin dmo
+  pin ws
+  pin mck
+
+public pcb-bundle i2s-fd : ; full duplex
+  pin ck
+  pin dmi
+  pin dmo
+  pin ws
+
+public pcb-bundle i2s-hd : ; half duplex
+  pin ck
+  pin d
+  pin ws
+
+public pcb-bundle i2s-hd-mck : ; half duplex manager clock
+  pin ck
+  pin d
+  pin ws
+  pin mck
 
 public pcb-bundle jtag :
   pin tck
@@ -41,42 +147,187 @@ public pcb-bundle jtag-4:
   pin tdi
   pin tdo
   pin tms
-  
-public pcb-bundle banked-io (bank:String):
-  pin gpio
 
-public pcb-bundle fpga-io :
-  pin io
+public pcb-bundle low-freq-oscillator :
+  pin in
+  pin out
 
-public pcb-bundle gpio :
-  pin gpio
+public pcb-bundle lvds : 
+  diff-pair-pins()
+
+public pcb-bundle mdio : 
+  pin mdc
+  pin data
+
+public pcb-bundle mii : 
+  pin col
+  pin crs
+  pin mdc
+  pin mdio 
+  port rxd: pin[4]
+  pin rx-clk
+  pin rx-dv
+  port txd: pin[4]
+  pin tx-clk
+  pin tx-en
+
+public pcb-bundle mii-with-error : 
+  pin col
+  pin crs
+  pin mdc
+  pin mdio 
+  port rxd: pin[4]
+  pin rx-clk
+  pin rx-dv
+  port txd: pin[4]
+  pin tx-clk
+  pin tx-en
+  pin rx-error
+
+  public pcb-bundle rmii : 
+  pin ref-clk
+  pin mdio
+  pin crs-dv
+  pin mdc
+  pin tx-en
+  port rxd: pin[4]
+  port txd: pin[4]
+
+public pcb-bundle op-amp : 
+  pin vout: dac
+  pin vinh: adc
+  pin vinn: adc
+
+public pcb-bundle op-amp-follow : 
+  pin vout: dac
+  pin vinh: adc
+
+public pcb-bundle power :
+  pin vdd
+  pin gnd
+;  property(vdd.PowerPin) = True ; will not work
 
 public pcb-bundle pwm :
   pin pwm
 
-public pcb-bundle adc :
-  pin adc
-
-public pcb-bundle digital-in :
-  pin digital-in
-
-public pcb-bundle digital-out :
-  pin digital-out
-
 public pcb-bundle reset :
   pin reset
 
-public pcb-bundle i2c :
+public pcb-bundle rgb-led :
+  pin r
+  pin g
+  pin b
+  pin a
+
+public pcb-bundle rgmii :
+  port txd : pin[4]
+  port rxd : pin[4]
+  pin tx-clk
+  pin tx-ctrl
+  pin rx-clk
+  pin rx-ctrl
+
+public pcb-bundle sai : 
+  pin sck
+  pin d
+  pin fs
+
+public pcb-bundle sai-mck : ; serial audio interface with manager clock
+  pin sck
+  pin d
+  pin fs
+  pin mck
+
+public pcb-bundle sai-pdm(ck:int, n:int) : ;################################# min 1 ck and min 1 d
+  port ck: ck[n]
+  port d: d[n]
+
+public pcb-bundle sdmmc-1 : 
+  pin d
+  pin ck
+  pin cmd
+
+public pcb-bundle sdmmc-1-auto : 
+  pin d
+  pin ck
+  pin cmd
+  pin ckin
+  
+public pcb-bundle sdmmc-1-dir : ; serial data 1 bit with directional voltage converter
+  pin d
+  pin ck
+  pin cmd
+  pin ckin
+  pin cdir
+  pin ddir 
+
+public pcb-bundle sdmmc-4 : 
+  port d :d[4]
+  pin ck
+  pin cmd
+
+public pcb-bundle sdmmc-4-auto : 
+  port d :d[4]
+  pin ck
+  pin cmd
+  pin ckin
+  
+public pcb-bundle sdmmc-4-dir : ; serial data 1 bit with directional voltage converter
+  port d :d[4]
+  pin ck
+  pin cmd
+  pin ckin
+  pin cdir
+  pin d0dir 
+  pin d123dir
+
+public pcb-bundle shield-diff-pair :
+  diff-pair-pins()
+  pin shield
+
+public pcb-bundle smbus-alert :
   pin sda
   pin scl
+  pin a
 
-public pcb-bundle can :
-  pin canh
-  pin canl
+public pcb-bundle spdif : 
+  pin spdif
+
+public pcb-bundle spi :
+  pin mosi
+  pin miso
+  pin sck
+  pin ss
+
+public pcb-bundle spi-dual :
+  pin cs
+  pin sck
+  pin io[2]
+
+public pcb-bundle spi-quad :
+  pin cs
+  pin sck
+  pin io[4]
+
+public pcb-bundle SPST :
+  pin p
+  pin t
 
 public pcb-bundle swd:
   pin swdio
   pin swdclk
+
+public pcb-bundle swpmi : 
+  pin swpmi
+
+public pcb-bundle swpmi-xcvr : 
+  pin suspend
+  pin rx
+  pin tx
+
+public pcb-bundle trd :
+  port trd : diff-pair
+  pin common
 
 public pcb-bundle uart :
   pin rx
@@ -102,12 +353,6 @@ public pcb-bundle uart4-with (ctrl-pins:Tuple<Symbol>) :
   for p in ctrl-pins do:
     make-pin(p)
 
-public pcb-bundle spi :
-  pin mosi
-  pin miso
-  pin sck
-  pin ss
-
 public pcb-bundle usb-2-data:
   diff-pair-pins()
 
@@ -116,46 +361,22 @@ public pcb-bundle usb-2 :
   port vbus : power
   pin id
 
-public pcb-bundle rgmii :
-  port txd : pin[4]
-  port rxd : pin[4]
-  pin tx-clk
-  pin tx-ctrl
-  pin rx-clk
-  pin rx-ctrl
+public pcb-bundle usb3-no-id :
+  port power : power
+  port d : diff-pair
+  port std_ssrx : diff-pair
+  port std_sstx : diff-pair
+  pin drain
 
-public pcb-bundle ethernet-1000 :
-  port mdi : diff-pair[4]
+public pcb-bundle usb3-signals :
+  port d : diff-pair
+  port std_ssrx : diff-pair
+  port std_sstx : diff-pair
 
-public pcb-bundle trd :
-  port trd : diff-pair
-  pin common
-
-public pcb-bundle rgb-led :
-  pin r
-  pin g
-  pin b
-  pin a
-
-public pcb-bundle crystal :
-  pin in
-  pin out
-
-public pcb-bundle low-freq-oscillator :
-  pin in
-  pin out
-
-public pcb-bundle high-freq-oscillator : 
-  pin in
-  pin out
-
-public pcb-bundle i2s (mclk?:True|False, duplex?:True|False):
-  pin blck
-  pin ws
-  if mclk?:
-    pin mclk
-  if duplex?:
-    pin sdi
-    pin sdo
-  else:
-    pin sd
+public pcb-bundle usb3-with-id :
+  port power : power
+  port d : diff-pair
+  port std_ssrx : diff-pair
+  port std_sstx : diff-pair
+  pin drain
+  pin id


### PR DESCRIPTION
alphabetically and proposed new bundles. for in-out/rx-tx names I would like to use mdo mdi for manager data in manager data out instead of data out to avoid ambiguity on from what direction it's an output vs an input, this is not ready to be merged, as we can combine some bundle names using new stanza features and remove some unused or seldom used legacy bundles.