### PR TITLE
IPC Compliant SO/DIP Packages

### DIFF
--- a/tests/test-land-patterns.stanza
+++ b/tests/test-land-patterns.stanza
@@ -86,4 +86,5 @@ pcb-module main-module:
   place(e3) on Top 
 set-rules(sierra-adv-rules)
 make-default-board(main-module, 2, Rectangle(12.0, 12.0))
-view-board()
+; view-board()
+view(SOIC-CMP)

--- a/tests/test-land-patterns.stanza
+++ b/tests/test-land-patterns.stanza
@@ -13,6 +13,20 @@ defpackage ocdb/test/land-patterns:
   import ocdb/generic-components
   import ocdb/symbols
 
+pcb-component SOIC-CMP:
+  pcb-landpattern SO8N:
+    make-n-pin-soic-landpattern(8,    ; num-pins
+                                1.27, ; pin-pitch
+                                tol(6.0, 0.2), ;outer-length
+                                tol(3.9, 0.1), ;part-length
+                                tol(4.9, 0.1), ;part-width
+                                min-typ-max(0.4, 1.04, 1.27),  ; lead-width
+                                min-typ-max(0.28, 0.38, 0.48)) ; lead-length 
+  port p: pin[[1 2]]
+  val lp = SO8N
+  landpattern = lp(p[1] => lp.p[1], p[2] => lp.p[2])
+  make-box-symbol()
+
 pcb-component vishay-resistor-1005 :
   name = "Generic Vishay Resistor"
   description = "Generic chip resistor, 1005 package"
@@ -65,11 +79,11 @@ pcb-component example-2:
 
 pcb-module main-module:
   inst e1: example-1
-  inst e2: example-2
-  inst e3: vishay-resistor-1005
-  place(e1) at loc(-3.0, 0.0) on Top
-  place(e2) at loc(0.0, 0.0) on Top
-  place(e3) at loc(3.0, 0.0) on Top
+  inst e2: SOIC-CMP
+  inst e3: example-2
+  place(e1) on Top
+  place(e2) on Top
+  place(e3) on Top 
 set-rules(sierra-adv-rules)
-make-default-board(main-module, 2, Rectangle(12.0, 5.0))
+make-default-board(main-module, 2, Rectangle(12.0, 12.0))
 view-board()

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -23,8 +23,6 @@ public var MIN-CAP-VOLTAGE = 10.0 ; Minimum voltage to allow for capacitors
 
 ; Landpattern variables
 public var SOLDER-MASK-REGISTRATION: Double = 0.15
-public var PLACEMENT-TOLERANCE   = 0.05   ; "P" on page 13 IPC-7351B.
-public var FABRICATION-TOLERANCE = 0.1524 ; "F" on page 13 IPC-7351B.
 public var MIN-SILKSCREEN-TEXT-HEIGHT: Double  = 0.762
 public var MIN-COPPER-FEATURE: Double  = 0.127
 public var MIN-SPACING: Double  = 0.127

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1040,22 +1040,27 @@ public pcb-landpattern smd-testpoint-pkg (d:Double) :
   layer(Silkscreen("f-silk", Top)) = Circle(d / 2.0)
   ref-label()
 
+; Helper struct to contain the results of the IPC formula in section 3 of 
+; 7351-B
 defstruct IpcResults:
   Zmax:Double,
   Gmin:Double,
   Xmin:Double,
 
+; Helper to compute the pad size from the formula results
 defn pad-size (i:IpcResults) -> Dims:
   Dims(0.5 * (Zmax(i) - Gmin(i)), Xmin(i))
 
