### PR TITLE
Feature/jitx 522 new bundle use fixes

### DIFF
--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -439,6 +439,47 @@ defn print-i2s (o:OutputStream, mcu:Stm32MCU):
       pin-names
     )
 
+defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
+  for ip-block in filter(prefix?{instance-name(_),"QUADSPI"}, ip(mcu)) do:
+    val pins = unique-pins-for(instance-name(ip-block), mcu)
+    val optional = StringBuffer()
+
+    print-pins(pins)
+
+    val io0? = contains?(pins, "BK1_IO0")
+    val io1? = contains?(pins, "BK1_IO1")
+    val io2? = contains?(pins, "BK1_IO2")
+    val io3? = contains?(pins, "BK1_IO3")
+    val ncs? = contains?(pins, "NCS") or contains?(pins, "BK1_NCS")
+    val clk? = contains?(pins, "CLK")
+
+    val bundle-name = "quad-spi"
+    val pin-names = to-tuple(cat-all([
+      ["sdio0"] when io0? else []
+      ["sdio1"] when io1? else []
+      ["sdio2"] when io2? else []
+      ["sdio3"] when io3? else []
+      ["cs"]  when ncs? else []
+      ["sck"]  when clk? else []
+    ]))
+
+    do(println, pin-names)
+
+    val signal-names = to-tuple(cat-all([
+      ["IO0"] when io0? else []
+      ["IO1"] when io1? else []
+      ["IO2"] when io2? else []
+      ["IO3"] when io3? else []
+      ["NCS"] when ncs? else []
+      ["CLK"] when clk? else []
+    ]))
+
+    print-bundle-data(
+      o, mcu, instance-name(ip-block), bundle-name,
+      signal-names
+      pin-names
+    )
+
 ;==============================================================================
 ;============================= UART edge cases ================================
 ;==============================================================================
@@ -569,6 +610,7 @@ public defn make-supports ():
   do(println{os, _}, dac)
 
   ; Next print the IP blocks we care about
+  print-quad-spi(os, mcu)
   print-i2c(os, mcu)
   print-can(os, mcu)
   print-spi(os, mcu)

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -315,9 +315,9 @@ defn print-bundle-data (
   ocdb-pins:Tuple<String>,     ; pins of the bundle we care about
 ):
   ; in order to support indexing ew sanitize the pin names a bit first
-  defn sanitize(s:String):
+  defn sanitize (s:String):
     replace(s, "[", "_") $> 
-    replace(s, "]", "_")
+    replace{_, "]", "_"}
 
   if length(ocdb-pins) != length(cubemx-signals):
     fatal("invalid mapping of cubemx signals to pcb-bundle data in ocdb.")

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -460,10 +460,10 @@ defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
 
     val bundle-name = "quad-spi"
     val pin-names = to-tuple(cat-all([
-      ["sdio0"] when io0? else []
-      ["sdio1"] when io1? else []
-      ["sdio2"] when io2? else []
-      ["sdio3"] when io3? else []
+      ["sdio[0]"] when io0? else []
+      ["sdio[1]"] when io1? else []
+      ["sdio[2]"] when io2? else []
+      ["sdio[3]"] when io3? else []
       ["cs"]  when ncs? else []
       ["sck"]  when clk? else []
     ]))

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -455,7 +455,8 @@ defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
     val io1? = contains?(pins, "BK1_IO1")
     val io2? = contains?(pins, "BK1_IO2")
     val io3? = contains?(pins, "BK1_IO3")
-    val ncs? = contains?(pins, "NCS") or contains?(pins, "BK1_NCS")
+    val ncs? = contains?(pins, "NCS")
+    val bk1-ncs? = contains?(pins, "BK1_NCS")
     val clk? = contains?(pins, "CLK")
 
     val bundle-name = "quad-spi"
@@ -465,16 +466,18 @@ defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
       ["sdio[2]"] when io2? else []
       ["sdio[3]"] when io3? else []
       ["cs"]  when ncs? else []
