### PR TITLE
Fix i2s to generate supports in new format

### DIFF
--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -413,34 +413,30 @@ defn print-oscillator (o:OutputStream, mcu:Stm32MCU):
       ["in", "out"]
     )
 
+; print-i2s currently ignores ext_SD and CKIN signals
 defn print-i2s (o:OutputStream, mcu:Stm32MCU):
   for ip-block in filter(prefix?{instance-name(_),"I2S"}, ip(mcu)) do:
     val pins = unique-pins-for(instance-name(ip-block), mcu)
-    val optional = StringBuffer()
 
     val mck? = contains?(pins, "MCK")
     val sdmi? = contains?(pins, "SDI")
     val sd? = contains?(pins, "SD")
     val sdo? = contains?(pins, "SDO")
-    val extsd? = contains?(pins, "ext_SD")
     val ck? = contains?(pins, "CK")
     val sck? = contains?(pins, "SCK")
 
-    if mck?:
-      print(optional, "I2S-MCK")
-    if sdmi?:
-      if empty?(optional):
-        print(optional, "I2S-SDMI")
-      else:
-        print(optional, ", I2S-SDMI")
-    
-    val bundle-name = "i2s()" when empty?(optional) else to-string("i2s([%_])" % [optional])
+    val optional = Vector<String>()
+    if mck?: 
+      add(optional, "I2S-MCK")
+    if sdmi?: 
+      add(optional, "I2S-SDMI")
+
+    val bundle-name = "i2s()" when empty?(optional) else to-string("i2s([%,])" % [optional])
     val pin-names = to-tuple(cat-all([
       ["mck"]  when mck? else []
       ["sdmi"] when sdmi? else []
       ["sdmo"] when sd? else []
       ["sdmo"] when sdo? else []
-      ["sdmo"] when extsd? else []
       ["ck"] when ck? else []
       ["ck"] when sck? else []
       ["ws"]
@@ -451,7 +447,6 @@ defn print-i2s (o:OutputStream, mcu:Stm32MCU):
       ["SDI"] when sdmi? else []
       ["SD"] when sd? else []
       ["SDO"] when sdo? else []
-      ["ext_SD"] when extsd? else []
       ["CK"] when ck? else []
       ["SCK"] when sck? else []
       ["WS"]
@@ -463,12 +458,13 @@ defn print-i2s (o:OutputStream, mcu:Stm32MCU):
       pin-names
     )
 
+; print-quad-spi currently ignores BK2 signals
 defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
   for ip-block in filter(prefix?{instance-name(_),"QUADSPI"}, ip(mcu)) do:
     val pins = unique-pins-for(instance-name(ip-block), mcu)
     val optional = StringBuffer()
 
-    print-pins(pins)
+    ; print-pins(pins)
 
     val io0? = contains?(pins, "BK1_IO0")
     val io1? = contains?(pins, "BK1_IO1")
@@ -489,7 +485,7 @@ defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
       ["sck"]  when clk? else []
     ]))
 
-    do(println, pin-names)
+    ;do(println, pin-names)
 
     val signal-names = to-tuple(cat-all([
       ["BK1_IO0"] when io0? else []
@@ -564,7 +560,7 @@ defn uart-case (instance-name:String, mcu:Stm32MCU) -> UartCase:
     for c in 0 to 4 do:
       val check = uart-cubemx-pins(UartCase(c))
       if same-set?(to-hashset<String>(uart-cubemx-pins(UartCase(c))), pins):
-        println("uart-case: Returning %_" % [UartCase(c)])
+        ; println("uart-case: Returning %_" % [UartCase(c)])
         return(UartCase(c))
     fatal("Unsupported UART pin set: %," % [pins])
 
@@ -655,3 +651,4 @@ defn print-pins (pins:Set<String>):
   for p in pins do:
     print("%_, " % [p])
   println(" ")
+

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -418,24 +418,43 @@ defn print-i2s (o:OutputStream, mcu:Stm32MCU):
     val pins = unique-pins-for(instance-name(ip-block), mcu)
     val optional = StringBuffer()
 
-    val mck? = contains?(pins, "MCLK")
+    val mck? = contains?(pins, "MCK")
     val sdmi? = contains?(pins, "SDI")
+    val sd? = contains?(pins, "SD")
+    val sdo? = contains?(pins, "SDO")
+    val extsd? = contains?(pins, "ext_SD")
+    val ck? = contains?(pins, "CK")
+    val sck? = contains?(pins, "SCK")
+
     if mck?:
-      print(optional, "I2S-MCK, ")
+      print(optional, "I2S-MCK")
     if sdmi?:
-      print(optional, "I2S-SDMI")
+      if empty?(optional):
+        print(optional, "I2S-SDMI")
+      else:
+        print(optional, ", I2S-SDMI")
     
     val bundle-name = "i2s()" when empty?(optional) else to-string("i2s([%_])" % [optional])
     val pin-names = to-tuple(cat-all([
       ["mck"]  when mck? else []
       ["sdmi"] when sdmi? else []
-      ["ws" "ck" "sdmo"]
+      ["sdmo"] when sd? else []
+      ["sdmo"] when sdo? else []
+      ["sdmo"] when extsd? else []
+      ["ck"] when ck? else []
+      ["ck"] when sck? else []
+      ["ws"]
     ]))
 
     val signal-names = to-tuple(cat-all([
-      ["MCLK"] when mck? else []
+      ["MCK"] when mck? else []
       ["SDI"] when sdmi? else []
-      ["WS" "CK" "SDO"]
+      ["SD"] when sd? else []
+      ["SDO"] when sdo? else []
+      ["ext_SD"] when extsd? else []
+      ["CK"] when ck? else []
+      ["SCK"] when sck? else []
+      ["WS"]
     ]))
 
     print-bundle-data(


### PR DESCRIPTION
The new generated output looks as follows

```
    pcb-bundle I2S3_MCK:
      pin p
    pcb-bundle I2S3_SD:
      pin p
    pcb-bundle I2S3_CK:
      pin p
    pcb-bundle I2S3_WS:
      pin p

    supports I2S3_CK:
      I2S3_CK.p => self.PB[3]
    supports I2S3_WS:
      I2S3_WS.p => self.PA[15]
    supports I2S3_CK:
      I2S3_CK.p => self.PC[10]
    supports I2S3_SD:
      I2S3_SD.p => self.PB[5]
    supports I2S3_SD:
      I2S3_SD.p => self.PC[12]
    supports I2S3_MCK:
      I2S3_MCK.p => self.PC[7]
    supports I2S3_WS:
      I2S3_WS.p => self.PA[4]
    supports i2s([I2S-MCK]):
      require mck-pin: I2S3_MCK
      require sdmo-pin: I2S3_SD
      require ck-pin: I2S3_CK
      require ws-pin: I2S3_WS
      i2s([I2S-MCK]).mck => mck-pin.p
      i2s([I2S-MCK]).sdmo => sdmo-pin.p
      i2s([I2S-MCK]).ck => ck-pin.p
      i2s([I2S-MCK]).ws => ws-pin.p

```