-public defn ipc-formula (
-  L:Toleranced,
-  T:Toleranced,
-  W:Toleranced,
-  P:Double,
-  F:Double,
-  fillets:LeadFillets, 
+; the IPC formula
+defn ipc-formula (
+  L:Toleranced, ; the distance from edge-of-lead to edge-of-lead on the exterior of the land pattern
+  T:Toleranced, ; the nominal size of the leads, in the same dimension as L
+  W:Toleranced, ; the nominal size of hte leads, in the dimension orthogonal to L
+  P:Double,     ; placement tolerance/accuracy
+  F:Double,     ; fabrication tolerance/accuracy
+  fillets:LeadFillets, ; looked up using lead-fillets(lead-type, density-level)
 ):
+  ; compute root-mean-squared of a sequence of numbers
   defn rms (s:Seqable<Double>):
     sqrt(sum(seq(fn (x:Double): x * x, s)))
   val [Jt, Jh, Js, _] = to-tuple(fillets)
@@ -1068,14 +1073,20 @@ public defn ipc-formula (
   val C_W  = tolerance-range(W)
   val C_T  = tolerance-range(T)
   val C_S  = rms([C_L, C_T])
-  val Zmax = Lmin + 2.0 * Jt + rms([C_L, P, F])
-  val Gmin = Smax - 2.0 * Jh - rms([C_S, P, F])
-  val Xmin = Wmin + 2.0 * Js + rms([C_W, P, F])
+  val Zmax = Lmin + 2.0 * Jt + rms([C_L, P, F]) ; the distance from edge of land to edge of land on the exterior of the land pattern
+  val Gmin = Smax - 2.0 * Jh - rms([C_S, P, F]) ; the distance from edge of land to edge of land on the interior of the land pattern
+  val Xmin = Wmin + 2.0 * Js + rms([C_W, P, F]) ; the size of the land in the dimension orthogonal to Z and G.
   IpcResults(Zmax, Gmin, Xmin)
-
-
-public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pins of the component
-                                         pitch:Double,            ; pitch of the pins of the component
+   
+; Create an `n` pin SOIC land pattern. 
+;
+; Restrictions:
+; - n must be even
+; - the leads are oriented on the left and right sides of the land pattern
+; - p[1] is the top left pin
+;
+public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of the component
+                                         pitch:Double,       ; pitch of the pins of the component
                                          outer-x:Toleranced, ; the "outer length" (x-dimension) of the component, from lead-to-lead
                                          part-x:Toleranced,  ; the length of the part/package (x-dimension)
                                          part-y:Toleranced,   ; the width of the part/package (y-dimension)
@@ -1115,9 +1126,9 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pi
     ; compute the courtyard
     val [max-y, min-y] = fork-on-seq(seq(y{center(_)}, locs), maximum, minimum)
     val lp-y-dim = y(pad-sz) + max-y - min-y
-    val lp-sz   = Dims(Zmax(ipc), y(pad-sz) + max-y - min-y) + 2.0 * SOLDER-MASK-REGISTRATION
+    val lp-sz   = enlarge(Dims(Zmax(ipc), y(pad-sz) + max-y - min-y), 2.0 * SOLDER-MASK-REGISTRATION)
     val part-sz = Dims(max-value(part-x), max-value(part-y))
-    val cy-sz   = max(lp-sz, part-sz) + 2.0 * courtyard-excess(lead-fillets)
+    val cy-sz   = enlarge(max(lp-sz, part-sz), 2.0 * courtyard-excess(lead-fillets))
     layer(Courtyard(Top)) = Rectangle(cy-sz)
         
     ;----------------------------------------------------
@@ -1126,10 +1137,11 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pi
     val line-length = 3.0 * line-width - line-width
     val dist  = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + line-width * 0.5 + 0.01
     val pad-loc = center(locs[0])
-    val pol-x = -0.5 * x(pad-loc)
-    val pol-y =  0.5 * y(pad-loc) + dist
+    println("pad-loc:%_" % [pad-loc])
+    val pol-x = min(-0.5 * x(part-sz), x(pad-loc) - 0.5 * x(pad-sz))
+    val pol-y = max( 0.5 * y(part-sz), y(pad-loc) + 0.5 * y(pad-sz))
     layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * Line(line-width, [Point(0.0, 0.0), Point(line-length, 0.0)])
-      
+    
     ;----------------------------------------------------
     ; place the reference label    
     val text-y = 0.5 * (y(cy-sz) + MIN-SILKSCREEN-TEXT-HEIGHT)
@@ -1137,20 +1149,20 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pi
 
 public defn make-n-pin-soic-landpattern (num-pins:Int,
                                          pitch:Double,
-                                         outer-length:Toleranced,
-                                         length:Toleranced,
-                                         width:Toleranced,
-                                         lead-length:Toleranced,
-                                         lead-width:Toleranced) :
+                                         outer-x:Toleranced,
+                                         part-x:Toleranced,
+                                         part-y:Toleranced,
+                                         lead-x:Toleranced,
+                                         lead-y:Toleranced) :
   val lead-type = BigGullWingLeads when pitch > 0.0625 else SmallGullWingLeads
   make-n-pin-soic-landpattern(num-pins,
                               pitch
-                              outer-length,
-                              length,
-                              width,
+                              outer-x,
+                              part-x,
+                              part-y,
                               lead-type,
-                              lead-length,
-                              lead-width,
+                              lead-x,
+                              lead-y,
                               FABRICATION-TOLERANCE,
                               PLACEMENT-TOLERANCE,
                               DensityLevelC)
@@ -1180,7 +1192,7 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
 
     ; ----------------------------------------------------
     ; place the pads
-    val pad-sz = pad-size(ipc)
+    val pad-sz = transpose(pad-size(ipc))
     val y-max = 0.5 * Gmin(ipc) + 0.5 * y(pad-sz)
     val y-min = (- y-max)
 
@@ -1194,9 +1206,9 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
     
     ; ----------------------------------------------------
     ; compute the courtyard
-    val lp-sz   = Dims(x(pad-sz), Zmax(ipc)) + 2.0 * SOLDER-MASK-REGISTRATION
+    val lp-sz   = enlarge(Dims(x(pad-sz), Zmax(ipc)), 2.0 * SOLDER-MASK-REGISTRATION)
     val part-sz = Dims(max-value(width), max-value(length))
-    val cy-sz   = max(lp-sz, part-sz) + 2.0 * courtyard-excess(lead-fillets)
+    val cy-sz   = enlarge(max(lp-sz, part-sz), 2.0 * courtyard-excess(lead-fillets))
     layer(Courtyard(Top)) = Rectangle(cy-sz)
     
     ; ----------------------------------------------------

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1056,13 +1056,9 @@ defn ipc-formula (
   L:Toleranced, ; the distance from edge-of-lead to edge-of-lead on the exterior of the land pattern
   T:Toleranced, ; the nominal size of the leads, in the same dimension as L
   W:Toleranced, ; the nominal size of hte leads, in the dimension orthogonal to L
-  P:Double,     ; placement tolerance/accuracy
-  F:Double,     ; fabrication tolerance/accuracy
   fillets:LeadFillets, ; looked up using lead-fillets(lead-type, density-level)
 ):
   ; compute root-mean-squared of a sequence of numbers
-  defn rms (s:Seqable<Double>):
-    sqrt(sum(seq(fn (x:Double): x * x, s)))
   val [Jt, Jh, Js, _] = to-tuple(fillets)
   val Lmax = max-value(L)
   val Lmin = min-value(L)
@@ -1072,10 +1068,10 @@ defn ipc-formula (
   val C_L  = tolerance-range(L)
   val C_W  = tolerance-range(W)
   val C_T  = tolerance-range(T)
-  val C_S  = rms([C_L, C_T])
-  val Zmax = Lmin + 2.0 * Jt + rms([C_L, P, F]) ; the distance from edge of land to edge of land on the exterior of the land pattern
-  val Gmin = Smax - 2.0 * Jh - rms([C_S, P, F]) ; the distance from edge of land to edge of land on the interior of the land pattern
-  val Xmin = Wmin + 2.0 * Js + rms([C_W, P, F]) ; the size of the land in the dimension orthogonal to Z and G.
+  val C_S  = sqrt(C_L * C_L + C_T * C_T)
+  val Zmax = Lmin + 2.0 * Jt + C_L ; the distance from edge of land to edge of land on the exterior of the land pattern
+  val Gmin = Smax - 2.0 * Jh - C_S ; the distance from edge of land to edge of land on the interior of the land pattern
+  val Xmin = Wmin + 2.0 * Js + C_W ; the size of the land in the dimension orthogonal to Z and G.
   IpcResults(Zmax, Gmin, Xmin)
    
 ; Create an `n` pin SOIC land pattern. 
@@ -1093,8 +1089,6 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of
                                          lead-type:LandProtrusionType, ; the lead/land protrusion type of the part
                                          lead-x:Toleranced, ; the length (x-dimension) of the leads
                                          lead-y:Toleranced,  ; the width (y-dimension) of the leads
-                                         fabrication-tolerance:Double,
-                                         placement-tolerance:Double,
                                          density-level:DensityLevel):
   fatal("n must be even") when (num-pins % 2) != 0
   val lead-fillets = lead-fillets(lead-type, density-level)
@@ -1104,7 +1098,6 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of
     ; Compute adjustments to dimensions using IPC formula
     val ipc = ipc-formula(
       outer-x, lead-x, lead-y, 
-      placement-tolerance, fabrication-tolerance,
       lead-fillets
     )
 
@@ -1137,7 +1130,6 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of
     val line-length = 3.0 * line-width - line-width
     val dist  = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + line-width * 0.5 + 0.01
     val pad-loc = center(locs[0])
-    println("pad-loc:%_" % [pad-loc])
     val pol-x = min(-0.5 * x(part-sz), x(pad-loc) - 0.5 * x(pad-sz))
     val pol-y = max( 0.5 * y(part-sz), y(pad-loc) + 0.5 * y(pad-sz))
     layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * Line(line-width, [Point(0.0, 0.0), Point(line-length, 0.0)])
@@ -1163,16 +1155,12 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,
                               lead-type,
                               lead-x,
                               lead-y,
-                              FABRICATION-TOLERANCE,
-                              PLACEMENT-TOLERANCE,
                               DensityLevelC)
 
 public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vertical) dimension of the package
                                            width:Toleranced,  ; the width (horizontal) dimension of the package
                                            lead-length:Toleranced, ; the length (vertical) dimension of the conductors/leads of the package
                                            lead-width?:False|Toleranced, ; the width (horizontal) dimension of the conductors/leads of the package, if different from `length`
