### PR TITLE
Updates to new `jtag` and `uart` bundle APIs 

### DIFF
--- a/components/espressif/ESP32-PICO-D4.stanza
+++ b/components/espressif/ESP32-PICO-D4.stanza
@@ -164,7 +164,7 @@ public pcb-module module :
       property(io[0].p.digital-io) = DigitalIO(OpenCollector(Interval(0.0, 0.1 * 3.3, false), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
       property(io[1].p.digital-io) = DigitalIO(OpenCollector(Interval(0.0, 0.1 * 3.3, false), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
   for i in 0 to 2 do:
-    val ocdb-uart = ocdb/bundles/uart
+    val ocdb-uart = /uart()
     supports ocdb-uart:
       require io:io-pin[2] from mcu
       ocdb-uart.tx => io[0].p

--- a/components/fremont-micro-devices/FT25H04.stanza
+++ b/components/fremont-micro-devices/FT25H04.stanza
@@ -31,7 +31,8 @@ public pcb-component component :
 
   make-box-symbol()
   assign-landpattern(sop65-landpattern(8))
-  
+
+  val spi = spi()  
   supports spi :
     spi.sdo  =>  self.SI
     spi.sdi  =>  self.SO

--- a/components/microchip/ATmega32U4.stanza
+++ b/components/microchip/ATmega32U4.stanza
@@ -211,6 +211,7 @@ public pcb-module module :
     i2c.scl => mcu.PD0
     i2c.sda => mcu.PD1
 
+  val spi = spi()
   supports spi:
     spi.sdo => mcu.PB2
     spi.sdi => mcu.PB3

--- a/components/microsemi/A2F200M3F-FGG256I.stanza
+++ b/components/microsemi/A2F200M3F-FGG256I.stanza
@@ -371,11 +371,13 @@ public pcb-component component :
     i2c.sda => I2C_1_SDA-GPIO[30] 
     i2c.scl => I2C_1_SCL-GPIO[31]
 
+  val spi = spi()
   supports spi : 
     spi.sdo => SPI_1_DO-GPIO[24] 
     spi.cs   => SPI_1_SS-GPIO[27] 
     spi.sck  => SPI_1_CLK-GPIO[26]
-    spi.sdi => SPI_1_DI-GPIO[25] 
+    spi.sdi => SPI_1_DI-GPIO[25]
+  
   supports spi : 
     spi.sdo => SPI_0_DO-GPIO[16] 
     spi.cs   => SPI_0_SS-GPIO[19] 
@@ -385,6 +387,7 @@ public pcb-component component :
   supports reset :
     reset.reset => MSS_RESET_N
 
+  val jtag = jtag([JTAG-TRSTN])
   supports jtag :
     jtag.trstn => TRSTB 
     jtag.tms => TMS   

--- a/components/nordic/nRF52832.stanza
+++ b/components/nordic/nRF52832.stanza
@@ -167,14 +167,16 @@ public pcb-module module :
       i2c.sda => pins[0].p
       i2c.scl => pins[1].p
   for i in 0 to 3 do :
-    supports spi() :
+    val spi = spi()
+    supports spi :
       require pins:io-pin[4] from proc
       spi.sdo => pins[0].p
       spi.sdi => pins[1].p
       spi.sck => pins[2].p
       spi.cs => pins[3].p
   for i in 0 to 2 do :
-    supports uart() :
+    val uart = uart()
+    supports uart :
       require pins:io-pin[2] from proc
       uart.tx => pins[0].p
       uart.rx => pins[1].p

--- a/components/nordic/nRF52832.stanza
+++ b/components/nordic/nRF52832.stanza
@@ -167,14 +167,14 @@ public pcb-module module :
       i2c.sda => pins[0].p
       i2c.scl => pins[1].p
   for i in 0 to 3 do :
-    supports spi :
+    supports spi() :
       require pins:io-pin[4] from proc
       spi.sdo => pins[0].p
       spi.sdi => pins[1].p
       spi.sck => pins[2].p
       spi.cs => pins[3].p
   for i in 0 to 2 do :
-    supports uart :
+    supports uart() :
       require pins:io-pin[2] from proc
       uart.tx => pins[0].p
       uart.rx => pins[1].p

--- a/components/si-labs/CP2105.stanza
+++ b/components/si-labs/CP2105.stanza
@@ -92,8 +92,8 @@ public pcb-component component :
 public pcb-module module :
   port power : power
   port usb-2 : usb-2
-  port e-uart : uart-with([`dtr `rts])
-  port s-uart : uart-with([`dtr `rts])
+  port e-uart : uart([UART-DTR, UART-RTS])
+  port s-uart : uart([UART-DTR, UART-RTS])
   pin reset
   pin vio
   pin gnd

--- a/components/st-microelectronics/STM32F031F6P6-old.stanza
+++ b/components/st-microelectronics/STM32F031F6P6-old.stanza
@@ -156,13 +156,13 @@ public pcb-component component :
     USART1_RX.p => self.PA[10]
   supports USART1_TX:
     USART1_TX.p => self.PA[14]
-  supports uart-with([`rts]):
+  supports uart([UART-RTS]):
     require tx-pin: USART1_TX
     require rx-pin: USART1_RX
     require rts-pin: USART1_RTS
-    uart-with([`rts]).tx => tx-pin.p
-    uart-with([`rts]).rx => rx-pin.p
-    uart-with([`rts]).rts => rts-pin.p
+    uart([UART-RTS]).tx => tx-pin.p
+    uart([UART-RTS]).rx => rx-pin.p
+    uart([UART-RTS]).rts => rts-pin.p
 
   pcb-bundle RCC_OSC_IN: 
     pin p

--- a/components/st-microelectronics/STM32F031F6P6-supports.stanza
+++ b/components/st-microelectronics/STM32F031F6P6-supports.stanza
@@ -118,13 +118,13 @@ public defn stm-support ( ) :
       USART2_RX.p => self.PA[10]
     supports USART2_TX:
       USART2_TX.p => self.PA[14]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle RCC_OSC_IN: pin p
     pcb-bundle RCC_OSC_OUT: pin p

--- a/components/st-microelectronics/STM32F031F_4-6_Px.supports.stanza
+++ b/components/st-microelectronics/STM32F031F_4-6_Px.supports.stanza
@@ -123,13 +123,13 @@ public defn make-supports ():
       USART1_RX.p => self.PA[10]
     supports USART1_TX:
       USART1_TX.p => self.PA[14]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle I2S1_SD:
       pin p

--- a/components/st-microelectronics/STM32F038G6Ux.supports.stanza
+++ b/components/st-microelectronics/STM32F038G6Ux.supports.stanza
@@ -158,13 +158,13 @@ public defn make-supports ():
       USART1_TX.p => self.PB[6]
     supports USART1_RX:
       USART1_RX.p => self.PB[7]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle I2S1_SD:
       pin p

--- a/components/st-microelectronics/STM32F102C_4-6_Tx.supports.stanza
+++ b/components/st-microelectronics/STM32F102C_4-6_Tx.supports.stanza
@@ -202,13 +202,13 @@ public defn make-supports ():
       USART1_TX.p => self.PB[6]
     supports USART1_RX:
       USART1_RX.p => self.PB[7]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART2_TX:
       pin p
@@ -223,13 +223,13 @@ public defn make-supports ():
       USART2_TX.p => self.PA[2]
     supports USART2_RX:
       USART2_RX.p => self.PA[3]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle RCC_OSC_IN:
       pin p

--- a/components/st-microelectronics/STM32F102R_4-6_Tx.supports.stanza
+++ b/components/st-microelectronics/STM32F102R_4-6_Tx.supports.stanza
@@ -244,13 +244,13 @@ public defn make-supports ():
       USART1_TX.p => self.PB[6]
     supports USART1_RX:
       USART1_RX.p => self.PB[7]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART2_TX:
       pin p
@@ -265,13 +265,13 @@ public defn make-supports ():
       USART2_TX.p => self.PA[2]
     supports USART2_RX:
       USART2_RX.p => self.PA[3]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle RCC_OSC_IN:
       pin p

--- a/components/st-microelectronics/STM32F103R_4-6_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F103R_4-6_Hx.supports.stanza
@@ -241,13 +241,13 @@ public defn make-supports ():
       USART1_TX.p => self.PA[9]
     supports USART1_TX:
       USART1_TX.p => self.PB[6]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART2_TX:
       pin p
@@ -262,13 +262,13 @@ public defn make-supports ():
       USART2_RX.p => self.PA[3]
     supports USART2_RTS:
       USART2_RTS.p => self.PA[1]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle RCC_OSC_IN:
       pin p

--- a/components/st-microelectronics/STM32F103R_8-B_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F103R_8-B_Hx.supports.stanza
@@ -283,13 +283,13 @@ public defn make-supports ():
       USART1_TX.p => self.PA[9]
     supports USART1_TX:
       USART1_TX.p => self.PB[6]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART2_TX:
       pin p
@@ -304,13 +304,13 @@ public defn make-supports ():
       USART2_RX.p => self.PA[3]
     supports USART2_RTS:
       USART2_RTS.p => self.PA[1]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART3_TX:
       pin p
@@ -329,13 +329,13 @@ public defn make-supports ():
       USART3_TX.p => self.PB[10]
     supports USART3_RX:
       USART3_RX.p => self.PB[11]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART3_TX
       require rx-pin: USART3_RX
       require rts-pin: USART3_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle RCC_OSC_IN:
       pin p

--- a/components/st-microelectronics/STM32F103T_4-6_Ux.supports.stanza
+++ b/components/st-microelectronics/STM32F103T_4-6_Ux.supports.stanza
@@ -165,13 +165,13 @@ public defn make-supports ():
       USART1_TX.p => self.PB[6]
     supports USART1_RX:
       USART1_RX.p => self.PB[7]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART2_TX:
       pin p
@@ -186,13 +186,13 @@ public defn make-supports ():
       USART2_TX.p => self.PA[2]
     supports USART2_RX:
       USART2_RX.p => self.PA[3]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle RCC_OSC_IN:
       pin p

--- a/components/st-microelectronics/STM32F105V_8-B_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F105V_8-B_Hx.supports.stanza
@@ -438,13 +438,13 @@ public defn make-supports ():
       USART1_TX.p => self.PA[9]
     supports USART1_RX:
       USART1_RX.p => self.PA[10]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART2_TX:
       pin p
@@ -465,13 +465,13 @@ public defn make-supports ():
       USART2_TX.p => self.PA[2]
     supports USART2_RX:
       USART2_RX.p => self.PA[3]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART3_TX:
       pin p
@@ -496,13 +496,13 @@ public defn make-supports ():
       USART3_TX.p => self.PD[8]
     supports USART3_RTS:
       USART3_RTS.p => self.PD[12]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART3_TX
       require rx-pin: USART3_RX
       require rts-pin: USART3_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle I2S2_SD:
       pin p

--- a/components/st-microelectronics/STM32F107VCHx.supports.stanza
+++ b/components/st-microelectronics/STM32F107VCHx.supports.stanza
@@ -423,13 +423,13 @@ public defn make-supports ():
       USART1_TX.p => self.PA[9]
     supports USART1_RX:
       USART1_RX.p => self.PA[10]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART1_TX
       require rx-pin: USART1_RX
       require rts-pin: USART1_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART2_TX:
       pin p
@@ -450,13 +450,13 @@ public defn make-supports ():
       USART2_TX.p => self.PA[2]
     supports USART2_RX:
       USART2_RX.p => self.PA[3]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle USART3_TX:
       pin p
@@ -481,13 +481,13 @@ public defn make-supports ():
       USART3_TX.p => self.PD[8]
     supports USART3_RTS:
       USART3_RTS.p => self.PD[12]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART3_TX
       require rx-pin: USART3_RX
       require rts-pin: USART3_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle I2S2_SD:
       pin p

--- a/components/st-microelectronics/STM32L031F_4-6_Px.supports.stanza
+++ b/components/st-microelectronics/STM32L031F_4-6_Px.supports.stanza
@@ -121,13 +121,13 @@ public defn make-supports ():
       USART2_RX.p => self.PA[10]
     supports USART2_TX:
       USART2_TX.p => self.PA[14]
-    supports uart-with([`rts]):
+    supports uart([UART-RTS]):
       require tx-pin: USART2_TX
       require rx-pin: USART2_RX
       require rts-pin: USART2_RTS
-      uart-with([`rts]).tx => tx-pin.p
-      uart-with([`rts]).rx => rx-pin.p
-      uart-with([`rts]).rts => rts-pin.p
+      uart([UART-RTS]).tx => tx-pin.p
+      uart([UART-RTS]).rx => rx-pin.p
+      uart([UART-RTS]).rts => rts-pin.p
 
     pcb-bundle RCC_OSC_IN:
       pin p

--- a/components/tag-connect/TC2050-IDC-NL.stanza
+++ b/components/tag-connect/TC2050-IDC-NL.stanza
@@ -54,6 +54,7 @@ public pcb-module module :
     jtag-bundle.tck => con.p[4]
     jtag-bundle.tms => con.p[2]
 
-  supports swd:
-    swd.swdclk => con.p[4]
-    swd.swdio  => con.p[2]
+  val swd-bundle = ocdb/bundles/swd
+  supports swd-bundle:
+    swd-bundle.swdclk => con.p[4]
+    swd-bundle.swdio  => con.p[2]

--- a/components/tag-connect/TC2050-IDC-NL.stanza
+++ b/components/tag-connect/TC2050-IDC-NL.stanza
@@ -45,13 +45,15 @@ public pcb-module module :
   net (pwr.vdd, jtag.p[1])
   net (pwr.gnd, jtag.p[9], jtag.p[5], jtag.p[3])
 
-  supports jtag:
-    jtag.trstn => con.p[10]
-    jtag.tdi => con.p[8]
-    jtag.tdo => con.p[6]
-    jtag.tck => con.p[4]
-    jtag.tms => con.p[2]
+  val jtag-bundle = /jtag([JTAG-TRSTN])
+  val con = jtag
+  supports jtag-bundle:
+    jtag-bundle.trstn => con.p[10]
+    jtag-bundle.tdi => con.p[8]
+    jtag-bundle.tdo => con.p[6]
+    jtag-bundle.tck => con.p[4]
+    jtag-bundle.tms => con.p[2]
 
   supports swd:
     swd.swdclk => con.p[4]
-    swd.swdio => con.p[2]
+    swd.swdio  => con.p[2]

--- a/components/texas-instruments/CC2640.stanza
+++ b/components/texas-instruments/CC2640.stanza
@@ -92,12 +92,14 @@ public pcb-component component :
   ;   sda   =>    pins[0].p
   ;   scl   =>    pins[1].p
 
-  supports uart():
+  val uart = uart()
+  supports uart:
     require pins:io-pin[2]
     uart.rx    =>    pins[0].p
     uart.tx    =>    pins[1].p
 
-  supports jtag([JTAG-TRSTN]):
+  val jtag = jtag([JTAG-TRSTN])
+  supports jtag:
     require pins:io-pin[3]
     jtag.tms => self.JTAG_TMSC
     jtag.tck => self.JTAG_TCKC

--- a/components/texas-instruments/CC2640.stanza
+++ b/components/texas-instruments/CC2640.stanza
@@ -92,12 +92,12 @@ public pcb-component component :
   ;   sda   =>    pins[0].p
   ;   scl   =>    pins[1].p
 
-  supports uart:
+  supports uart():
     require pins:io-pin[2]
     uart.rx    =>    pins[0].p
     uart.tx    =>    pins[1].p
 
-  supports jtag:
+  supports jtag([JTAG-TRSTN]):
     require pins:io-pin[3]
     jtag.tms => self.JTAG_TMSC
     jtag.tck => self.JTAG_TCKC

--- a/components/texas-instruments/SN65HVD1781.stanza
+++ b/components/texas-instruments/SN65HVD1781.stanza
@@ -66,7 +66,7 @@ public pcb-module module (terminate:Double|False) :
   inst xcvr : ocdb/texas-instruments/SN65HVD1781/component
   port power : power
   port rs485 : rs485
-  port uart : uart-with([`rts])
+  port uart : uart([RTS])
   pin R
   net (R uart.rx xcvr.R)
   pin D

--- a/components/texas-instruments/SN65HVD1781.stanza
+++ b/components/texas-instruments/SN65HVD1781.stanza
@@ -66,7 +66,7 @@ public pcb-module module (terminate:Double|False) :
   inst xcvr : ocdb/texas-instruments/SN65HVD1781/component
   port power : power
   port rs485 : rs485
-  port uart : uart([RTS])
+  port uart : uart([UART-RTS])
   pin R
   net (R uart.rx xcvr.R)
   pin D

--- a/components/texas-instruments/SN65HVD1786.stanza
+++ b/components/texas-instruments/SN65HVD1786.stanza
@@ -67,7 +67,7 @@ public pcb-module module (terminate:Double|False) :
   inst xcvr : ocdb/texas-instruments/SN65HVD1786/component
   port power : power
   port rs485 : rs485
-  port uart : uart-with([`rts])
+  port uart : uart([RTS])
   pin R
   net (R uart.rx xcvr.R)
   pin D

--- a/components/texas-instruments/SN65HVD1786.stanza
+++ b/components/texas-instruments/SN65HVD1786.stanza
@@ -67,7 +67,7 @@ public pcb-module module (terminate:Double|False) :
   inst xcvr : ocdb/texas-instruments/SN65HVD1786/component
   port power : power
   port rs485 : rs485
-  port uart : uart([RTS])
+  port uart : uart([UART-RTS])
   pin R
   net (R uart.rx xcvr.R)
   pin D

--- a/components/texas-instruments/TCAN1051.stanza
+++ b/components/texas-instruments/TCAN1051.stanza
@@ -46,8 +46,8 @@ public pcb-component component :
 public pcb-module module:
   ; Set up ports
   port can : can
-  port uart : uart
-  port uart-rts : uart([UART-RTS])
+  port uart : uart()
+  port uart-rts : /uart([UART-RTS])
   pin s
   port power:power
   pin vcc

--- a/designs/tutorial.stanza
+++ b/designs/tutorial.stanza
@@ -35,7 +35,7 @@ pcb-module first-design :
 
   ; Add a CAN transceiver
   inst xr : ocdb/texas-instruments/TCAN1051/module
-  require can-out:uart-with([`rts]) from stm.mcu
+  require can-out:uart([UART-RTS]) from stm.mcu
   net UART (can-out, xr.uart-rts)
   net CAN (xr.can, connector.can)
 

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -85,7 +85,7 @@ public pcb-enum ocdb/bundles/UARTPins :
   UART-CK
   UART-DE
 
-pcb-bundle uart (pins:Tuple<ocdb/bundles/UARTPins>) :
+public pcb-bundle uart (pins:Tuple<UARTPins>) :
   pin rx
   pin tx
   for p in pins do :
@@ -99,10 +99,10 @@ pcb-bundle uart (pins:Tuple<ocdb/bundles/UARTPins>) :
       UART-CK : make-pin(`ck)
       UART-DE : make-pin(`de)
 
-public pcb-bundle uart ():
+public defn uart ():
   uart([])
 
-pcb-bundle usart (pins:Tuple<ocdb/bundles/UARTPins>) :
+public pcb-bundle usart (pins:Tuple<ocdb/bundles/UARTPins>) :
   pin rx
   pin tx
   for p in pins do :
@@ -116,7 +116,7 @@ pcb-bundle usart (pins:Tuple<ocdb/bundles/UARTPins>) :
       UART-CK : make-pin(`ck)
       UART-DE : make-pin(`de)
 
-public pcb-bundle usart ():
+public defn usart ():
   usart([])
 
 public pcb-enum ocdb/bundles/SPIPins :
@@ -127,7 +127,7 @@ public pcb-enum ocdb/bundles/SPIPins :
   SPI-COPI
   SPI-SDIO
 
-public pcb-bundle spi  (pins:Tuple<ocdb/bundles/SPIPins>):
+public pcb-bundle spi  (pins:Tuple<SPIPins>):
   pin sck
   for p in pins do :
     switch(p) :
@@ -138,7 +138,7 @@ public pcb-bundle spi  (pins:Tuple<ocdb/bundles/SPIPins>):
       SPI-COPI  : make-pin(`copi)
 
 ; Most common spi bundle
-public pcb-bundle spi ():
+public defn spi ():
   spi([SPI-SDO SPI-SDI SPI-CS])
 
 public pcb-bundle quad-spi :
@@ -204,5 +204,5 @@ public pcb-bundle i2s  (pins:Tuple<ocdb/bundles/I2SPins>):
       I2S-SDMI : make-pin(`sdmi)
       I2S-MCK  : make-pin(`mck)
 
-public pcb-bundle i2s () :
+public defn i2s () :
   i2s([])

--- a/utils/debug-utils.stanza
+++ b/utils/debug-utils.stanza
@@ -437,7 +437,7 @@ public defn db-jumper-persist-zero-res (nodes:Tuple<Tuple<JITXObject>>) :
 public defn db-jtag-to-cmp (pwr:JITXObject, cmp:JITXObject) :
   inside pcb-module :
     eval-when true :
-      require jtag:jtag from cmp
+      require jtag: jtag() from cmp
       db-jtag(pwr, jtag)
 
 ; Adds a FTDI connector to a component
@@ -451,7 +451,7 @@ public defn db-ftdi-two-comms (pwr:JITXObject, cmp:JITXObject) :
   inside pcb-module :
     eval-when true :
       if property(self.debug) :
-        require uart:uart from cmp
+        require uart: uart() from cmp
         db-ftdi(pwr, uart)
 
 ; Adds a FTDI connector with RTS and CTS to a component
@@ -465,7 +465,7 @@ public defn db-ftdi-four-comms (pwr:JITXObject, cmp:JITXObject) :
   inside pcb-module :
     eval-when true :
       if property(self.debug) :
-        require ftdi:uart4 from cmp
+        require ftdi: uart([UART-RTS, UART-CTS]) from cmp
         db-ftdi(pwr, ftdi)
 
 ; ====================
@@ -616,10 +616,10 @@ public defn db-ftdi (pwr:JITXObject, uart:JITXObject) :
         net (pwr.vdd, ftdi-conn.p[3])
         match(port-type(uart)) :
           (pa:Bundle) :
-            if pa == ocdb/bundles/uart :
+            if pa == /uart() :
               net (uart.rx, ftdi-conn.p[4]) 
               net (uart.tx, ftdi-conn.p[5])
-            else if pa == uart4 :
+            else if pa == /uart([UART-RTS, UART-CTS]) :
               net (uart.cts, ftdi-conn.p[2])
               net (uart.txd, ftdi-conn.p[4])
               net (uart.rxd, ftdi-conn.p[5])


### PR DESCRIPTION
Fixes a few compilation errors with the new bundles. 

There are a few compilation errors I'm not sure about:

```
open-components-database/components/tag-connect/TC2050-IDC-NL.stanza:58.4: Cannot call function 
make-support of type (() -> ?, JITXClient, False|FileInfo, Bundle, False|Ref) -> False with 
arguments of type (() -> False, StanzaJITXClient, FileInfo, Pin, False).
````
and 
```
open-components-database/components/espressif/ESP32-PICO-D4.stanza:158.34: Cannot call function 
DigitalIO of type (LogicFamily, Double, Double, JITXObject, JITXObject, Double) -> DigitalIO with 
arguments of type (CMOSOutput, Double, Double).
```
