### PR TITLE
IPC compliant small outline (SO) landpatterns

### DIFF
--- a/tests/test-land-patterns.stanza
+++ b/tests/test-land-patterns.stanza
@@ -13,6 +13,20 @@ defpackage ocdb/test/land-patterns:
   import ocdb/generic-components
   import ocdb/symbols
 
+pcb-component SOIC-CMP:
+  pcb-landpattern SO8N:
+    make-n-pin-soic-landpattern(8,    ; num-pins
+                                1.27, ; pin-pitch
+                                tol(6.0, 0.2), ;outer-length
+                                tol(3.9, 0.1), ;part-length
+                                tol(4.9, 0.1), ;part-width
+                                min-typ-max(0.4, 1.04, 1.27),  ; lead-width
+                                min-typ-max(0.28, 0.38, 0.48)) ; lead-length 
+  port p: pin[[1 2]]
+  val lp = SO8N
+  landpattern = lp(p[1] => lp.p[1], p[2] => lp.p[2])
+  make-box-symbol()
+
 pcb-component vishay-resistor-1005 :
   name = "Generic Vishay Resistor"
   description = "Generic chip resistor, 1005 package"
@@ -65,11 +79,11 @@ pcb-component example-2:
 
 pcb-module main-module:
   inst e1: example-1
-  inst e2: example-2
-  inst e3: vishay-resistor-1005
-  place(e1) at loc(-3.0, 0.0) on Top
-  place(e2) at loc(0.0, 0.0) on Top
-  place(e3) at loc(3.0, 0.0) on Top
+  inst e2: SOIC-CMP
+  inst e3: example-2
+  place(e1) on Top
+  place(e2) on Top
+  place(e3) on Top 
 set-rules(sierra-adv-rules)
-make-default-board(main-module, 2, Rectangle(12.0, 5.0))
+make-default-board(main-module, 2, Rectangle(12.0, 12.0))
 view-board()

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -465,7 +465,6 @@ public defn make-generic-landpattern (pad-names:Seqable<Ref>,
 
 ; Naming for a 2-column arrangment of pins 
 public defn soic-naming-convention (row:Int, column:Int, num-pins:Int) -> Ref:
-  println("row:%_, col:%_" % [row, column])
   if (column < 0) or (column > 1): 
     fatal("soic naming convention supports a maximum of 2 columns")
   switch(column):
@@ -1063,6 +1062,8 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,
     defn wiggle-room (C:Double) -> Double:
       rms([C, fabrication-tolerance, placement-tolerance])
     
+    ;----------------------------------------------------
+    ; Compute adjustments to dimensions using IPC formula
     val [Jt, Jh, Js, courtyard-excess] = to-tuple(lead-fillets(lead-type, density-level))
     val Lmax = max-value(length)
     val Lmin = min-value(length)
@@ -1112,10 +1113,6 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,
     ; place the reference label    
     val text-y = 0.5 * (cy-y-dim + MIN-SILKSCREEN-TEXT-HEIGHT)
     ref-label(0.0, text-y)
-
-    ;----------------------------------------------------
-    ; debugging, remove prior to merging
-    layer(Courtyard(Bottom)) = Rectangle(typ(part-length), typ(part-width))
 
 public defn make-n-pin-soic-landpattern (num-pins:Int,
                                          pitch:Double,

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1040,14 +1040,14 @@ public pcb-landpattern smd-testpoint-pkg (d:Double) :
   layer(Silkscreen("f-silk", Top)) = Circle(d / 2.0)
   ref-label()
 
-public defn make-n-pin-soic-landpattern (num-pins:Int,
-                                         pitch:Double,
-                                         outer-length:Toleranced,
-                                         part-length:Toleranced,
-                                         part-width:Toleranced,
-                                         lead-type:LandProtrusionType,
-                                         lead-length:Toleranced,
-                                         lead-width:Toleranced,
+public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pins of the component
+                                         pitch:Double,            ; pitch of the pins of the component
+                                         outer-length:Toleranced, ; the "outer length" (x-dimension) of the component, from lead-to-lead
+                                         part-length:Toleranced,  ; the length of the part/package (x-dimension)
+                                         part-width:Toleranced,   ; the width of the part/package (y-dimension)
+                                         lead-type:LandProtrusionType, ; the lead/land protrusion type of the part
+                                         lead-length:Toleranced, ; the length (x-dimension) of the leads
+                                         lead-width:Toleranced,  ; the width (y-dimension) of the leads
                                          fabrication-tolerance:Double,
                                          placement-tolerance:Double,
                                          density-level:DensityLevel):

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1042,20 +1042,19 @@ public pcb-landpattern smd-testpoint-pkg (d:Double) :
 
 public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pins of the component
                                          pitch:Double,            ; pitch of the pins of the component
-                                         outer-length:Toleranced, ; the "outer length" (x-dimension) of the component, from lead-to-lead
-                                         part-length:Toleranced,  ; the length of the part/package (x-dimension)
-                                         part-width:Toleranced,   ; the width of the part/package (y-dimension)
+                                         outer-x:Toleranced,      ; the "outer length" (x-dimension) of the component, from lead-to-lead
+                                         part-x:Toleranced,       ; the length of the part/package (x-dimension)
+                                         part-y:Toleranced,       ; the width of the part/package (y-dimension)
                                          lead-type:LandProtrusionType, ; the lead/land protrusion type of the part
-                                         lead-length:Toleranced, ; the length (x-dimension) of the leads
-                                         lead-width:Toleranced,  ; the width (y-dimension) of the leads
-                                         fabrication-tolerance:Double,
-                                         placement-tolerance:Double,
-                                         density-level:DensityLevel):
+                                         lead-x:Toleranced,  ; the length (x-dimension) of the leads
+                                         lead-y:Toleranced,  ; the width (y-dimension) of the leads
+                                         fabrication-tolerance:Double, ; the fabrication tolerance (F)
+                                         placement-tolerance:Double,   ; the placement tolerance/accuracy (P)
+                                         density-level:DensityLevel):  ; the density level of the design
   fatal("n must be even") when (num-pins % 2) != 0
   inside pcb-landpattern:
