### PR TITLE
Compile error found during compiling of jitx-client

### DIFF
--- a/components/texas-instruments/CC2640.stanza
+++ b/components/texas-instruments/CC2640.stanza
@@ -94,16 +94,16 @@ public pcb-component component :
 
   supports uart():
     require pins:io-pin[2]
-    uart.rx    =>    pins[0].p
-    uart.tx    =>    pins[1].p
+    uart().rx    =>    pins[0].p
+    uart().tx    =>    pins[1].p
 
   supports jtag([JTAG-TRSTN]):
     require pins:io-pin[3]
-    jtag.tms => self.JTAG_TMSC
-    jtag.tck => self.JTAG_TCKC
-    jtag.tdi => pins[0].p
-    jtag.tdo => pins[1].p
-    jtag.trstn => pins[2].p
+    jtag([JTAG-TRSTN]).tms => self.JTAG_TMSC
+    jtag([JTAG-TRSTN]).tck => self.JTAG_TCKC
+    jtag([JTAG-TRSTN]).tdi => pins[0].p
+    jtag([JTAG-TRSTN]).tdo => pins[1].p
+    jtag([JTAG-TRSTN]).trstn => pins[2].p
 
   for i in 0 to 31 do:
     supports gpio:


### PR DESCRIPTION
Currently, not all OCDB files are compiled when changes are made to OCDB. Some errors are found during compilation of jitx-client. This PR fixes those errors