-                                           fabrication-tolerance:Double, ; the fabrication tolerance (F)
-                                           placement-tolerance:Double    ; the placement tolerance or accuracy (P)
                                            density-level:DensityLevel,   ; the density level of the design (DensityLevelA|DensityLevelB|DensityLevelC)
                                            anode-and-cathode?:True|False,; whether the pads should be named `a` and `c` (if false, p[1] and p[2])
                                            polarized?:True|False         ; whether a polarity marker is required or not
@@ -1186,7 +1174,6 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
     ; compute the base dimensions of the lands
     val ipc = ipc-formula(
       length, lead-length, width when lead-width? is False else lead-width? as Toleranced,
-      placement-tolerance, fabrication-tolerance,
       lead-fillets
     )
 
@@ -1250,7 +1237,6 @@ public defn make-two-pin-chip-landpattern (length:Toleranced,
                                            polarized?:True|False):
   make-two-pin-chip-landpattern(
     length, width, lead-length, lead-width?, 
-    FABRICATION-TOLERANCE, PLACEMENT-TOLERANCE, 
     density-level, polarized?, polarized?
   )
 
@@ -1270,28 +1256,13 @@ public pcb-landpattern two-pin-chip-landpattern (length:Toleranced,
                                                  width:Toleranced,
                                                  lead-length:Toleranced,
                                                  lead-width?:False|Toleranced,
-                                                 fabrication-tolerance:Double,
-                                                 placement-tolerance:Double
                                                  density-level:DensityLevel,
                                                  polarized?:True|False):
   make-two-pin-chip-landpattern(
     length, width, lead-length, lead-width?,
-    fabrication-tolerance, placement-tolerance, 
     density-level, polarized?, polarized?
   )
 