-    val length = outer-length
-    val width  = part-width
-
+    ; layer(Silkscreen("f-silk", Bottom)) = LineRectangle(typ(part-x), typ(part-y))
+    
     defn rms (s:Seqable<Double>) -> Double:
       sqrt(sum(seq(fn (x:Double): x * x, s)))
 
@@ -1065,27 +1064,33 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pi
     ;----------------------------------------------------
     ; Compute adjustments to dimensions using IPC formula
     val [Jt, Jh, Js, courtyard-excess] = to-tuple(lead-fillets(lead-type, density-level))
-    val Lmax = max-value(length)
-    val Lmin = min-value(length)
-    val Tmin = min-value(lead-length)
-    val Wmin = min-value(lead-width)
+    val Lmax = max-value(outer-x)
+    val Lmin = min-value(outer-x)
+    val Tmin = min-value(lead-x)
+    val Wmin = min-value(lead-y)
     val Smax = Lmax - 2.0 * Tmin
-    val Cw   = tolerance-range(width)
-    val Cl   = tolerance-range(length) 
-    val Cs   = rms([tolerance-range(lead-length), Cl])
+    val Cw   = tolerance-range(lead-y)
+    val Cl   = tolerance-range(outer-x) 
+    val Cs   = rms([tolerance-range(lead-x), Cl])
     val Zmax = Lmin + 2.0 * Jt + wiggle-room(Cl)
     val Gmin = Smax - 2.0 * Jh - wiggle-room(Cs)
     val Xmin = Wmin + 2.0 * Js + wiggle-room(Cw)
 
+    ; layer(Silkscreen("f-silk", Top)) = LineRectangle(Zmax, typ(part-y))
+    ; layer(Silkscreen("f-silk", Top)) = LineRectangle(Gmin, typ(part-y))
+
     ;----------------------------------------------------
     ; compute our pad sizes
-    val pad-x-dim = 0.5 * (Zmax - Gmin)
-    val pad-y-dim = Xmin
-    val pad_ = smd-pad(Rectangle(pad-x-dim, pad-y-dim))
+    val pad-x = 0.5 * (Zmax - Gmin)
+    val pad-y = Xmin
+    val pad_ = smd-pad(Rectangle(pad-x, pad-y))
     
     ;----------------------------------------------------
     ; place the pads
-    val locs = to-tuple(grid-locs(num-pins / 2, 2, Gmin + pad-x-dim, pitch, false))
+    val locs = to-tuple(grid-locs(num-pins / 2, 2, Gmin + pad-x, pitch, false))
+    ; layer(Silkscreen("f-silk", Bottom)) = locs[0] * LineRectangle(typ(lead-x), typ(lead-y))
+    ; layer(Silkscreen("f-silk", Top))    = locs[0] * LineRectangle(pad-x, Xmin)
+
     for (i in 0 to false, l in locs) do:
       val name = soic-naming-convention(i % (num-pins / 2), i / (num-pins / 2), num-pins)
       pad (name): pad_ at l
@@ -1094,9 +1099,9 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pi
     ; compute the courtyard    
     val ys = to-tuple(seq(y{center(_)}, locs))
     val lp-x-dim = Zmax + 2.0 * SOLDER-MASK-REGISTRATION
