### PR TITLE
Feature/jitx 522 add missing pins 1

### DIFF
--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -484,10 +484,10 @@ defn print-i2s (o:OutputStream, mcu:Stm32MCU):
 ; print uart or usart. The implementation is the same except names.
 ; The expected input for the variable uart-or-usart is "UART" or "USART"
 defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
-  print("Printing %_" %[uart-or-usart])
+  ;println("Printing %_" %[uart-or-usart])
   for ip-block in filter(prefix?{instance-name(_), uart-or-usart}, ip(mcu)) do:
     val pins = unique-pins-for(instance-name(ip-block), mcu)
-    print-pins(pins)
+    ;print-pins(pins)
 
     val dtr? = contains?(pins, "DTR")
     val cts? = contains?(pins, "CTS")

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -481,6 +481,82 @@ defn print-i2s (o:OutputStream, mcu:Stm32MCU):
       pin-names
     )
 
+; print uart or usart. The implementation is the same except names.
+; The expected input for the variable uart-or-usart is "UART" or "USART"
+defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
+  for ip-block in filter(prefix?{instance-name(_), uart-or-usart}, ip(mcu)) do:
+    val pins = unique-pins-for(instance-name(ip-block), mcu)
+    print-pins(pins)
+
+    val dtr? = contains?(pins, "DTR")
+    val cts? = contains?(pins, "CTS")
+    val dcd? = contains?(pins, "DCD")
+    val ri? = contains?(pins, "RI")
+    val dst? = contains?(pins, "DST")
+    val rts? = contains?(pins, "RTS")
+    val ck? = contains?(pins, "CK")
+    val de? = contains?(pins, "DE")
+    val nss? = contains?(pins, "NSS")
+
+    val optional = Vector<String>()
+    if dtr?: 
+      add(optional, "UART-DTR")
+    if cts?: 
+      add(optional, "UART-CTS")
+    if dcd?: 
+      add(optional, "UART-DCD")
+    if ri?: 
+      add(optional, "UART-RI")
+    if dst?: 
+      add(optional, "UART-DST")
+    if rts?: 
+      add(optional, "UART-RTS")
+    if ck?: 
+      add(optional, "UART-CK")
+    if de?: 
+      add(optional, "UART-DE")
+    if nss?: 
+      add(optional, "UART-NSS")
+
+    var bundle-name
+    if uart_or_usart == "UART":
+      bundle-name = "uart()" when empty?(optional) else to-string("uart([%,])" % [optional])
+    else:
+      bundle-name = "usart()" when empty?(optional) else to-string("usart([%,])" % [optional])
+    val pin-names = to-tuple(cat-all([
+      ["UART-DTR"]  when dtr? else []
+      ["UART-CTS"] when cts? else []
+      ["UART-DCD"] when dcd? else []
+      ["UART-RI"] when ri? else []
+      ["UART-DST"] when dst? else []
+      ["UART-RTS"] when rts? else []
+      ["UART-CK"] when ck? else []
+      ["UART-DE"] when de? else []
+      ["UART-NSS"] when nss? else []
+      ["rx"]
+      ["tx"]
+    ]))
+
+    val signal-names = to-tuple(cat-all([
+      ["DTR"] when dtr? else []
+      ["CTS"] when cts? else []
+      ["DCD"] when dcd? else []
+      ["RT"] when ri? else []
+      ["DST"] when dst? else []
+      ["RTS"] when rts? else []
+      ["CK"] when ck? else []
+      ["DE"] when de? else []
+      ["NSS"] when nss? else []
+      ["RX"]
+      ["TX"]
+    ]))
+
+    print-bundle-data(
+      o, mcu, instance-name(ip-block), bundle-name,
+      signal-names
+      pin-names
+    )
+
 ; print-quad-spi currently ignores BK2 signals
 defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
   for ip-block in filter(prefix?{instance-name(_),"QUADSPI"}, ip(mcu)) do:
@@ -663,8 +739,8 @@ public defn make-supports ():
   print-i2c(os, mcu)
   print-can(os, mcu)
   print-spi(os, mcu)
-  print-uart(os, mcu)
-  print-usart(os, mcu)
+  print-uart-or-usart(os, mcu, "UART")
+  print-uart-or-usart(os, mcu, "USART")
   print-i2s(os, mcu)
   print-oscillator(os, mcu)
 

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -527,7 +527,7 @@ defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
     val rts? = contains?(pins, "RTS")
     val ck? = contains?(pins, "CK")
     val de? = contains?(pins, "DE")
-    val nss? = contains?(pins, "NSS")
+    val cs? = contains?(pins, "NSS")
 
     val optional = Vector<String>()
     if dtr?: 