-; Create a a two pin chip landpattern with a custom lead width, if it exists.
-public defn two-pin-chip-landpattern (length:Toleranced,
-                                      width:Toleranced,
-                                      lead-length:Toleranced,
-                                      lead-width?:False|Toleranced,
-                                      density-level:DensityLevel,
-                                      polarized?:True|False):
-  two-pin-chip-landpattern(
-    length, width, lead-length, lead-width?, 
-    FABRICATION-TOLERANCE, PLACEMENT-TOLERANCE, 
-    density-level, polarized?
-  )
 
 ; Create a two-pin chip landpattern with a custom density level
 public defn two-pin-chip-landpattern (length:Toleranced,

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -465,7 +465,6 @@ public defn make-generic-landpattern (pad-names:Seqable<Ref>,
 
 ; Naming for a 2-column arrangment of pins 
 public defn soic-naming-convention (row:Int, column:Int, num-pins:Int) -> Ref:
-  println("row:%_, col:%_" % [row, column])
   if (column < 0) or (column > 1): 
     fatal("soic naming convention supports a maximum of 2 columns")
   switch(column):
@@ -1063,6 +1062,8 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,
     defn wiggle-room (C:Double) -> Double:
       rms([C, fabrication-tolerance, placement-tolerance])
     
+    ;----------------------------------------------------
+    ; Compute adjustments to dimensions using IPC formula
     val [Jt, Jh, Js, courtyard-excess] = to-tuple(lead-fillets(lead-type, density-level))
     val Lmax = max-value(length)
     val Lmin = min-value(length)
@@ -1112,10 +1113,6 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,
     ; place the reference label    
     val text-y = 0.5 * (cy-y-dim + MIN-SILKSCREEN-TEXT-HEIGHT)
     ref-label(0.0, text-y)
-
-    ;----------------------------------------------------
-    ; debugging, remove prior to merging
-    layer(Courtyard(Bottom)) = Rectangle(typ(part-length), typ(part-width))
 
 public defn make-n-pin-soic-landpattern (num-pins:Int,
                                          pitch:Double,

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1040,78 +1040,99 @@ public pcb-landpattern smd-testpoint-pkg (d:Double) :
   layer(Silkscreen("f-silk", Top)) = Circle(d / 2.0)
   ref-label()
 
-public defn make-n-pin-soic-landpattern (num-pins:Int,
-                                         pitch:Double,
-                                         outer-length:Toleranced,
-                                         part-length:Toleranced,
-                                         part-width:Toleranced,
-                                         lead-type:LandProtrusionType,
-                                         lead-length:Toleranced,
-                                         lead-width:Toleranced,
+defstruct IpcResults:
+  Zmax:Double,
+  Gmin:Double,
+  Xmin:Double,
+
+defn pad-size (i:IpcResults) -> Dims:
+  Dims(0.5 * (Zmax(i) - Gmin(i)), Xmin(i))
+
+public defn ipc-formula (
+  L:Toleranced,
+  T:Toleranced,
+  W:Toleranced,
+  P:Double,
+  F:Double,
+  fillets:LeadFillets, 
+):
+  defn rms (s:Seqable<Double>):
+    sqrt(sum(seq(fn (x:Double): x * x, s)))
+  val [Jt, Jh, Js, _] = to-tuple(fillets)
+  val Lmax = max-value(L)
+  val Lmin = min-value(L)
+  val Wmin = min-value(W)
+  val Tmin = min-value(T)
+  val Smax = Lmax - 2.0 * Tmin
+  val C_L  = tolerance-range(L)
+  val C_W  = tolerance-range(W)
+  val C_T  = tolerance-range(T)
+  val C_S  = rms([C_L, C_T])
+  val Zmax = Lmin + 2.0 * Jt + rms([C_L, P, F])
+  val Gmin = Smax - 2.0 * Jh - rms([C_S, P, F])
+  val Xmin = Wmin + 2.0 * Js + rms([C_W, P, F])
+  IpcResults(Zmax, Gmin, Xmin)
+
+
+public defn make-n-pin-soic-landpattern (num-pins:Int,            ; number of pins of the component
+                                         pitch:Double,            ; pitch of the pins of the component
+                                         outer-x:Toleranced, ; the "outer length" (x-dimension) of the component, from lead-to-lead
+                                         part-x:Toleranced,  ; the length of the part/package (x-dimension)
+                                         part-y:Toleranced,   ; the width of the part/package (y-dimension)
+                                         lead-type:LandProtrusionType, ; the lead/land protrusion type of the part
+                                         lead-x:Toleranced, ; the length (x-dimension) of the leads
+                                         lead-y:Toleranced,  ; the width (y-dimension) of the leads
                                          fabrication-tolerance:Double,
                                          placement-tolerance:Double,
                                          density-level:DensityLevel):
   fatal("n must be even") when (num-pins % 2) != 0
+  val lead-fillets = lead-fillets(lead-type, density-level)
+
   inside pcb-landpattern:
-    val length = outer-length
-    val width  = part-width
-
-    defn rms (s:Seqable<Double>) -> Double:
-      sqrt(sum(seq(fn (x:Double): x * x, s)))
-
-    defn wiggle-room (C:Double) -> Double:
-      rms([C, fabrication-tolerance, placement-tolerance])
-    
     ;----------------------------------------------------
     ; Compute adjustments to dimensions using IPC formula
-    val [Jt, Jh, Js, courtyard-excess] = to-tuple(lead-fillets(lead-type, density-level))
-    val Lmax = max-value(length)
-    val Lmin = min-value(length)
-    val Tmin = min-value(lead-length)
-    val Wmin = min-value(lead-width)
-    val Smax = Lmax - 2.0 * Tmin
-    val Cw   = tolerance-range(width)
-    val Cl   = tolerance-range(length) 
-    val Cs   = rms([tolerance-range(lead-length), Cl])
-    val Zmax = Lmin + 2.0 * Jt + wiggle-room(Cl)
-    val Gmin = Smax - 2.0 * Jh - wiggle-room(Cs)
-    val Xmin = Wmin + 2.0 * Js + wiggle-room(Cw)
+    val ipc = ipc-formula(
+      outer-x, lead-x, lead-y, 
+      placement-tolerance, fabrication-tolerance,
+      lead-fillets
+    )
 
     ;----------------------------------------------------
     ; compute our pad sizes
-    val pad-x-dim = 0.5 * (Zmax - Gmin)
-    val pad-y-dim = Xmin
-    val pad_ = smd-pad(Rectangle(pad-x-dim, pad-y-dim))
-    
+    val pad-sz  = pad-size(ipc)
+
     ;----------------------------------------------------
     ; place the pads
-    val locs = to-tuple(grid-locs(num-pins / 2, 2, Gmin + pad-x-dim, pitch, false))
+    val grid-sz = Dims(Gmin(ipc) + x(pad-sz), pitch)
+    val locs    = to-tuple(grid-locs(num-pins / 2, 2, x(grid-sz), y(grid-sz), false))
     for (i in 0 to false, l in locs) do:
-      val name = soic-naming-convention(i % (num-pins / 2), i / (num-pins / 2), num-pins)
-      pad (name): pad_ at l
-
+      val r = i % (num-pins / 2)
+      val c = i / (num-pins / 2)
+      val idx = (i + 1) when c == 0 else num-pins - r
+      pad p[idx] : smd-pad(Rectangle(pad-sz)) at l
+    
     ;----------------------------------------------------
-    ; compute the courtyard    
-    val ys = to-tuple(seq(y{center(_)}, locs))
-    val lp-x-dim = Zmax + 2.0 * SOLDER-MASK-REGISTRATION
-    val lp-y-dim = pad-y-dim + maximum(ys) - minimum(ys) + 2.0 * SOLDER-MASK-REGISTRATION
-    val cy-x-dim = max(lp-x-dim, max-value(part-length)) + 2.0 * courtyard-excess
-    val cy-y-dim = max(lp-y-dim, max-value(part-width)) + 2.0 * courtyard-excess
-    layer(Courtyard(Top)) = Rectangle(cy-x-dim, cy-y-dim)
-
+    ; compute the courtyard
+    val [max-y, min-y] = fork-on-seq(seq(y{center(_)}, locs), maximum, minimum)
+    val lp-y-dim = y(pad-sz) + max-y - min-y
+    val lp-sz   = Dims(Zmax(ipc), y(pad-sz) + max-y - min-y) + 2.0 * SOLDER-MASK-REGISTRATION
+    val part-sz = Dims(max-value(part-x), max-value(part-y))
+    val cy-sz   = max(lp-sz, part-sz) + 2.0 * courtyard-excess(lead-fillets)
+    layer(Courtyard(Top)) = Rectangle(cy-sz)
+        
     ;----------------------------------------------------
     ; draw the orientation marker
-    val min-silk-width = clearance(current-rules(), MinSilkscreenWidth)
-    val line = Line(min-silk-width, [Point(min-silk-width * 0.5, 0.0),
-                                     Point(3.5 * min-silk-width, 0.0)])
-    val dist = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + min-silk-width * 0.5 + 0.01
-    val pol-x = -0.5 * lp-x-dim
-    val pol-y =  0.5 * lp-y-dim
-    layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * line
+    val line-width  = clearance(current-rules(), MinSilkscreenWidth)
+    val line-length = 3.0 * line-width - line-width
+    val dist  = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + line-width * 0.5 + 0.01
+    val pad-loc = center(locs[0])
+    val pol-x = -0.5 * x(pad-loc)
+    val pol-y =  0.5 * y(pad-loc) + dist
+    layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * Line(line-width, [Point(0.0, 0.0), Point(line-length, 0.0)])
       
     ;----------------------------------------------------
     ; place the reference label    
-    val text-y = 0.5 * (cy-y-dim + MIN-SILKSCREEN-TEXT-HEIGHT)
+    val text-y = 0.5 * (y(cy-sz) + MIN-SILKSCREEN-TEXT-HEIGHT)
     ref-label(0.0, text-y)
 
 public defn make-n-pin-soic-landpattern (num-pins:Int,
@@ -1120,18 +1141,19 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,
                                          length:Toleranced,
                                          width:Toleranced,
                                          lead-length:Toleranced,
-                                         lead-width:Toleranced):
+                                         lead-width:Toleranced) :
+  val lead-type = BigGullWingLeads when pitch > 0.0625 else SmallGullWingLeads
   make-n-pin-soic-landpattern(num-pins,
-                               pitch
-                               outer-length,
-                               length,
-                               width,
-                               BigGullWingLeads,
-                               lead-length,
-                               lead-width,
-                               FABRICATION-TOLERANCE,
-                               PLACEMENT-TOLERANCE,
-                               DensityLevelC)
+                              pitch
+                              outer-length,
+                              length,
+                              width,
+                              lead-type,
+                              lead-length,
+                              lead-width,
+                              FABRICATION-TOLERANCE,
+                              PLACEMENT-TOLERANCE,
+                              DensityLevelC)
 
 public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vertical) dimension of the package
                                            width:Toleranced,  ; the width (horizontal) dimension of the package
@@ -1144,72 +1166,40 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
                                            polarized?:True|False         ; whether a polarity marker is required or not
                                            ):
   inside pcb-landpattern:
-    ; helper to compute the pad refs
-    defn pad-refs () -> Tuple<Ref>:
-      if anode-and-cathode?:
-        [Ref("a"), Ref("c")]
-      else:
-        [IndexRef(Ref("p"), 1), IndexRef(Ref("p"), 2)]
-    
-    ; helper to compute the excess required by density level and tolerances
-    defn wiggle-room (C:Double):
-      val F = fabrication-tolerance
-      val P = placement-tolerance
-      sqrt(C * C + F * F + P * P)
-
     ; compute the solder fillets based on the protrusion type
     ; if > 16xx (1.6mm), use big rectangular leads
     val land-protrusion-type = BigRectangularLeads when typ(length) > 1.6 else SmallRectangularLeads
-    ; lookup 
-    val fillets = lead-fillets(land-protrusion-type, density-level)
-    val Cw = tolerance-range(width)  ; is this the most reasonable? 
-    val Cl = tolerance-range(length) 
-    val Cs = 
-      let:
-        val Ct = tolerance-range(lead-length)
-        sqrt(Ct * Ct + Cl * Cl)
-    
+    val lead-fillets = lead-fillets(land-protrusion-type, density-level)
+
     ; compute the base dimensions of the lands
-    val Lmax = max-value(length)
-    val Lmin = min-value(length)
-    val Tmin = min-value(lead-length)
-    val Wmin = match(lead-width?):
-      (lead-width:Toleranced): 
-        min-value(lead-width)
-      (_:False):
-        min-value(width)
-    
-    val Smax = Lmax - 2.0 * Tmin
-    val [Jt, Jh, Js] = [toe(fillets), heel(fillets), side(fillets)]
-    val Zmax = Lmin + 2.0 * Jt + wiggle-room(Cl)
-    val Gmin = Smax - 2.0 * Jh - wiggle-room(Cs)
-    val Xmin = Wmin + 2.0 * Js + wiggle-room(Cw)
-
-    ; finalize the geometry
-    val land-length = 0.5 * (Zmax - Gmin)
-    val land-width  = Xmin
+    val ipc = ipc-formula(
+      length, lead-length, width when lead-width? is False else lead-width? as Toleranced,
+      placement-tolerance, fabrication-tolerance,
+      lead-fillets
+    )
 
     ; ----------------------------------------------------
-    val y-max = 0.5 * Gmin + 0.5 * land-length
-    val y-min = -1.0 * y-max
+    ; place the pads
+    val pad-sz = pad-size(ipc)
+    val y-max = 0.5 * Gmin(ipc) + 0.5 * y(pad-sz)
+    val y-min = (- y-max)
 
-    val refs = pad-refs()
-    val pad_ = smd-pad(Rectangle(land-width, land-length)) ; pass in solder-mask-defined? 
-
-    pad (refs[0]): pad_ at loc(0.0, y-max)
-    pad (refs[1]): pad_ at loc(0.0, y-min)
-
-    ; ----------------------------------------------------
-    val lp-x-size  = land-width + 2.0 * SOLDER-MASK-REGISTRATION
-    val lp-y-size  = Zmax + 2.0 * SOLDER-MASK-REGISTRATION
-    val cmp-x-size = max-value(width)
-    val cmp-y-size = max-value(length)
-    val excess     = courtyard-excess(fillets)
-    val cy-x-size  = max(lp-x-size, cmp-x-size) + 2.0 * excess
-    val cy-y-size  = max(lp-y-size, cmp-y-size) + 2.0 * excess
-  
-    layer(Courtyard(Top)) = Rectangle(cy-x-size, cy-y-size)
+    val pad_ = smd-pad(Rectangle(pad-sz)) ; pass in solder-mask-defined? 
+    if anode-and-cathode?:
+      pad a: pad_ at loc(0.0, y-max)
+      pad c: pad_ at loc(0.0, y-min)
+    else:
+      pad p[1]: pad_ at loc(0.0, y-max)
+      pad p[2]: pad_ at loc(0.0, y-min)
     