-    val lp-y-dim = pad-y-dim + maximum(ys) - minimum(ys) + 2.0 * SOLDER-MASK-REGISTRATION
-    val cy-x-dim = max(lp-x-dim, max-value(part-length)) + 2.0 * courtyard-excess
-    val cy-y-dim = max(lp-y-dim, max-value(part-width)) + 2.0 * courtyard-excess
+    val lp-y-dim = pad-y + maximum(ys) - minimum(ys) + 2.0 * SOLDER-MASK-REGISTRATION
+    val cy-x-dim = max(lp-x-dim, max-value(part-x)) + 2.0 * courtyard-excess
+    val cy-y-dim = max(lp-y-dim, max-value(part-y)) + 2.0 * courtyard-excess
     layer(Courtyard(Top)) = Rectangle(cy-x-dim, cy-y-dim)
 
     ;----------------------------------------------------
@@ -1113,7 +1118,11 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pi
     ; place the reference label    
     val text-y = 0.5 * (cy-y-dim + MIN-SILKSCREEN-TEXT-HEIGHT)
     ref-label(0.0, text-y)
-
+    ; layer(Silkscreen("f-silk", Bottom)) = Line(min-silk-width, [
+    ;   Point(-0.5 * typ(outer-x), 3.5)
+    ;   Point( 0.5 * typ(outer-x), 3.5)
+    ; ])
+    ; false
 public defn make-n-pin-soic-landpattern (num-pins:Int,
                                          pitch:Double,
                                          outer-length:Toleranced,

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -465,6 +465,7 @@ public defn make-generic-landpattern (pad-names:Seqable<Ref>,
 
 ; Naming for a 2-column arrangment of pins 
 public defn soic-naming-convention (row:Int, column:Int, num-pins:Int) -> Ref:
+  println("row:%_, col:%_" % [row, column])
   if (column < 0) or (column > 1): 
     fatal("soic naming convention supports a maximum of 2 columns")
   switch(column):
@@ -1040,6 +1041,101 @@ public pcb-landpattern smd-testpoint-pkg (d:Double) :
   layer(Silkscreen("f-silk", Top)) = Circle(d / 2.0)
   ref-label()
 
+public defn make-n-pin-soic-landpattern (num-pins:Int,
+                                         pitch:Double,
+                                         outer-length:Toleranced,
+                                         part-length:Toleranced,
+                                         part-width:Toleranced,
+                                         lead-type:LandProtrusionType,
+                                         lead-length:Toleranced,
+                                         lead-width:Toleranced,
+                                         fabrication-tolerance:Double,
+                                         placement-tolerance:Double,
+                                         density-level:DensityLevel):
+  fatal("n must be even") when (num-pins % 2) != 0
+  inside pcb-landpattern:
+    val length = outer-length
+    val width  = part-width
+
+    defn rms (s:Seqable<Double>) -> Double:
+      sqrt(sum(seq(fn (x:Double): x * x, s)))
+
+    defn wiggle-room (C:Double) -> Double:
+      rms([C, fabrication-tolerance, placement-tolerance])
+    
+    val [Jt, Jh, Js, courtyard-excess] = to-tuple(lead-fillets(lead-type, density-level))
+    val Lmax = max-value(length)
+    val Lmin = min-value(length)
+    val Tmin = min-value(lead-length)
+    val Wmin = min-value(lead-width)
+    val Smax = Lmax - 2.0 * Tmin
+    val Cw   = tolerance-range(width)
+    val Cl   = tolerance-range(length) 
+    val Cs   = rms([tolerance-range(lead-length), Cl])
+    val Zmax = Lmin + 2.0 * Jt + wiggle-room(Cl)
+    val Gmin = Smax - 2.0 * Jh - wiggle-room(Cs)
+    val Xmin = Wmin + 2.0 * Js + wiggle-room(Cw)
+
+    ;----------------------------------------------------
+    ; compute our pad sizes
+    val pad-x-dim = 0.5 * (Zmax - Gmin)
+    val pad-y-dim = Xmin
+    val pad_ = smd-pad(Rectangle(pad-x-dim, pad-y-dim))
+    
+    ;----------------------------------------------------
+    ; place the pads
+    val locs = to-tuple(grid-locs(num-pins / 2, 2, Gmin + pad-x-dim, pitch, false))
+    for (i in 0 to false, l in locs) do:
+      val name = soic-naming-convention(i % (num-pins / 2), i / (num-pins / 2), num-pins)
+      pad (name): pad_ at l
+
+    ;----------------------------------------------------
+    ; compute the courtyard    
+    val ys = to-tuple(seq(y{center(_)}, locs))
+    val lp-x-dim = Zmax + 2.0 * SOLDER-MASK-REGISTRATION
+    val lp-y-dim = pad-y-dim + maximum(ys) - minimum(ys) + 2.0 * SOLDER-MASK-REGISTRATION
+    val cy-x-dim = max(lp-x-dim, max-value(part-length)) + 2.0 * courtyard-excess
+    val cy-y-dim = max(lp-y-dim, max-value(part-width)) + 2.0 * courtyard-excess
+    layer(Courtyard(Top)) = Rectangle(cy-x-dim, cy-y-dim)
+
+    ;----------------------------------------------------
+    ; draw the orientation marker
+    val min-silk-width = clearance(current-rules(), MinSilkscreenWidth)
+    val line = Line(min-silk-width, [Point(min-silk-width * 0.5, 0.0),
+                                     Point(3.5 * min-silk-width, 0.0)])
+    val dist = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + min-silk-width * 0.5 + 0.01
+    val pol-x = -0.5 * lp-x-dim
+    val pol-y =  0.5 * lp-y-dim
+    layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * line
+      
+    ;----------------------------------------------------
+    ; place the reference label    
+    val text-y = 0.5 * (cy-y-dim + MIN-SILKSCREEN-TEXT-HEIGHT)
+    ref-label(0.0, text-y)
+
+    ;----------------------------------------------------
+    ; debugging, remove prior to merging
+    layer(Courtyard(Bottom)) = Rectangle(typ(part-length), typ(part-width))
+
+public defn make-n-pin-soic-landpattern (num-pins:Int,
+                                         pitch:Double,
+                                         outer-length:Toleranced,
+                                         length:Toleranced,
+                                         width:Toleranced,
+                                         lead-length:Toleranced,
+                                         lead-width:Toleranced):
+  make-n-pin-soic-landpattern(num-pins,
+                               pitch
+                               outer-length,
+                               length,
+                               width,
+                               BigGullWingLeads,
+                               lead-length,
+                               lead-width,
+                               FABRICATION-TOLERANCE,
+                               PLACEMENT-TOLERANCE,
+                               DensityLevelC)
+
 public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vertical) dimension of the package
                                            width:Toleranced,  ; the width (horizontal) dimension of the package
                                            lead-length:Toleranced, ; the length (vertical) dimension of the conductors/leads of the package
@@ -1106,6 +1202,7 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
     pad (refs[0]): pad_ at loc(0.0, y-max)
     pad (refs[1]): pad_ at loc(0.0, y-min)
 
+    ; ----------------------------------------------------
     val lp-x-size  = land-width + 2.0 * SOLDER-MASK-REGISTRATION
     val lp-y-size  = Zmax + 2.0 * SOLDER-MASK-REGISTRATION
     val cmp-x-size = max-value(width)

--- a/utils/land-protrusions.stanza
+++ b/utils/land-protrusions.stanza
@@ -49,6 +49,9 @@ public pcb-struct ocdb/land-patterns/packages/LeadFillets:
   side:Double ; space on the edges of the lead
   courtyard-excess:Double ; additional area to add to the courtyard 
 
+public defn to-tuple (l:LeadFillets) -> [Double, Double, Double, Double]:
+  [toe(l), heel(l), side(l), courtyard-excess(l)]
+
 ; Compute the LeadFillets of a lead type
 public defn lead-fillets (lead-type:LandProtrusionType) -> LeadFillets:
   lead-fillets(lead-type, DensityLevelA)

--- a/utils/tolerance.stanza
+++ b/utils/tolerance.stanza
@@ -65,3 +65,11 @@ public defn in-range? (t:Toleranced, value:Double) -> True|False:
  ; Returns the difference between max and min of the toleranced values
 public defn tolerance-range (t:Toleranced) -> Double:
   max-value(t) - min-value(t)
+
+public defn plus (l:Toleranced, r:Toleranced) -> Toleranced:
+  defn rms (s:Seqable<Double>):
+    sqrt(sum(seq(fn (x:Double): x * x, s)))
+
+  val tol+ = rms([tol+(l), tol+(r)])
+  val tol- = rms([tol-(l), tol-(r)])
+  Toleranced(typ(l) + typ(r), tol+, tol-)


### PR DESCRIPTION
Example:

![Screenshot from 2021-07-26 15-30-26](https://user-images.githubusercontent.com/28515218/127068033-d329e826-d7ca-4100-88bc-c798edc70bef.png)

The package outline will be omitted from the final results, it is present in the screenshot to help debugging the generator. 