+      ["cs"]  when bk1-ncs? else []
       ["sck"]  when clk? else []
     ]))
 
     do(println, pin-names)
 
     val signal-names = to-tuple(cat-all([
-      ["IO0"] when io0? else []
-      ["IO1"] when io1? else []
-      ["IO2"] when io2? else []
-      ["IO3"] when io3? else []
+      ["BK1_IO0"] when io0? else []
+      ["BK1_IO1"] when io1? else []
+      ["BK1_IO2"] when io2? else []
+      ["BK1_IO3"] when io3? else []
+      ["BK1_NCS"] when bk1-ncs? else []
       ["NCS"] when ncs? else []
       ["CLK"] when clk? else []
     ]))

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -314,6 +314,11 @@ defn print-bundle-data (
   cubemx-signals:Tuple<String> ; signals in cubemx data we want to map
   ocdb-pins:Tuple<String>,     ; pins of the bundle we care about
 ):
+  ; in order to support indexing ew sanitize the pin names a bit first
+  defn sanitize(s:String):
+    replace(s, "[", "_") $> 
+    replace(s, "]", "_")
+
   if length(ocdb-pins) != length(cubemx-signals):
     fatal("invalid mapping of cubemx signals to pcb-bundle data in ocdb.")
   
@@ -339,9 +344,9 @@ defn print-bundle-data (
   println(o, "supports %_:" % [ocdb-name])
   val os = IndentedStream(o)
   for (op in ocdb-pins, s in signals*) do:
-    println(os, "require %_-pin: %_" % [op, s])
+    println(os, "require %_-pin: %_" % [sanitize(op), s])
   for op in ocdb-pins do:
-    println(os, "%_.%_ => %_-pin.p" % [ocdb-name, op, op])
+    println(os, "%_.%_ => %_-pin.p" % [ocdb-name, op, sanitize(op)])
   println(o,"")
 
 defn print-bundle (
@@ -379,10 +384,10 @@ defn print-spi (o:OutputStream, mcu:Stm32MCU):
   )
 
 defn print-i2c (o:OutputStream, mcu:Stm32MCU):
-  print-bundle(
+  print-bundle(               
     o, mcu, "I2C", "i2c"
     ["SDA", "SCL"]
-    ["sda", "scl"]
+    ["sda", "scl"] 
     suffix?{_, "SMBA"}
   )
 


### PR DESCRIPTION
JITX-522

Now generate support statements for quad-spi. The following file results in the output as below

```
	<IP ClockEnableMode="__HAL_RCC_QSPI_CLK_ENABLE" ConfigFile="QUADSPI-STM32F4xx" InstanceName="QUADSPI" Name="QUADSPI" Version="quadspi1_v1_0_Cube"/>
	<IP ClockEnableMode="__HAL_RCC_QSPI_CLK_ENABLE" ConfigFile="QUADSPI-STM32F4xx" InstanceName="QUADSPI" Name="QUADSPI" Version="quadspi1_v1_0_Cube"/>
	<IP ClockEnableMode="__HAL_RCC_QSPI_CLK_ENABLE" ConfigFile="QUADSPI-STM32F4xx" InstanceName="QUADSPI" Name="QUADSPI" Version="quadspi1_v1_0_Cube"/>
	<IP ClockEnableMode="__HAL_RCC_QSPI_CLK_ENABLE" ConfigFile="QUADSPI-STM32F4xx" InstanceName="QUADSPI" Name="QUADSPI" Version="quadspi1_v1_0_Cube"/>
	<Pin Name="PA1" Position="15" Type="I/O">
		<Signal Name="QUADSPI_BK1_IO3"/>
        ...
    </Pin>
	<Pin Name="PA6" Position="22" Type="I/O">
		<Signal Name="ADC1_IN6"/>
		<Signal Name="I2S2_MCK"/>
		<Signal Name="QUADSPI_BK2_IO0"/>
        ...
    </Pin>
	<Pin Name="PA7" Position="23" Type="I/O">
		<Signal Name="ADC1_IN7"/>
		<Signal Name="I2S1_SD"/>
		<Signal Name="QUADSPI_BK2_IO1"/>
        ...
    </Pin>
	<Pin Name="PC4" Position="24" Type="I/O">
		<Signal Name="ADC1_IN14"/>
		<Signal Name="FSMC_NE4"/>
		<Signal Name="I2S1_MCK"/>
		<Signal Name="QUADSPI_BK2_IO2"/>
        ...
    </Pin>
	<Pin Name="PC5" Position="25" Type="I/O">
		<Signal Name="ADC1_IN15"/>
		<Signal Name="FMPI2C1_SMBA"/>
		<Signal Name="FSMC_NOE"/>
		<Signal Name="QUADSPI_BK2_IO3"/>
        ...
    </Pin>
	<Pin Name="PB1" Position="27" Type="I/O">
		<Signal Name="ADC1_IN9"/>
		<Signal Name="DFSDM1_DATIN0"/>
		<Signal Name="I2S5_WS"/>
		<Signal Name="QUADSPI_CLK"/>
        ...
    </Pin>
	<Pin Name="PB2" Position="28" Type="I/O">
		<Signal Name="DFSDM1_CKIN0"/>
		<Signal Name="QUADSPI_CLK"/>
        ...
    </Pin>
	<Pin Name="PC8" Position="39" Type="I/O">
		<Signal Name="QUADSPI_BK1_IO2"/>
        ...
    </Pin>
	<Pin Name="PC9" Position="40" Type="I/O">
		<Signal Name="I2C3_SDA"/>
		<Signal Name="I2S_CKIN"/>
		<Signal Name="QUADSPI_BK1_IO0"/>
        ...
    </Pin>
	<Pin Name="PC10" Position="51" Type="I/O">
		<Signal Name="I2S3_CK"/>
		<Signal Name="QUADSPI_BK1_IO1"/>
        ...
    </Pin>
	<Pin Name="PC11" Position="52" Type="I/O">
		<Signal Name="ADC1_EXTI11"/>
		<Signal Name="FSMC_D2"/>
		<Signal Name="FSMC_DA2"/>
		<Signal Name="I2S3_ext_SD"/>
		<Signal Name="QUADSPI_BK2_NCS"/>
        ...
    </Pin>
	<Pin Name="PB6" Position="58" Type="I/O">
		<Signal Name="CAN2_TX"/>
		<Signal Name="I2C1_SCL"/>
		<Signal Name="QUADSPI_BK1_NCS"/>
        ...
    </Pin>

```
```
    pcb-bundle QUADSPI_IO0:
      pin p
    pcb-bundle QUADSPI_IO1:
      pin p
    pcb-bundle QUADSPI_IO2:
      pin p
    pcb-bundle QUADSPI_IO3:
      pin p
    pcb-bundle QUADSPI_NCS:
      pin p
    pcb-bundle QUADSPI_CLK:
      pin p

    supports QUADSPI_CLK:
      QUADSPI_CLK.p => self.PB[1]
    supports QUADSPI_CLK:
      QUADSPI_CLK.p => self.PB[2]
    supports quad-spi:
      require sdio_0_-pin: QUADSPI_IO0
      require sdio_1_-pin: QUADSPI_IO1
      require sdio_2_-pin: QUADSPI_IO2
      require sdio_3_-pin: QUADSPI_IO3
      require cs-pin: QUADSPI_NCS
      require sck-pin: QUADSPI_CLK
      quad-spi.sdio[0] => sdio_0_-pin.p
      quad-spi.sdio[1] => sdio_1_-pin.p
      quad-spi.sdio[2] => sdio_2_-pin.p
      quad-spi.sdio[3] => sdio_3_-pin.p
      quad-spi.cs => cs-pin.p
      quad-spi.sck => sck-pin.p

```