+    ; ----------------------------------------------------
+    ; compute the courtyard
+    val lp-sz   = Dims(x(pad-sz), Zmax(ipc)) + 2.0 * SOLDER-MASK-REGISTRATION
+    val part-sz = Dims(max-value(width), max-value(length))
+    val cy-sz   = max(lp-sz, part-sz) + 2.0 * courtyard-excess(lead-fillets)
+    layer(Courtyard(Top)) = Rectangle(cy-sz)
+    
+    ; ----------------------------------------------------
     ; draw the polarity marker
     if polarized?:
       val min-silk-width = clearance(current-rules(), MinSilkscreenWidth)
@@ -1233,11 +1223,11 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
       val line = Line(min-silk-width, [Point(min-silk-width * 0.5, 0.0),
                                        Point(3.5 * min-silk-width, 0.0)])
       val dist = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + min-silk-width * 0.5 + 0.01
-      val pol-x = -0.5 * max(lp-x-size, cmp-x-size)
-      val pol-y =  0.5 * max(lp-y-size, cmp-y-size) + dist
+      val pol-x = -0.5 * max(x(lp-sz), x(part-sz))
+      val pol-y =  0.5 * max(y(lp-sz), y(part-sz)) + dist
       layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y) * line
       
-    val text-x = 0.5 * (cy-x-size + MIN-SILKSCREEN-TEXT-HEIGHT)
+    val text-x = 0.5 * (x(cy-sz) + MIN-SILKSCREEN-TEXT-HEIGHT)
     ref-label(loc(text-x, 0.0, -90.0),C)
 
 public defn make-two-pin-chip-landpattern (length:Toleranced,

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1052,12 +1052,10 @@ defn pad-size (i:IpcResults) -> Dims:
   Dims(0.5 * (Zmax(i) - Gmin(i)), Xmin(i))
 
 ; the IPC formula
-defn ipc-formula (
-  L:Toleranced, ; the distance from edge-of-lead to edge-of-lead on the exterior of the land pattern
-  T:Toleranced, ; the nominal size of the leads, in the same dimension as L
-  W:Toleranced, ; the nominal size of hte leads, in the dimension orthogonal to L
-  fillets:LeadFillets, ; looked up using lead-fillets(lead-type, density-level)
-):
+defn ipc-formula (L:Toleranced, ; the distance from edge-of-lead to edge-of-lead on the exterior of the land pattern
+                  T:Toleranced, ; the nominal size of the leads, in the same dimension as L
+                  W:Toleranced, ; the nominal size of the leads, in the dimension orthogonal to L
+                  fillets:LeadFillets): ; looked up using lead-fillets(lead-type, density-level)
   ; compute root-mean-squared of a sequence of numbers
   val [Jt, Jh, Js, _] = to-tuple(fillets)
   val Lmax = max-value(L)
@@ -1081,14 +1079,14 @@ defn ipc-formula (
 ; - the leads are oriented on the left and right sides of the land pattern
 ; - p[1] is the top left pin
 ;
-public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of the component
-                                         pitch:Double,       ; pitch of the pins of the component
-                                         outer-x:Toleranced, ; the "outer length" (x-dimension) of the component, from lead-to-lead
-                                         part-x:Toleranced,  ; the length of the part/package (x-dimension)
-                                         part-y:Toleranced,   ; the width of the part/package (y-dimension)
+public defn make-n-pin-soic-landpattern (num-pins:Int,                 ; number of pins of the component
+                                         pitch:Double,                 ; pitch of the pins of the component
+                                         component-length:Toleranced,  ; the overall length of the component, from terminal-edge to terminal-edge
+                                         package-length:Toleranced,    ; the length of the package 
+                                         package-width:Toleranced,     ; the width of the package
                                          lead-type:LandProtrusionType, ; the lead/land protrusion type of the part
-                                         lead-x:Toleranced, ; the length (x-dimension) of the leads
-                                         lead-y:Toleranced,  ; the width (y-dimension) of the leads
+                                         terminal-length:Toleranced,   ; the length of the terminals
+                                         terminal-width:Toleranced,    ; the width of the terminals
                                          density-level:DensityLevel):
   fatal("n must be even") when (num-pins % 2) != 0
   val lead-fillets = lead-fillets(lead-type, density-level)
@@ -1097,7 +1095,7 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of
     ;----------------------------------------------------
     ; Compute adjustments to dimensions using IPC formula
     val ipc = ipc-formula(
-      outer-x, lead-x, lead-y, 
+      component-length, terminal-length, terminal-width, 
       lead-fillets
     )
 
@@ -1120,18 +1118,18 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of
     val [max-y, min-y] = fork-on-seq(seq(y{center(_)}, locs), maximum, minimum)
     val lp-y-dim = y(pad-sz) + max-y - min-y
     val lp-sz   = enlarge(Dims(Zmax(ipc), y(pad-sz) + max-y - min-y), 2.0 * SOLDER-MASK-REGISTRATION)
-    val part-sz = Dims(max-value(part-x), max-value(part-y))
+    val part-sz = Dims(max-value(package-length), max-value(package-width))
     val cy-sz   = enlarge(max(lp-sz, part-sz), 2.0 * courtyard-excess(lead-fillets))
     layer(Courtyard(Top)) = Rectangle(cy-sz)
         
     ;----------------------------------------------------
     ; draw the orientation marker
-    val line-width  = clearance(current-rules(), MinSilkscreenWidth)
-    val line-length = 3.0 * line-width - line-width
-    val dist  = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + line-width * 0.5 + 0.01
     val pad-loc = center(locs[0])
     val pol-x = min(-0.5 * x(part-sz), x(pad-loc) - 0.5 * x(pad-sz))
     val pol-y = max( 0.5 * y(part-sz), y(pad-loc) + 0.5 * y(pad-sz))
+    val line-width  = clearance(current-rules(), MinSilkscreenWidth)
+    val line-length = 3.0 * line-width - line-width
+    val dist  = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + line-width * 0.5 + 0.01
     layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * Line(line-width, [Point(0.0, 0.0), Point(line-length, 0.0)])
     
     ;----------------------------------------------------
@@ -1141,20 +1139,20 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of
 
 public defn make-n-pin-soic-landpattern (num-pins:Int,
                                          pitch:Double,
-                                         outer-x:Toleranced,
-                                         part-x:Toleranced,
-                                         part-y:Toleranced,
-                                         lead-x:Toleranced,
-                                         lead-y:Toleranced) :
+                                         component-length:Toleranced,
+                                         package-length:Toleranced,
+                                         package-width:Toleranced,
+                                         terminal-length:Toleranced,
+                                         terminal-width:Toleranced) :
   val lead-type = BigGullWingLeads when pitch > 0.0625 else SmallGullWingLeads
   make-n-pin-soic-landpattern(num-pins,
                               pitch
-                              outer-x,
-                              part-x,
-                              part-y,
+                              component-length,
+                              package-length,
+                              package-width,
                               lead-type,
-                              lead-x,
-                              lead-y,
+                              terminal-length,
+                              terminal-width,
                               DensityLevelC)
 
 public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vertical) dimension of the package
