### PR TITLE
Fixed offset/expand computation

### DIFF
--- a/tests/test-pads.stanza
+++ b/tests/test-pads.stanza
@@ -1,0 +1,59 @@
+#use-added-syntax(jitx)
+defpackage pads :
+  import core
+  import collections
+  import math
+  import jitx
+  import jitx/commands
+  import ocdb/defaults
+
+  import ocdb/symbols
+  import ocdb/box-symbol
+  import ocdb/land-patterns
+  import ocdb/bundles
+  import ocdb/generator-utils
+  import ocdb/generic-components
+
+pcb-landpattern lp (n:Int) :
+  for i in 0 to n by 4 do :
+    val d = to-double(i) * 2.0
+    val drill = 0.5
+    val x = 1.0
+    val y = 2.0
+    pad p[i] : pth-pad(drill / 2., x / 2.) at loc(d, d)
+    pad p[i + 1] : oval-pth-pad(drill, x, y) at loc(d + 2.0, d + 2.0)
+    pad p[i + 2] : rect-pth-pad(drill, x, y) at loc(d + 4.0, d + 4.0)
+    pad p[i + 3] : round-rect-pth-pad(drill, x, y, 0.25) at loc(d + 6.0, d + 6.0)
+    pad p[i + 4] : dshape-pth-pad(drill, x, y, y, 0.5) at loc(d + 8.0, d + 8.0)
+    pad p[i + 5] : chamfered-rect-pth-pad(drill, x, y, y, 0.5) at loc(d + 10.0, d + 10.0)
+  ref-label()
+
+pcb-symbol sym (n:Int) :
+  for i in 0 to n do :
+    val d = to-double(i) * 2.54
+    pin p[i] at Point(d, d)
+
+pcb-component ldo-9000-sym (n:Int) :
+  name = "AP2112"
+  manufacturer = "Diodes Incorporated"
+  description = "600-mA, Low-Dropout Regulator"
+  mpn = "AP2112K-3.3TRG1"
+  reference-prefix = "A"
+
+  port p : pin[n]
+
+  val sym = sym(n)
+  val lp = lp(n)
+  symbol = sym(for i in 0 to n do : p[i] => sym.p[i])
+  landpattern = lp(for i in 0 to n do : p[i] => lp.p[i])
+
+pcb-module ldo :
+  val num-pins = 4
+  public inst l : ldo-9000-sym(num-pins)[4]
+
+set-export-backend(`kicad)
+make-default-board(ldo, 4, Rectangle(10.0, 10.0))
+
+view-board()
+;view-schematic()
+;export-cad()

--- a/tests/test-pads.stanza
+++ b/tests/test-pads.stanza
@@ -15,7 +15,7 @@ defpackage pads :
   import ocdb/generic-components
 
 pcb-landpattern lp (n:Int) :
-  for i in 0 to n by 4 do :
+  for i in 0 to n by 6 do :
     val d = to-double(i) * 2.0
     val drill = 0.5
     val x = 1.0
@@ -48,7 +48,7 @@ pcb-component ldo-9000-sym (n:Int) :
   landpattern = lp(for i in 0 to n do : p[i] => lp.p[i])
 
 pcb-module ldo :
-  val num-pins = 4
+  val num-pins = 6
   public inst l : ldo-9000-sym(num-pins)[4]
 
 set-export-backend(`kicad)

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -144,26 +144,26 @@ public defn apply-soldermask (mask-shape:Shape):
 ; Create the soldermask layers based on the pad shape, using a fixed factor.
 ; when expand? is true the soldermask shape is computed with expand(), else it is
 ; computed with offset()
-public defn apply-soldermask (amount:Double, expand?:True|False):
+public defn apply-soldermask (amount:Double):
   val mask-shape = 
     match(pad-shape(self)):
       (s:Rectangle|Circle|RoundedRectangle|Segment|Capsule):
-        val func = expand when expand? else offset
-        func(s, amount)
+        offset(s, amount)
       (s:ChamferedRectangle|DShape):
         val d = dims(s)
-        val expansion = 1.0 + amount / max(x(d), y(d))
-        expand(s, expansion)
+        val expansion-factor = 1.0 + amount / max(x(d), y(d))
+        expand(s, expansion-factor)
       (s:Shape):
-        ; FIXME: allow offset/expand to be used for other shapes!!
-        s  
+        ; FIXME: for other shapes we need an implementation of offset
+        s
+
   inside pcb-landpattern:
     apply-soldermask(mask-shape)
 
 ; Apply a default soldermask layer to a pcb-pad, using the SOLDER-MASK-REGISTRATION
 ; design variable and offset() method.
 public defn apply-soldermask ():