@@ -546,8 +546,8 @@ defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
       add(optional, "UART-CK")
     if de?: 
       add(optional, "UART-DE")
-    if nss?: 
-      add(optional, "UART-NSS")
+    if cs?: 
+      add(optional, "UART-CS")
 
     var bundle-name
     if uart-or-usart == "UART":
@@ -564,7 +564,7 @@ defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
       ["rts"] when rts? else []
       ["ck"] when ck? else []
       ["de"] when de? else []
-      ["nss"] when nss? else []
+      ["cs"] when cs? else []
       ["rx"]
       ["tx"]
     ]))
@@ -578,7 +578,7 @@ defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
       ["RTS"] when rts? else []
       ["CK"] when ck? else []
       ["DE"] when de? else []
-      ["NSS"] when nss? else []
+      ["NSS"] when cs? else []
       ["RX"]
       ["TX"]
     ]))

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -400,11 +400,41 @@ defn print-bundle (
       print-bundle-data(o, mcu, instance-name(ip-block), ocdb-name, cubemx-signals, ocdb-pins)
 
 defn print-spi (o:OutputStream, mcu:Stm32MCU):
-  print-bundle(
-    o, mcu, "SPI", "spi()"
-    ["MOSI", "MISO", "SCK", "NSS"]
-    ["sdo", "sdi", "sck", "cs"]
-  )
+  for ip-block in filter(prefix?{instance-name(_),"SPI"}, ip(mcu)) do:
+    val pins = unique-pins-for(instance-name(ip-block), mcu)
+
+    val sdo? = contains?(pins, "MOSI")
+    val sdi? = contains?(pins, "MISO")
+    val cs? = contains?(pins, "NSS")
+
+    val optional = Vector<String>()
+    if sdo?: 
+      add(optional, "SPI-SDO")
+    if sdi?: 
+      add(optional, "SPI-SDI")
+    if cs?: 
+      add(optional, "SPI-CS")
+
+    val bundle-name = "spi()" when empty?(optional) else to-string("spi([%,])" % [optional])
+    val pin-names = to-tuple(cat-all([
+      ["sdo"]  when sdo? else []
+      ["sdi"] when sdi? else []
+      ["cs"] when cs? else []
+      ["sck"]
+    ]))
+
+    val signal-names = to-tuple(cat-all([
+      ["MOSI"] when sdo? else []
+      ["MISO"] when sdi? else []
+      ["NSS"] when cs? else []
+      ["SCK"]
+    ]))
+
+    print-bundle-data(
+      o, mcu, instance-name(ip-block), bundle-name,
+      signal-names
+      pin-names
+    )
 
 defn print-i2c (o:OutputStream, mcu:Stm32MCU):
   print-bundle(               

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -191,7 +191,7 @@ defn ref-ify (s:String) -> Ref:
 
   ; internal helper. Prints failure message.
   defn fail () -> Void:
-    fatal("Could not parse %_ as a pin or pad ref." % [s])
+    throw(Exception("Could not parse %_ as a pin or pad ref." % [s]))
   
   ; main program
   defn driver (s:String):
@@ -343,13 +343,13 @@ defn print-bundle-data (
     replace{_, "]", "_"}
 
   if length(ocdb-pins) != length(cubemx-signals):
-    fatal("invalid mapping of cubemx signals to pcb-bundle data in ocdb.")
+    throw(Exception("invalid mapping of cubemx signals to pcb-bundle data in ocdb."))
   
   ; collect data
   val pins* = pins-with-signal(pins(mcu), prefix?{_, instance-name})
   val signals* = to-tuple(seq(to-string{"%__%_" % [instance-name, _]}, cubemx-signals))
   if empty?(pins*):
-    fatal("Missing pins for %_" % [instance-name])
+    throw(Exception("Missing pins for %_" % [instance-name]))
   
   ; print private bundles
   for s in signals* do:
@@ -585,7 +585,7 @@ defn uart-case (instance-name:String, mcu:Stm32MCU) -> UartCase:
       if same-set?(to-hashset<String>(uart-cubemx-pins(UartCase(c))), pins):
         ; println("uart-case: Returning %_" % [UartCase(c)])
         return(UartCase(c))
-    fatal("Unsupported UART pin set: %," % [pins])
+    throw(Exception("Unsupported UART pin set: %," % [pins]))
 
 defn print-usart (o:OutputStream, mcu:Stm32MCU):
   for uart-block in filter({name(_0) == "USART"}, ip(mcu)) do:

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -604,6 +604,16 @@ defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
       pin-names
     )
 
+; helper to determine if two sets have the same elements
+defn same-set?<?T> (l:Set<?T>, r:Set<?T>):
+  label<True|False> return:
+    if length(l) != length(r):
+      return(false)
+    for e in l do: 
+      if not r[e]:
+        return(false)
+    true
+
 ;=============================================================================
 ;========================= Importer Algorithm ================================
 ;=============================================================================

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -484,6 +484,7 @@ defn print-i2s (o:OutputStream, mcu:Stm32MCU):
 ; print uart or usart. The implementation is the same except names.
 ; The expected input for the variable uart-or-usart is "UART" or "USART"
 defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
+  print("Printing %_" %[uart-or-usart])
   for ip-block in filter(prefix?{instance-name(_), uart-or-usart}, ip(mcu)) do:
     val pins = unique-pins-for(instance-name(ip-block), mcu)
     print-pins(pins)
@@ -519,20 +520,21 @@ defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
       add(optional, "UART-NSS")
 
     var bundle-name
-    if uart_or_usart == "UART":
+    if uart-or-usart == "UART":
       bundle-name = "uart()" when empty?(optional) else to-string("uart([%,])" % [optional])
     else:
       bundle-name = "usart()" when empty?(optional) else to-string("usart([%,])" % [optional])
+
     val pin-names = to-tuple(cat-all([
-      ["UART-DTR"]  when dtr? else []
-      ["UART-CTS"] when cts? else []
-      ["UART-DCD"] when dcd? else []
-      ["UART-RI"] when ri? else []
-      ["UART-DST"] when dst? else []
-      ["UART-RTS"] when rts? else []
-      ["UART-CK"] when ck? else []
-      ["UART-DE"] when de? else []
-      ["UART-NSS"] when nss? else []
+      ["dtr"]  when dtr? else []
+      ["cts"] when cts? else []
+      ["dcd"] when dcd? else []
+      ["ri"] when ri? else []
+      ["dst"] when dst? else []
+      ["rts"] when rts? else []
+      ["ck"] when ck? else []
+      ["de"] when de? else []
+      ["nss"] when nss? else []
       ["rx"]
       ["tx"]
     ]))
@@ -541,7 +543,7 @@ defn print-uart-or-usart (o:OutputStream, mcu:Stm32MCU, uart-or-usart:String):
       ["DTR"] when dtr? else []
       ["CTS"] when cts? else []
       ["DCD"] when dcd? else []
-      ["RT"] when ri? else []
+      ["RI"] when ri? else []
       ["DST"] when dst? else []
       ["RTS"] when rts? else []
       ["CK"] when ck? else []
@@ -601,90 +603,6 @@ defn print-quad-spi (o:OutputStream, mcu:Stm32MCU):
       signal-names
       pin-names
     )
-
-;==============================================================================
-;============================= UART edge cases ================================
-;==============================================================================
-defenum UartCase:
-  Uart2   ; 2 pin UART
-  Uart2De ; 2 pin UART with DE pin
-  Uart4   ; 4 pin UART 
-  Uart4De ; 4 pin UART with DE pin
-
-
-defn usart-or-uart-bundle (uart?:True|False, c:UartCase):
-  val base = "uart" when uart? else "usart"
-  val args = 
-    switch(c):
-      Uart2:   "",
-      Uart2De: "[UART-DE]",
-      Uart4:   "[UART-CTS, UART-RTS]",
-      Uart4De: "[UART-CTS, UART-RTS, UART-DE]"
-  to-string("%_(%_)" % [base, args])
-
-; ocdb bundle identifer for a given UART case
-defn uart-bundle (c: UartCase):
-  usart-or-uart-bundle(true, c)
-
-defn usart-bundle (c:UartCase):
-  usart-or-uart-bundle(false, c)
-
-; the OCDB pin names for a UART case
-defn uart-ocdb-pins (c:UartCase):
-  switch(c):
-    Uart2:   ["tx", "rx"]
-    Uart2De: ["tx", "rx", "de"]
-    Uart4:   ["tx", "rx", "cts", "rts"]
-    Uart4De: ["tx", "rx", "cts", "rts", "de"]
-
-; the CubeMX pin names for a UART case
-defn uart-cubemx-pins (c:UartCase):
-  to-tuple(seq(upper-case, uart-ocdb-pins(c)))
-
-; helper to determine if two sets have the same elements
-defn same-set?<?T> (l:Set<?T>, r:Set<?T>):
-  label<True|False> return:
-    if length(l) != length(r):
-      return(false)
-    for e in l do: 
-      if not r[e]:
-        return(false)
-    true
-
-; determine which case we are handling
-defn uart-case (instance-name:String, mcu:Stm32MCU) -> UartCase:
-  val pins = unique-pins-for(instance-name, mcu, suffix?{_, "CK"})
-  ;print-pins(pins)
-  label<UartCase> return:
-    for c in 0 to 4 do:
-      val check = uart-cubemx-pins(UartCase(c))
-      if same-set?(to-hashset<String>(uart-cubemx-pins(UartCase(c))), pins):
-        ; println("uart-case: Returning %_" % [UartCase(c)])
-        return(UartCase(c))
-    throw(Exception("Unsupported UART pin set: %," % [pins]))
-
-defn print-usart (o:OutputStream, mcu:Stm32MCU):
-  for uart-block in filter({name(_0) == "USART"}, ip(mcu)) do:
-    val case = uart-case(instance-name(uart-block), mcu)
-    print-bundle-data(
-      o, mcu,
-      instance-name(uart-block),
-      usart-bundle(case),
-      uart-cubemx-pins(case)
-      uart-ocdb-pins(case)
-    )
-
-defn print-uart (o:OutputStream, mcu:Stm32MCU):
-  for uart-block in filter({name(_0) == "UART"}, ip(mcu)) do:
-    val case = uart-case(instance-name(uart-block), mcu)
-    print-bundle-data(
-      o, mcu, 
-      instance-name(uart-block),
-      uart-bundle(case),
-      uart-cubemx-pins(case)
-      uart-ocdb-pins(case)
-    )
-
 
 ;=============================================================================
 ;========================= Importer Algorithm ================================

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -242,7 +242,7 @@ defn unique-pins-for (instance-name:String, mcu:Stm32MCU, ignore?: (String) -> T
     prefix?(s, instance-name) and not ignore?(s)
   val u = HashSet<String>()
   for p in pins-with-signal(pins(mcu), F) do:
-    for s in relevant-signals(p, instance-name) do:
+    for s in filter({not ignore?(_)}, relevant-signals(p, instance-name)) do:
       add(u, s[(length(instance-name) + 1) to false])
   u
 ;==============================================================================

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -88,7 +88,7 @@ public pcb-enum ocdb/bundles/UARTPins :
   UART-RTS
   UART-CK
   UART-DE
-  UART-NSS
+  UART-CS
 
 public pcb-bundle uart (pins:Tuple<UARTPins>) :
   pin rx
@@ -103,7 +103,7 @@ public pcb-bundle uart (pins:Tuple<UARTPins>) :
       UART-RTS : make-pin(`rts)
       UART-CK : make-pin(`ck)
       UART-DE : make-pin(`de)
-      UART-NSS : make-pin(`nss)
+      UART-CS : make-pin(`cs)
 
 public defn uart ():
   uart([])
@@ -121,7 +121,7 @@ public pcb-bundle usart (pins:Tuple<ocdb/bundles/UARTPins>) :
       UART-RTS : make-pin(`rts)
       UART-CK : make-pin(`ck)
       UART-DE : make-pin(`de)
-      UART-NSS : make-pin(`nss)
+      UART-CS : make-pin(`cs)
 
 public defn usart ():
   usart([])

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -143,6 +143,7 @@ public pcb-bundle spi  (pins:Tuple<SPIPins>):
       SPI-CS  : make-pin(`cs)
       SPI-CIPO  : make-pin(`cipo)
       SPI-COPI  : make-pin(`copi)
+      SPI-SDIO  : make-pin(`sdio)
 
 ; Most common spi bundle
 public defn spi ():

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -88,6 +88,7 @@ public pcb-enum ocdb/bundles/UARTPins :
   UART-RTS
   UART-CK
   UART-DE
+  UART-NSS
 
 public pcb-bundle uart (pins:Tuple<UARTPins>) :
   pin rx
@@ -102,6 +103,7 @@ public pcb-bundle uart (pins:Tuple<UARTPins>) :
       UART-RTS : make-pin(`rts)
       UART-CK : make-pin(`ck)
       UART-DE : make-pin(`de)
+      UART-NSS : make-pin(`nss)
 
 public defn uart ():
   uart([])
@@ -119,6 +121,7 @@ public pcb-bundle usart (pins:Tuple<ocdb/bundles/UARTPins>) :
       UART-RTS : make-pin(`rts)
       UART-CK : make-pin(`ck)
       UART-DE : make-pin(`de)
+      UART-NSS : make-pin(`nss)
 
 public defn usart ():
   usart([])


### PR DESCRIPTION
Added NSS pin to SPI in bundles.stanza.
**The above statement is incorrect. Added NSS pin to UART and USART in bundles.stanza**
Rewrote the logic to print SPI and UART
Bug fix for printing I2C. In some cases we were picking up SMBA pin which is supposed to be ignored
Changed fatal to Exception so the caller can decide what to do if a file parsing fails.