@@ -1183,13 +1181,13 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
     val y-max = 0.5 * Gmin(ipc) + 0.5 * y(pad-sz)
     val y-min = (- y-max)
 
-    val pad_ = smd-pad(Rectangle(pad-sz)) ; pass in solder-mask-defined? 
+    val pad-def = smd-pad(Rectangle(pad-sz)) ; pass in solder-mask-defined? 
     if anode-and-cathode?:
-      pad a: pad_ at loc(0.0, y-max)
-      pad c: pad_ at loc(0.0, y-min)
+      pad a: pad-def at loc(0.0, y-max)
+      pad c: pad-def at loc(0.0, y-min)
     else:
-      pad p[1]: pad_ at loc(0.0, y-max)
-      pad p[2]: pad_ at loc(0.0, y-min)
+      pad p[1]: pad-def at loc(0.0, y-max)
+      pad p[2]: pad-def at loc(0.0, y-min)
     
     ; ----------------------------------------------------
     ; compute the courtyard

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -465,6 +465,7 @@ public defn make-generic-landpattern (pad-names:Seqable<Ref>,
 
 ; Naming for a 2-column arrangment of pins 
 public defn soic-naming-convention (row:Int, column:Int, num-pins:Int) -> Ref:
+  println("row:%_, col:%_" % [row, column])
   if (column < 0) or (column > 1): 
     fatal("soic naming convention supports a maximum of 2 columns")
   switch(column):
@@ -1040,6 +1041,101 @@ public pcb-landpattern smd-testpoint-pkg (d:Double) :
   layer(Silkscreen("f-silk", Top)) = Circle(d / 2.0)
   ref-label()
 
+public defn make-n-pin-soic-landpattern (num-pins:Int,
+                                         pitch:Double,
+                                         outer-length:Toleranced,
+                                         part-length:Toleranced,
+                                         part-width:Toleranced,
+                                         lead-type:LandProtrusionType,
+                                         lead-length:Toleranced,
+                                         lead-width:Toleranced,
+                                         fabrication-tolerance:Double,
+                                         placement-tolerance:Double,
+                                         density-level:DensityLevel):
+  fatal("n must be even") when (num-pins % 2) != 0
+  inside pcb-landpattern:
+    val length = outer-length
+    val width  = part-width
+
+    defn rms (s:Seqable<Double>) -> Double:
+      sqrt(sum(seq(fn (x:Double): x * x, s)))
+
+    defn wiggle-room (C:Double) -> Double:
+      rms([C, fabrication-tolerance, placement-tolerance])
+    
+    val [Jt, Jh, Js, courtyard-excess] = to-tuple(lead-fillets(lead-type, density-level))
+    val Lmax = max-value(length)
+    val Lmin = min-value(length)
+    val Tmin = min-value(lead-length)
+    val Wmin = min-value(lead-width)
+    val Smax = Lmax - 2.0 * Tmin
+    val Cw   = tolerance-range(width)
+    val Cl   = tolerance-range(length) 
+    val Cs   = rms([tolerance-range(lead-length), Cl])
+    val Zmax = Lmin + 2.0 * Jt + wiggle-room(Cl)
+    val Gmin = Smax - 2.0 * Jh - wiggle-room(Cs)
+    val Xmin = Wmin + 2.0 * Js + wiggle-room(Cw)
+
+    ;----------------------------------------------------
+    ; compute our pad sizes
+    val pad-x-dim = 0.5 * (Zmax - Gmin)
+    val pad-y-dim = Xmin
+    val pad_ = smd-pad(Rectangle(pad-x-dim, pad-y-dim))
+    
+    ;----------------------------------------------------
+    ; place the pads
+    val locs = to-tuple(grid-locs(num-pins / 2, 2, Gmin + pad-x-dim, pitch, false))
+    for (i in 0 to false, l in locs) do:
+      val name = soic-naming-convention(i % (num-pins / 2), i / (num-pins / 2), num-pins)
+      pad (name): pad_ at l
+
+    ;----------------------------------------------------
+    ; compute the courtyard    
+    val ys = to-tuple(seq(y{center(_)}, locs))
+    val lp-x-dim = Zmax + 2.0 * SOLDER-MASK-REGISTRATION
+    val lp-y-dim = pad-y-dim + maximum(ys) - minimum(ys) + 2.0 * SOLDER-MASK-REGISTRATION
+    val cy-x-dim = max(lp-x-dim, max-value(part-length)) + 2.0 * courtyard-excess
+    val cy-y-dim = max(lp-y-dim, max-value(part-width)) + 2.0 * courtyard-excess
+    layer(Courtyard(Top)) = Rectangle(cy-x-dim, cy-y-dim)
+
+    ;----------------------------------------------------
+    ; draw the orientation marker
+    val min-silk-width = clearance(current-rules(), MinSilkscreenWidth)
+    val line = Line(min-silk-width, [Point(min-silk-width * 0.5, 0.0),
+                                     Point(3.5 * min-silk-width, 0.0)])
+    val dist = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + min-silk-width * 0.5 + 0.01
+    val pol-x = -0.5 * lp-x-dim
+    val pol-y =  0.5 * lp-y-dim
+    layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * line
+      
+    ;----------------------------------------------------
+    ; place the reference label    
+    val text-y = 0.5 * (cy-y-dim + MIN-SILKSCREEN-TEXT-HEIGHT)
+    ref-label(0.0, text-y)
+
+    ;----------------------------------------------------
+    ; debugging, remove prior to merging
+    layer(Courtyard(Bottom)) = Rectangle(typ(part-length), typ(part-width))
+
+public defn make-n-pin-soic-landpattern (num-pins:Int,
+                                         pitch:Double,
+                                         outer-length:Toleranced,
+                                         length:Toleranced,
+                                         width:Toleranced,
+                                         lead-length:Toleranced,
+                                         lead-width:Toleranced):
+  make-n-pin-soic-landpattern(num-pins,
+                               pitch
+                               outer-length,
+                               length,
+                               width,
+                               BigGullWingLeads,
+                               lead-length,
+                               lead-width,
+                               FABRICATION-TOLERANCE,
+                               PLACEMENT-TOLERANCE,
+                               DensityLevelC)
+
 public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vertical) dimension of the package
                                            width:Toleranced,  ; the width (horizontal) dimension of the package
                                            lead-length:Toleranced, ; the length (vertical) dimension of the conductors/leads of the package