-  apply-soldermask(SOLDER-MASK-REGISTRATION, false)
+  apply-soldermask(SOLDER-MASK-REGISTRATION)
 
 ; A "solder mask defined pad" is one where the soldermask opening is smaller than 
 ; the pad shape. This method takes a pad as an argument and converts it into a 

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -180,7 +180,7 @@ public defn soldermask-defined (p:Pad):
     pcb-pad SMD-p:
       name  = to-string("%_, SMD" % [name(p)])
       type  = pad-type(p)
-      shape = offet(pad-shape(p), SOLDER-MASK-REGISTRATION)
+      shape = offset(pad-shape(p), SOLDER-MASK-REGISTRATION)
       apply-soldermask(pad-shape(p))
       for layer_ in filter({specifier(_) is-not SolderMask}, layers(p)) do:
         layer(specifier(layer_)) = shape(layer_)

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -237,9 +237,9 @@ public pcb-pad testpoint-pad (testpoint-shape:Shape):
 public defn testpoint-pad (diameter:Double) :
   testpoint-pad(Circle(0.5 * diameter))
 
-public pcb-pad pth-pad (shape_:Shape, hole-shape:Shape):
+public pcb-pad pth-pad (pad-shape:Shape, hole-shape:Shape):
   name = "PTH Pad"
-  shape = shape_
+  shape = pad-shape
   type = TH
   apply-soldermask()
   layer(Cutout()) = hole-shape
@@ -281,7 +281,6 @@ public defn oval-smd-pad (w:Double, h:Double) :
 ; Create a capsule shaped TH pad with anchor
 public defn oval-pth-pad (anchor:Anchor, drill-w:Double, drill-h:Double, pad-w:Double, pad-h:Double) :
   val shape = capsule(anchor, pad-w, pad-h)
-  ;println("s:%_, os:%_" % [shape, offset(shape, SOLDER-MASK-REGISTRATION)])
   val hole = capsule(anchor, drill-w, drill-h)
   pth-pad(shape, hole)
 

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -180,8 +180,8 @@ public defn soldermask-defined (p:Pad):
     pcb-pad SMD-p:
       name  = to-string("%_, SMD" % [name(p)])
       type  = pad-type(p)
-      shape = pad-shape(p)
-      apply-soldermask(0.85, true)
+      shape = offet(pad-shape(p), SOLDER-MASK-REGISTRATION)
+      apply-soldermask(pad-shape(p))
       for layer_ in filter({specifier(_) is-not SolderMask}, layers(p)) do:
         layer(specifier(layer_)) = shape(layer_)
     SMD-p

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -147,11 +147,13 @@ public defn apply-soldermask (mask-shape:Shape):
 public defn apply-soldermask (amount:Double, expand?:True|False):
   val mask-shape = 
     match(pad-shape(self)):
-      (s:Rectangle|Circle|RoundedRectangle|Segment):
+      (s:Rectangle|Circle|RoundedRectangle|Segment|Capsule):
         val func = expand when expand? else offset
         func(s, amount)
-      (s:ChamferedRectangle|DShape|Capsule):
-        expand(s, amount)
+      (s:ChamferedRectangle|DShape):
+        val d = dims(s)
+        val expansion = 1.0 + amount / max(x(d), y(d))
+        expand(s, expansion)
       (s:Shape):
         ; FIXME: allow offset/expand to be used for other shapes!!
         s  
@@ -235,9 +237,9 @@ public pcb-pad testpoint-pad (testpoint-shape:Shape):
 public defn testpoint-pad (diameter:Double) :
   testpoint-pad(Circle(0.5 * diameter))
 
-public pcb-pad pth-pad (pad-shape:Shape, hole-shape:Shape):
+public pcb-pad pth-pad (shape_:Shape, hole-shape:Shape):
   name = "PTH Pad"
-  shape = pad-shape
+  shape = shape_
   type = TH
   apply-soldermask()
   layer(Cutout()) = hole-shape
@@ -279,6 +281,7 @@ public defn oval-smd-pad (w:Double, h:Double) :
 ; Create a capsule shaped TH pad with anchor
 public defn oval-pth-pad (anchor:Anchor, drill-w:Double, drill-h:Double, pad-w:Double, pad-h:Double) :
   val shape = capsule(anchor, pad-w, pad-h)
+  ;println("s:%_, os:%_" % [shape, offset(shape, SOLDER-MASK-REGISTRATION)])
   val hole = capsule(anchor, drill-w, drill-h)
   pth-pad(shape, hole)
 


### PR DESCRIPTION
Fixes the computation of `expansion` for a given solder mask layer on Capsule, DShape, and ChamferedRectangle pads. 

Before:
![Screenshot from 2021-07-19 13-26-20](https://user-images.githubusercontent.com/28515218/126223008-acc7981c-d973-402b-9411-f0a556fbef72.png)

After:

![Screenshot from 2021-07-19 13-25-42](https://user-images.githubusercontent.com/28515218/126223018-7354b637-b758-4bb9-b2ac-4b368cc9a13c.png)

`tests/test-pads.stanza` is a test harness for reproducing the results (Thanks, @ariel-hi!)