@@ -1106,6 +1202,7 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
     pad (refs[0]): pad_ at loc(0.0, y-max)
     pad (refs[1]): pad_ at loc(0.0, y-min)
 
+    ; ----------------------------------------------------
     val lp-x-size  = land-width + 2.0 * SOLDER-MASK-REGISTRATION
     val lp-y-size  = Zmax + 2.0 * SOLDER-MASK-REGISTRATION
     val cmp-x-size = max-value(width)

--- a/utils/land-protrusions.stanza
+++ b/utils/land-protrusions.stanza
@@ -49,6 +49,9 @@ public pcb-struct ocdb/land-patterns/packages/LeadFillets:
   side:Double ; space on the edges of the lead
   courtyard-excess:Double ; additional area to add to the courtyard 
 
+public defn to-tuple (l:LeadFillets) -> [Double, Double, Double, Double]:
+  [toe(l), heel(l), side(l), courtyard-excess(l)]
+
 ; Compute the LeadFillets of a lead type
 public defn lead-fillets (lead-type:LandProtrusionType) -> LeadFillets:
   lead-fillets(lead-type, DensityLevelA)

--- a/utils/tolerance.stanza
+++ b/utils/tolerance.stanza
@@ -65,3 +65,11 @@ public defn in-range? (t:Toleranced, value:Double) -> True|False:
  ; Returns the difference between max and min of the toleranced values
 public defn tolerance-range (t:Toleranced) -> Double:
   max-value(t) - min-value(t)
+
+public defn plus (l:Toleranced, r:Toleranced) -> Toleranced:
+  defn rms (s:Seqable<Double>):
+    sqrt(sum(seq(fn (x:Double): x * x, s)))
+
+  val tol+ = rms([tol+(l), tol+(r)])
+  val tol- = rms([tol-(l), tol-(r)])
+  Toleranced(typ(l) + typ(r), tol+, tol-)

--- a/utils/tolerance.stanza
+++ b/utils/tolerance.stanza
@@ -65,11 +65,3 @@ public defn in-range? (t:Toleranced, value:Double) -> True|False:
  ; Returns the difference between max and min of the toleranced values
 public defn tolerance-range (t:Toleranced) -> Double:
   max-value(t) - min-value(t)
-
-public defn plus (l:Toleranced, r:Toleranced) -> Toleranced:
-  defn rms (s:Seqable<Double>):
-    sqrt(sum(seq(fn (x:Double): x * x, s)))
-
-  val tol+ = rms([tol+(l), tol+(r)])
-  val tol- = rms([tol-(l), tol-(r)])
-  Toleranced(typ(l) + typ(r), tol+, tol-)


### PR DESCRIPTION
New APIs:

```
public defn make-n-pin-soic-landpattern (num-pins:Int,       ; number of pins of the component
                                         pitch:Double,       ; pitch of the pins of the component
                                         outer-x:Toleranced, ; the "outer length" (x-dimension) of the component, from lead-to-lead
                                         part-x:Toleranced,  ; the length of the part/package (x-dimension)
                                         part-y:Toleranced,   ; the width of the part/package (y-dimension)
                                         lead-type:LandProtrusionType, ; the lead/land protrusion type of the part
                                         lead-x:Toleranced, ; the length (x-dimension) of the leads
                                         lead-y:Toleranced,  ; the width (y-dimension) of the leads
                                         fabrication-tolerance:Double,
                                         placement-tolerance:Double,
                                         density-level:DensityLevel):
 
public defn make-n-pin-soic-landpattern (num-pins:Int,
                                         pitch:Double,
                                         outer-x:Toleranced,
                                         part-x:Toleranced,
                                         part-y:Toleranced,
                                         lead-x:Toleranced,
                                         lead-y:Toleranced) :
```

Usage:

```
pcb-component SOIC-CMP:
  pcb-landpattern SO8N:
    make-n-pin-soic-landpattern(8,    ; num-pins
                                1.27, ; pin-pitch
                                tol(6.0, 0.2), ;outer-length
                                tol(3.9, 0.1), ;part-length
                                tol(4.9, 0.1), ;part-width
                                min-typ-max(0.4, 1.04, 1.27),  ; lead-width
                                min-typ-max(0.28, 0.38, 0.48)) ; lead-length 
  port p: pin[[1 2]]
  val lp = SO8N
  landpattern = lp(p[1] => lp.p[1], p[2] => lp.p[2])
  make-box-symbol()
```

Output:

![Screenshot from 2021-07-27 13-36-24](https://user-images.githubusercontent.com/28515218/127561422-a4cbaeb6-633c-42fd-840c-c5bf63d816f8.png)

