### PR TITLE
IPC Compliant Quad Landpatterns

### DIFF
--- a/tests/test-land-patterns.stanza
+++ b/tests/test-land-patterns.stanza
@@ -122,4 +122,4 @@ pcb-module main-module:
 
 set-rules(sierra-adv-rules)
 make-default-board(main-module, 2, Rectangle(12.0, 12.0))
-view(QFP)
+view-board()

--- a/tests/test-land-patterns.stanza
+++ b/tests/test-land-patterns.stanza
@@ -31,12 +31,12 @@ pcb-component QFP:
 
 pcb-component QFN:
   pcb-landpattern MLPQ-UT8:
-    make-qfn-landpattern([1, 1, 3, 3],    ; number of pins on each side (Up, Down, Left, Right)
+    make-qfn-landpattern([3, 1, 3, 1],    ; number of pins on each side (Up, Down, Left, Right)
                          0.4,             ; pitch
                          tol(1.5, 0.0),   ; package dimensions 
                          tol(0.35, 0.05), ; lead size, x direction (for p[1])
                          tol(0.20, 0.05)) ; lead size, y direction (for p[1])
-    
+
   port p: pin[1 through 8]
   landpattern = MLPQ-UT8(
     for n in 1 through 8 do:
@@ -122,4 +122,4 @@ pcb-module main-module:
 
 set-rules(sierra-adv-rules)
 make-default-board(main-module, 2, Rectangle(12.0, 12.0))
-view-board()
+view(QFP)

--- a/tests/test-land-patterns.stanza
+++ b/tests/test-land-patterns.stanza
@@ -12,6 +12,53 @@ defpackage ocdb/test/land-patterns:
   import ocdb/rules
   import ocdb/generic-components
   import ocdb/symbols
+  import ocdb/land-protrusions
+
+pcb-component QFP:
+  pcb-landpattern LQFP48:
+    make-quad-landpattern(
+      24, 24   ; pins on north/south and east/west faces
+      0.5, 0.5 ; pitch on north/south and east/west faces
+      min-typ-max(8.8, 9.0, 9.2), min-typ-max(8.8, 9.0, 9.2) ; outer-x, outer-y ("D" and "E")
+      min-typ-max(6.8, 7.0, 7.2), min-typ-max(6.8, 7.0, 7.2) ; part-x, part-y (D1, E1)
+      min-typ-max(0.45, 0.6, 0.75), min-typ-max(0.17, 0.22, 0.27) ; lead-x, lead-y (L, b)
+      SmallGullWingLeads
+    )
+  port p : pin[[1]]
+  val lp = LQFP48
+  landpattern = 
+    lp(p[1] => lp.p[1])
+  make-box-symbol()
+
+pcb-component QFN:
+  pcb-landpattern MLPQ-UT8:
+    make-quad-landpattern(
+      2,  ; pins on north/south faces
+      6,  ; pins on east/west faces
+      0.4 ; pitch on north-south faces
+      0.4 ; pitch on east-west faces
+      tol(1.5, 0.0) ; outer-x
+      tol(1.5, 0.0) ; outer-y
+      tol(1.5, 0.0) ; part-x
+      tol(1.5, 0.0) ; part-y
+      min-typ-max(0.30, 0.35, 0.40) ; lead-dim-1
+      min-typ-max(0.15, 0.20, 0.25) ; lead-dim-2
+      QuadFlatNoLeads
+    )
+  val lp = MLPQ-UT8
+  port p: pin[[1 through 8]]
+  landpattern = 
+    lp(
+      p[1] => lp.p[1]
+      p[2] => lp.p[2]
+      p[3] => lp.p[3]
+      p[4] => lp.p[4]
+      p[5] => lp.p[5]
+      p[6] => lp.p[6]
+      p[7] => lp.p[7]
+      p[8] => lp.p[8]
+    )
+  make-box-symbol()
 
 pcb-component SOIC-CMP:
   pcb-landpattern SO8N:
@@ -81,10 +128,14 @@ pcb-module main-module:
   inst e1: example-1
   inst e2: SOIC-CMP
   inst e3: example-2
+  inst e4: QFN
+  inst e5: QFP
   place(e1) on Top
   place(e2) on Top
   place(e3) on Top 
+  place(e4) on Top
+
 set-rules(sierra-adv-rules)
 make-default-board(main-module, 2, Rectangle(12.0, 12.0))
 ; view-board()
-view(SOIC-CMP)
+view(QFP)

--- a/tests/test-land-patterns.stanza
+++ b/tests/test-land-patterns.stanza
@@ -24,10 +24,12 @@ pcb-component QFP:
       min-typ-max(0.45, 0.6, 0.75), min-typ-max(0.17, 0.22, 0.27) ; lead-x, lead-y (L, b)
       SmallGullWingLeads
     )
-  port p : pin[[1]]
+  port p: pin[1 through 48]
   val lp = LQFP48
-  landpattern = 
-    lp(p[1] => lp.p[1])
+  landpattern = lp(
+    for n in 1 through 48 do:
+      p[n] => lp.p[n]
+  )
   make-box-symbol()
 
 pcb-component QFN:

--- a/tests/test-land-patterns.stanza
+++ b/tests/test-land-patterns.stanza
@@ -16,50 +16,32 @@ defpackage ocdb/test/land-patterns:
 
 pcb-component QFP:
   pcb-landpattern LQFP48:
-    make-quad-landpattern(
-      24, 24   ; pins on north/south and east/west faces
-      0.5, 0.5 ; pitch on north/south and east/west faces
-      min-typ-max(8.8, 9.0, 9.2), min-typ-max(8.8, 9.0, 9.2) ; outer-x, outer-y ("D" and "E")
-      min-typ-max(6.8, 7.0, 7.2), min-typ-max(6.8, 7.0, 7.2) ; part-x, part-y (D1, E1)
-      min-typ-max(0.45, 0.6, 0.75), min-typ-max(0.17, 0.22, 0.27) ; lead-x, lead-y (L, b)
-      SmallGullWingLeads
-    )
+    make-qfp-landpattern(48,   ; number of pins 
+                         0.5,  ; pitch ("e")
+                         tol(9.0, 0.2),   ; outer size (lead-to-lead), "D" and "E"
+                         tol(7.0, 0.2),   ; package size, "D1" and "E1"
+                         tol(0.6, 0.15),  ; lead size, x direction (for p[1]), "L"
+                         tol(0.22, 0.05)) ; lead size, y direction (for p[1]), "b"
   port p: pin[1 through 48]
-  val lp = LQFP48
-  landpattern = lp(
+  landpattern = LQFP48(
     for n in 1 through 48 do:
-      p[n] => lp.p[n]
+      p[n] => LQFP48.p[n]
   )
   make-box-symbol()
 
 pcb-component QFN:
   pcb-landpattern MLPQ-UT8:
-    make-quad-landpattern(
-      2,  ; pins on north/south faces
-      6,  ; pins on east/west faces
-      0.4 ; pitch on north-south faces
-      0.4 ; pitch on east-west faces
-      tol(1.5, 0.0) ; outer-x
-      tol(1.5, 0.0) ; outer-y
-      tol(1.5, 0.0) ; part-x
-      tol(1.5, 0.0) ; part-y
-      min-typ-max(0.30, 0.35, 0.40) ; lead-dim-1
-      min-typ-max(0.15, 0.20, 0.25) ; lead-dim-2
-      QuadFlatNoLeads
-    )
-  val lp = MLPQ-UT8
-  port p: pin[[1 through 8]]
-  landpattern = 
-    lp(
-      p[1] => lp.p[1]
-      p[2] => lp.p[2]
-      p[3] => lp.p[3]
-      p[4] => lp.p[4]
-      p[5] => lp.p[5]
-      p[6] => lp.p[6]
-      p[7] => lp.p[7]
-      p[8] => lp.p[8]
-    )
+    make-qfn-landpattern([1, 1, 3, 3],    ; number of pins on each side (Up, Down, Left, Right)
+                         0.4,             ; pitch
+                         tol(1.5, 0.0),   ; package dimensions 
+                         tol(0.35, 0.05), ; lead size, x direction (for p[1])
+                         tol(0.20, 0.05)) ; lead size, y direction (for p[1])
+    
+  port p: pin[1 through 8]
+  landpattern = MLPQ-UT8(
+    for n in 1 through 8 do:
+      p[n] => MLPQ-UT8.p[n]
+  )
   make-box-symbol()
 
 pcb-component SOIC-CMP:
@@ -136,8 +118,8 @@ pcb-module main-module:
   place(e2) on Top
   place(e3) on Top 
   place(e4) on Top
+  place(e5) on Top
 
 set-rules(sierra-adv-rules)
 make-default-board(main-module, 2, Rectangle(12.0, 12.0))
-; view-board()
-view(QFP)
+view-board()

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -28,6 +28,7 @@ public var MIN-COPPER-FEATURE: Double  = 0.127
 public var MIN-SPACING: Double  = 0.127
 public var PREFER-SOLDERMASK-DEFINED: True|False = false
 public var SILK-SOLDER-MASK-CLEARANCE: Double = 0.15
+public var DENSITY-LEVEL: DensityLevel = DensityLevelC
 
 ; For consolidation
 ;public var PREFERRED-MANUFACTURERS = ["Yageo", "Panasonic Electronic Components", "Vishay Dale", "TE Connectivity Passive Product"]

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1071,7 +1071,149 @@ defn ipc-formula (L:Toleranced, ; the distance from edge-of-lead to edge-of-lead
   val Gmin = Smax - 2.0 * Jh - C_S ; the distance from edge of land to edge of land on the interior of the land pattern
   val Xmin = Wmin + 2.0 * Js + C_W ; the size of the land in the dimension orthogonal to Z and G.
   IpcResults(Zmax, Gmin, Xmin)
-   
+
+; A helper struct to compute the indices of a quad landpattern
+defstruct QuadIdx:
+  east:  Tuple<Int> ; the pin indices on the east face of the land pattern
+  south: Tuple<Int> ; the pin indices on the south face of hte land pattern
+  west:  Tuple<Int> ; the pin indiices on the west face of the land pattern
+  north: Tuple<Int> ; the pin inidices on the north face of the land pattern
+
+; printer for debugging QuadIdx
+defmethod print (o:OutputStream, q:QuadIdx):
+  print(o, "QuadIdx:")
+  val os = IndentedStream(o)
+  lnprint(os, "North:%_" % [north(q)])
+  lnprint(os, "South:%_" % [south(q)])
+  lnprint(os, "East:%_" %  [east(q)])
+  lnprint(os, "West:%_" %  [west(q)])
+
+; Compute the indices of a landpattern on each face
+defn QuadIdx (num-pins-ns:Int, num-pins-ew:Int):
+  val idx-e = to-tuple $ 1 through num-pins-ew / 2
+  val idx-s = to-tuple $ (maximum(idx-e) + 1) through (maximum(idx-e) + 1 + num-pins-ns / 2 - 1)
+  val idx-w = to-tuple $ reverse $ (maximum(idx-s) + 1) through (maximum(idx-s) + 1 + num-pins-ew / 2 - 1)
+  val idx-n = to-tuple $ reverse $ (maximum(idx-w) + 1) through (maximum(idx-w) + 1 + num-pins-ns / 2 - 1)
+  QuadIdx(idx-e, idx-s, idx-w, idx-n)
+
+; Get the north/south indices, in one tuple
+defn north-south (q:QuadIdx):
+  to-tuple(cat-all([north(q), south(q)]))
+
+; Get the east/west indicies, in one tuple
+defn east-west (q:QuadIdx):
+  to-tuple(cat-all([east(q), west(q)]))
+
+public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on the north/south faces
+                                   num-pins-ew: Int,    ; the number of pins on the east/west faces
+                                   pitch-ns: Double,    ; the pitch of pins on the north/south faces
+                                   pitch-ew: Double,    ; the pitch of pins on the east/west faces
+                                   outer-x: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
+                                   outer-y: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
+                                   part-x: Toleranced,  ; the size of the package in the x direction
+                                   part-y: Toleranced,  ; the size of hte package in the y direction
+                                   lead-dim-1: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
+                                   lead-dim-2: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
+                                   lead-type:  LandProtrusionType, ; the type of the leads
+                                   density-level: DensityLevel):   ; the density level of the design
+  ensure-even-positive!(num-pins-ns, "make-qfn-land-pattern")
+  ensure-even-positive!(num-pins-ew, "make-qfn-land-pattern")
+  val lead-fillets = lead-fillets(lead-type, density-level)
+  inside pcb-landpattern:
+    ;----------------------------------------------------------
+    ; compute dimensions
+    ; layer(Courtyard(Bottom)) = Rectangle(typ(part-x), typ(part-y))
+    val ipc-ns = ipc-formula(outer-x, lead-dim-1, lead-dim-2, 0.0, 0.0, lead-fillets)
+    val ipc-ew = ipc-formula(outer-y, lead-dim-1, lead-dim-2, 0.0, 0.0, lead-fillets)
+    val pad-sz-ns = transpose(pad-size(ipc-ns))
+    val pad-sz-ew = pad-size(ipc-ew)
+
+    ;----------------------------------------------------------
+    ; compute pad locations
+    val grid-sz-ns = Dims(pitch-ns, Gmin(ipc-ew) + y(pad-sz-ns))
+    val grid-sz-ew = Dims(Gmin(ipc-ew) + x(pad-sz-ew), pitch-ew)
+
+    val locs-ns = to-tuple $ grid-locs(2, num-pins-ns / 2, x(grid-sz-ns), y(grid-sz-ns), true)
+    val locs-ew = to-tuple $ grid-locs(num-pins-ew / 2, 2, x(grid-sz-ew), y(grid-sz-ew), false)
+    val idx = QuadIdx(num-pins-ns, num-pins-ew)
+    
+    ; layer(Courtyard(Top)) = Rectangle(Zmax(ipc-ew),Zmax(ipc-ns))
+    ; layer(Courtyard(Top)) = Rectangle(Gmin(ipc-ew),Gmin(ipc-ns))
+    ; layer(Courtyard(Bottom)) = locs-ew[0] * Rectangle(max-value(lead-dim-1), max-value(lead-dim-2))
+    
+    for (idx in north-south(idx), loc in locs-ns) do : 
+      pad p[idx]: smd-pad(Rectangle(pad-sz-ns)) at loc
+    
+    for (idx in east-west(idx), loc in locs-ew) do : 
+      pad p[idx]: smd-pad(Rectangle(pad-sz-ew)) at loc
+
+    ;----------------------------------------------------------
+    ; Compute the courtyard
+    val part-sz = Dims(max-value(part-x), max-value(part-y))
+    val lp-sz   = enlarge(Dims(Zmax(ipc-ew), Zmax(ipc-ns)), 2.0 * SOLDER-MASK-REGISTRATION)
+    val cy-sz   = enlarge(max(part-sz, lp-sz), courtyard-excess(lead-fillets))
+    layer(Courtyard(Top)) = Rectangle(cy-sz)
+  
+    ;----------------------------------------------------------
+    ; Place the polarity marker
+    val line-width  = clearance(current-rules(), MinSilkscreenWidth)
+    val line-length = 3.0 * line-width - line-width
+    val dist  = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + line-width * 0.5 + 0.01
+    val pad-loc = center(locs-ew[0])
+    val pol-x = min(-0.5 * x(part-sz), x(pad-loc) - 0.5 * x(pad-sz-ew))
+    val pol-y = max( 0.5 * y(part-sz), y(pad-loc) + 0.5 * y(pad-sz-ew))
+    layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * Line(line-width, [Point(0.0, 0.0), Point(line-length, 0.0)])
+
+    ;----------------------------------------------------------
+    ; Place the reference label
+    val text-y = 0.5 * (y(cy-sz) + MIN-SILKSCREEN-TEXT-HEIGHT)
+    ref-label(0.0, text-y)
+
+    
+public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on the north/south faces
+                                   num-pins-ew: Int,    ; the number of pins on the east/west faces
+                                   pitch-ns: Double,    ; the pitch of pins on the north/south faces
+                                   pitch-ew: Double,    ; the pitch of pins on the east/west faces
+                                   outer-x: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
+                                   outer-y: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
+                                   part-x: Toleranced,  ; the size of the package in the x direction
+                                   part-y: Toleranced,  ; the size of hte package in the y direction
+                                   lead-dim-1: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
+                                   lead-dim-2: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
+                                   lead-type: LandProtrusionType
+                                  ):
+  make-quad-landpattern(
+    num-pins-ns, num-pins-ew, 
+    pitch-ns, pitch-ew,
+    outer-x, outer-y,
+    part-x, part-y
+    lead-dim-1, lead-dim-2,
+    lead-type,
+    DensityLevelC
+  )
+
+public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on the north/south faces
+                                   num-pins-ew: Int,    ; the number of pins on the east/west faces
+                                   pitch-ns: Double,    ; the pitch of pins on the north/south faces
+                                   pitch-ew: Double,    ; the pitch of pins on the east/west faces
+                                   outer-x: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
+                                   outer-y: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
+                                   part-x: Toleranced,  ; the size of the package in the x direction
+                                   part-y: Toleranced,  ; the size of hte package in the y direction
+                                   lead-dim-1: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
+                                   lead-dim-2: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
+                                  ):
+  val lead-type = BigGullWingLeads when min(pitch-ns, pitch-ew) > 0.0625 else SmallGullWingLeads
+  make-quad-landpattern(
+    num-pins-ns, num-pins-ew, 
+    pitch-ns, pitch-ew,
+    outer-x, outer-y,
+    part-x, part-y
+    lead-dim-1, lead-dim-2,
+    lead-type,
+    DensityLevelC
+  )
+
 ; Create an `n` pin SOIC land pattern. 
 ;
 ; Restrictions:

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -212,6 +212,10 @@ public pcb-pad smd-pad (s:Shape):
 public defn smd-pad (anchor:Anchor, width:Double, height:Double):
   smd-pad(Rectangle(anchor, width, height))
 
+; Create a rectangular SMD pad 
+public defn smd-pad (d:Dims):
+  smd-pad(Rectangle(d))
+
 ; Create an SMD pad with a given width and height
 public defn smd-pad (width:Double, height:Double) :
   smd-pad(C, width, height)
@@ -733,6 +737,7 @@ public pcb-landpattern sop65-landpattern (n:Int) :
   make-sop65-landpattern(n, 6.4)
 
 public defn make-qfn-landpattern (pin-pitch:Double, lead-span:Double, n-pins:Int, pad-width:Double, pad-length:Double, corner-pads:[Pad,Pad]|False) :
+  println("called make-qfn-landpattern")
   inside pcb-landpattern :
     var n = -1
     if n-pins % 4 == 0 :
@@ -1047,6 +1052,9 @@ defstruct IpcResults:
   Gmin:Double,
   Xmin:Double,
 
+defmethod print (o:OutputStream, i:IpcResults):
+  print(o, "IpcResults(Zmax:%_, Gmin:%_, Xmin:%_" % [Zmax(i), Gmin(i), Xmin(i)])
+
 ; Helper to compute the pad size from the formula results
 defn pad-size (i:IpcResults) -> Dims:
   Dims(0.5 * (Zmax(i) - Gmin(i)), Xmin(i))
@@ -1104,10 +1112,14 @@ defn north-south (q:QuadIdx):
 defn east-west (q:QuadIdx):
   to-tuple(cat-all([east(q), west(q)]))
 
-public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on the north/south faces
-                                   num-pins-ew: Int,    ; the number of pins on the east/west faces
-                                   pitch-ns: Double,    ; the pitch of pins on the north/south faces
-                                   pitch-ew: Double,    ; the pitch of pins on the east/west faces
+public defn make-quad-landpattern (num-pins-north: Int, ; the number of pins on the north face
+                                   num-pins-south: Int, ; the number of pins on the south face
+                                   num-pins-east: Int,  ; the number of pins on the east face
+                                   num-pins-west: Int,  ; the number of pins on the west face
+                                   pitch-north:Double,  ; the pitch on the north face
+                                   pitch-south:Double,  ; the pitch on the south face
+                                   pitch-east:Double,   ; the pitch on the east face
+                                   pitch-west:Double,   ; the pithc on the west face
                                    outer-x: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
                                    outer-y: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
                                    part-x: Toleranced,  ; the size of the package in the x direction
@@ -1116,10 +1128,11 @@ public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on 
                                    lead-dim-2: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
                                    lead-type:  LandProtrusionType, ; the type of the leads
                                    density-level: DensityLevel):   ; the density level of the design
-  ensure-even-positive!(num-pins-ns, "make-qfn-land-pattern")
-  ensure-even-positive!(num-pins-ew, "make-qfn-land-pattern")
   val lead-fillets = lead-fillets(lead-type, density-level)
   inside pcb-landpattern:
+    layer(Courtyard(Bottom)) = Rectangle(max-value(part-x), max-value(part-y))
+    layer(Courtyard(Bottom)) = Rectangle(max-value(outer-x), max-value(outer-y))
+    
     ;----------------------------------------------------------
     ; compute dimensions
     ; layer(Courtyard(Bottom)) = Rectangle(typ(part-x), typ(part-y))
@@ -1127,26 +1140,53 @@ public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on 
     val ipc-ew = ipc-formula(outer-y, lead-dim-1, lead-dim-2, 0.0, 0.0, lead-fillets)
     val pad-sz-ns = transpose(pad-size(ipc-ns))
     val pad-sz-ew = pad-size(ipc-ew)
+    ; layer(Courtyard(Top)) = Rectangle(Zmax(ipc-ew), Zmax(ipc-ns))
+    ; layer(Courtyard(Top)) = Rectangle(Gmin(ipc-ew), Gmin(ipc-ns))
 
     ;----------------------------------------------------------
     ; compute pad locations
-    val grid-sz-ns = Dims(pitch-ns, Gmin(ipc-ew) + y(pad-sz-ns))
-    val grid-sz-ew = Dims(Gmin(ipc-ew) + x(pad-sz-ew), pitch-ew)
+    var acc = 0
 
-    val locs-ns = to-tuple $ grid-locs(2, num-pins-ns / 2, x(grid-sz-ns), y(grid-sz-ns), true)
-    val locs-ew = to-tuple $ grid-locs(num-pins-ew / 2, 2, x(grid-sz-ew), y(grid-sz-ew), false)
-    val idx = QuadIdx(num-pins-ns, num-pins-ew)
+    val x-shift = 0.5 * (Zmax(ipc-ew) - x(pad-sz-ew))
+    val y-shift = 0.5 * (Zmax(ipc-ns) - y(pad-sz-ns))
+    val x-shift-nom = 0.5 * max-value(outer-x) - 0.5 * max-value(lead-dim-1)
+    val y-shift-nom = 0.5 * max-value(outer-y) - 0.5 * max-value(lead-dim-1)
     
-    ; layer(Courtyard(Top)) = Rectangle(Zmax(ipc-ew),Zmax(ipc-ns))
-    ; layer(Courtyard(Top)) = Rectangle(Gmin(ipc-ew),Gmin(ipc-ns))
-    ; layer(Courtyard(Bottom)) = locs-ew[0] * Rectangle(max-value(lead-dim-1), max-value(lead-dim-2))
-    
-    for (idx in north-south(idx), loc in locs-ns) do : 
-      pad p[idx]: smd-pad(Rectangle(pad-sz-ns)) at loc
-    
-    for (idx in east-west(idx), loc in locs-ew) do : 
-      pad p[idx]: smd-pad(Rectangle(pad-sz-ew)) at loc
+    val pad-1-loc = to-tuple(grid-locs(num-pins-east, 2, 2.0 * x-shift, pitch-east))[0]
+    defn layout-pads (dir:Dir, n:Int, p:Double):
+      val nominal-locs = switch(dir):
+        Up: reverse $ to-list $ shift-locs(0.0, y-shift-nom, row-locs(n, p))
+        Down: shift-locs(0.0, (- y-shift-nom), row-locs(n, p))
+        Left: shift-locs((- x-shift-nom), 0.0, col-locs(n, p))
+        Right: reverse $ to-list $ shift-locs(x-shift-nom, 0.0, col-locs(n, p))
+      for loc in nominal-locs do:
+        layer(Courtyard(Bottom)) = 
+          if (dir == Up) or (dir == Down):
+            loc * Rectangle(max-value(lead-dim-2), max-value(lead-dim-1))
+          else:
+            loc * Rectangle(max-value(lead-dim-1), max-value(lead-dim-2))
+      
+      val locs = switch(dir):
+        Up: reverse(to-list $ shift-locs(0.0, y-shift, row-locs(n, p)))
+        Down: shift-locs(0.0, (- y-shift), row-locs(n, p))
+        Left: shift-locs((- x-shift), 0.0, col-locs(n, p))
+        Right: reverse(to-list $ shift-locs(x-shift, 0.0, col-locs(n, p)))
+      val def = switch(dir):
+        Up: smd-pad(pad-sz-ns)
+        Down: smd-pad(pad-sz-ns)
+        Left: smd-pad(pad-sz-ew)
+        Right: smd-pad(pad-sz-ew)
+        
+      val idx = acc to (acc + n)
+      acc = acc + n
+      for (i in idx, loc in locs) do:
+        pad p[i + 1]: def at loc
 
+    layout-pads(Left, num-pins-east,  pitch-east)
+    layout-pads(Down, num-pins-south, pitch-south)
+    layout-pads(Right,num-pins-west,  pitch-west)
+    layout-pads(Up,   num-pins-north, pitch-north)
+    
     ;----------------------------------------------------------
     ; Compute the courtyard
     val part-sz = Dims(max-value(part-x), max-value(part-y))
@@ -1159,7 +1199,7 @@ public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on 
     val line-width  = clearance(current-rules(), MinSilkscreenWidth)
     val line-length = 3.0 * line-width - line-width
     val dist  = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + line-width * 0.5 + 0.01
-    val pad-loc = center(locs-ew[0])
+    val pad-loc = center(pad-1-loc)
     val pol-x = min(-0.5 * x(part-sz), x(pad-loc) - 0.5 * x(pad-sz-ew))
     val pol-y = max( 0.5 * y(part-sz), y(pad-loc) + 0.5 * y(pad-sz-ew))
     layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * Line(line-width, [Point(0.0, 0.0), Point(line-length, 0.0)])
@@ -1169,50 +1209,36 @@ public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on 
     val text-y = 0.5 * (y(cy-sz) + MIN-SILKSCREEN-TEXT-HEIGHT)
     ref-label(0.0, text-y)
 
-    
-public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on the north/south faces
-                                   num-pins-ew: Int,    ; the number of pins on the east/west faces
-                                   pitch-ns: Double,    ; the pitch of pins on the north/south faces
-                                   pitch-ew: Double,    ; the pitch of pins on the east/west faces
-                                   outer-x: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
-                                   outer-y: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
-                                   part-x: Toleranced,  ; the size of the package in the x direction
-                                   part-y: Toleranced,  ; the size of hte package in the y direction
-                                   lead-dim-1: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
-                                   lead-dim-2: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
-                                   lead-type: LandProtrusionType
-                                  ):
-  make-quad-landpattern(
-    num-pins-ns, num-pins-ew, 
-    pitch-ns, pitch-ew,
-    outer-x, outer-y,
-    part-x, part-y
-    lead-dim-1, lead-dim-2,
-    lead-type,
-    DensityLevelC
-  )
+public defn make-quad-landpattern (num-pins:Int, pitch:Double, outer-xy:Toleranced, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced, lead-type:LandProtrusionType):
+  fatal("make-quad-landpattern(...) failed: num-pins must be divisible by 4. Called with: %_." % [num-pins]) when (num-pins % 4 != 0) or (num-pins <= 0)
+  fatal("make-quad-landpattern(...) failed: pitch must be greater than 0. Called with: %_." % [pitch]) when pitch <= 0.0
+  make-quad-landpattern(num-pins / 4, num-pins / 4, num-pins / 4, num-pins / 4, 
+                        pitch, pitch, pitch, pitch, 
+                        outer-xy, outer-xy, 
+                        package-xy, package-xy, 
+                        lead-x, lead-y, lead-type, DensityLevelC)
 
-public defn make-quad-landpattern (num-pins-ns: Int,    ; the number of pins on the north/south faces
-                                   num-pins-ew: Int,    ; the number of pins on the east/west faces
-                                   pitch-ns: Double,    ; the pitch of pins on the north/south faces
-                                   pitch-ew: Double,    ; the pitch of pins on the east/west faces
-                                   outer-x: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
-                                   outer-y: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
-                                   part-x: Toleranced,  ; the size of the package in the x direction
-                                   part-y: Toleranced,  ; the size of hte package in the y direction
-                                   lead-dim-1: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
-                                   lead-dim-2: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
-                                  ):
-  val lead-type = BigGullWingLeads when min(pitch-ns, pitch-ew) > 0.0625 else SmallGullWingLeads
-  make-quad-landpattern(
-    num-pins-ns, num-pins-ew, 
-    pitch-ns, pitch-ew,
-    outer-x, outer-y,
-    part-x, part-y
-    lead-dim-1, lead-dim-2,
-    lead-type,
-    DensityLevelC
-  )
+public defn make-qfn-landpattern (num-pins:Int, pitch:Double, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced):
+  make-quad-landpattern(num-pins,
+                        pitch,
+                        package-xy,
+                        package-xy, 
+                        lead-x, lead-y, QuadFlatNoLeads)
+
+public defn make-qfn-landpattern (num-pins:[Int, Int, Int, Int], pitch:Double, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced):
+  make-quad-landpattern(num-pins[0], num-pins[1], num-pins[2], num-pins[3], 
+                        pitch, pitch, pitch, pitch,
+                        package-xy, package-xy,
+                        package-xy, package-xy,
+                        lead-x, lead-y, QuadFlatNoLeads, DensityLevelC)
+
+public defn make-qfp-landpattern (num-pins:Int, pitch:Double, outer-xy:Toleranced, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced):
+  val lead-type = BigGullWingLeads when pitch >= 0.0625 else SmallGullWingLeads
+  make-quad-landpattern(num-pins, 
+                        pitch,
+                        outer-xy, 
+                        package-xy, 
+                        lead-x, lead-y, lead-type)
 
 ; Create an `n` pin SOIC land pattern. 
 ;

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1328,7 +1328,7 @@ public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vert
                                            width:Toleranced,  ; the width (horizontal) dimension of the package
                                            lead-length:Toleranced, ; the length (vertical) dimension of the conductors/leads of the package
                                            lead-width?:False|Toleranced, ; the width (horizontal) dimension of the conductors/leads of the package, if different from `length`
-                                           density-level:DensityLevel,   ; the density level of the design (DensityLevelA|DensityLevelB|DENSITY-LEVEL)
+                                           density-level:DensityLevel,   ; the density level of the design (DensityLevelA|DensityLevelB|DensityLevelC)
                                            anode-and-cathode?:True|False,; whether the pads should be named `a` and `c` (if false, p[1] and p[2])
                                            polarized?:True|False         ; whether a polarity marker is required or not
                                            ):

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1192,8 +1192,8 @@ public defn make-quad-landpattern (num-pins:Int,
                                    pitch:Double, 
                                    component-size:Toleranced, 
                                    package-size:Toleranced, 
-                                   lead-x:Toleranced, 
-                                   lead-y:Toleranced, 
+                                   lead-length:Toleranced, 
+                                   lead-width:Toleranced, 
                                    lead-type:LandProtrusionType):
   ensure-divisible!(num-pins, 4, "make-quad-landpattern(num-pins, ...)")
   if pitch <= 0.0:  

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1102,8 +1102,8 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
                                    pitch-south:Double,  ; the pitch on the south face
                                    pitch-east:Double,   ; the pitch on the east face
                                    pitch-north:Double,  ; the pitch on the north face
-                                   lead-span-1: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
-                                   lead-span-2: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
+                                   lead-span-x: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
+                                   lead-span-y: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
                                    package-length: Toleranced,  ; the size of the package in the x direction
                                    package-width: Toleranced,  ; the size of hte package in the y direction
                                    lead-length: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
@@ -1119,8 +1119,8 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
   inside pcb-landpattern: 
     ;----------------------------------------------------------
     ; compute dimensions
-    val ipc-ns = ipc-formula(lead-span-1, lead-length, lead-width, lead-fillets)
-    val ipc-ew = ipc-formula(lead-span-2, lead-length, lead-width, lead-fillets)
+    val ipc-ns = ipc-formula(lead-span-x, lead-length, lead-width, lead-fillets)
+    val ipc-ew = ipc-formula(lead-span-y, lead-length, lead-width, lead-fillets)
     val pad-sz-ns = transpose(pad-size(ipc-ns))
     val pad-sz-ew = pad-size(ipc-ew)
 

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1111,6 +1111,10 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
                                    lead-type:  LandProtrusionType, ; the type of the leads
                                    density-level: DensityLevel   ; the density level of the design
                                    ):
+
+  for pitch in [pitch-west, pitch-south, pitch-east, pitch-north] do:
+    fatal("make-quad-landpattern(...) failed: pitch must be nonzero and positive.") when pitch <= 0.0
+
   val lead-fillets = lead-fillets(lead-type, density-level)  
   inside pcb-landpattern: 
     ;----------------------------------------------------------
@@ -1196,8 +1200,6 @@ public defn make-quad-landpattern (num-pins:Int,
                                    lead-width:Toleranced, 
                                    lead-type:LandProtrusionType):
   ensure-divisible!(num-pins, 4, "make-quad-landpattern(num-pins, ...)")
-  if pitch <= 0.0:  
-    fatal("make-quad-landpattern(...) failed: pitch must be greater than 0. Called with: %_." % [pitch])
   make-quad-landpattern(num-pins / 4, num-pins / 4, num-pins / 4, num-pins / 4, 
                         pitch, pitch, pitch, pitch, 
                         lead-span, lead-span, 

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1127,8 +1127,9 @@ public defn make-quad-landpattern (num-pins-north: Int, ; the number of pins on 
                                    lead-dim-1: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
                                    lead-dim-2: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
                                    lead-type:  LandProtrusionType, ; the type of the leads
-                                   density-level: DensityLevel):   ; the density level of the design
-  val lead-fillets = lead-fillets(lead-type, density-level)
+                                   density-level: DensityLevel   ; the density level of the design
+                                   ):
+  val lead-fillets = lead-fillets(lead-type, density-level)  
   inside pcb-landpattern:
     layer(Courtyard(Bottom)) = Rectangle(max-value(part-x), max-value(part-y))
     layer(Courtyard(Bottom)) = Rectangle(max-value(outer-x), max-value(outer-y))
@@ -1209,7 +1210,13 @@ public defn make-quad-landpattern (num-pins-north: Int, ; the number of pins on 
     val text-y = 0.5 * (y(cy-sz) + MIN-SILKSCREEN-TEXT-HEIGHT)
     ref-label(0.0, text-y)
 
-public defn make-quad-landpattern (num-pins:Int, pitch:Double, outer-xy:Toleranced, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced, lead-type:LandProtrusionType):
+public defn make-quad-landpattern (num-pins:Int, 
+                                   pitch:Double, 
+                                   outer-xy:Toleranced, 
+                                   package-xy:Toleranced, 
+                                   lead-x:Toleranced, 
+                                   lead-y:Toleranced, 
+                                   lead-type:LandProtrusionType):
   fatal("make-quad-landpattern(...) failed: num-pins must be divisible by 4. Called with: %_." % [num-pins]) when (num-pins % 4 != 0) or (num-pins <= 0)
   fatal("make-quad-landpattern(...) failed: pitch must be greater than 0. Called with: %_." % [pitch]) when pitch <= 0.0
   make-quad-landpattern(num-pins / 4, num-pins / 4, num-pins / 4, num-pins / 4, 
@@ -1217,7 +1224,7 @@ public defn make-quad-landpattern (num-pins:Int, pitch:Double, outer-xy:Toleranc
                         outer-xy, outer-xy, 
                         package-xy, package-xy, 
                         lead-x, lead-y, lead-type, DensityLevelC)
-
+  
 public defn make-qfn-landpattern (num-pins:Int, pitch:Double, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced):
   make-quad-landpattern(num-pins,
                         pitch,

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -20,6 +20,12 @@ defn ensure-even-positive! (value: Int, name: String):
   if value < 2 or value % 2 == 1:
     fatal("%_ only supports a positive even number of pins." % [name])
 
+defn ensure-divisible! (value:Int, divisor:Int, name: String):
+  if divisor < 2:
+    fatal("%_ must be > 2" % [value])
+  if (value < divisor) or (value % 2 != 0):
+    fatal("%_ must be positive and divisible by %_." % [value])
+
 ; ====== Silk screen helpers ===================================================
 ; Create a reference label at (0, 0)
 ; ====== Reference Label Helpers ===============================================
@@ -152,7 +158,7 @@ public defn apply-soldermask (mask-shape:Shape):
 public defn apply-soldermask (amount:Double):
   val mask-shape = 
     match(pad-shape(self)):
-      (s:Rectangle|Circle|RoundedRectangle|Segment|Capsule):
+      (s:Rectangle|Circle|RoundedRectangle|Segment|Capsule|DShape|ChamferedRectangle):
         offset(s, amount)
       (s:ChamferedRectangle|DShape):
         val d = dims(s)
@@ -737,7 +743,6 @@ public pcb-landpattern sop65-landpattern (n:Int) :
   make-sop65-landpattern(n, 6.4)
 
 public defn make-qfn-landpattern (pin-pitch:Double, lead-span:Double, n-pins:Int, pad-width:Double, pad-length:Double, corner-pads:[Pad,Pad]|False) :
-  println("called make-qfn-landpattern")
   inside pcb-landpattern :
     var n = -1
     if n-pins % 4 == 0 :
@@ -1080,108 +1085,57 @@ defn ipc-formula (L:Toleranced, ; the distance from edge-of-lead to edge-of-lead
   val Xmin = Wmin + 2.0 * Js + C_W ; the size of the land in the dimension orthogonal to Z and G.
   IpcResults(Zmax, Gmin, Xmin)
 
-; A helper struct to compute the indices of a quad landpattern
-defstruct QuadIdx:
-  east:  Tuple<Int> ; the pin indices on the east face of the land pattern
-  south: Tuple<Int> ; the pin indices on the south face of hte land pattern
-  west:  Tuple<Int> ; the pin indiices on the west face of the land pattern
-  north: Tuple<Int> ; the pin inidices on the north face of the land pattern
-
-; printer for debugging QuadIdx
-defmethod print (o:OutputStream, q:QuadIdx):
-  print(o, "QuadIdx:")
-  val os = IndentedStream(o)
-  lnprint(os, "North:%_" % [north(q)])
-  lnprint(os, "South:%_" % [south(q)])
-  lnprint(os, "East:%_" %  [east(q)])
-  lnprint(os, "West:%_" %  [west(q)])
-
-; Compute the indices of a landpattern on each face
-defn QuadIdx (num-pins-ns:Int, num-pins-ew:Int):
-  val idx-e = to-tuple $ 1 through num-pins-ew / 2
-  val idx-s = to-tuple $ (maximum(idx-e) + 1) through (maximum(idx-e) + 1 + num-pins-ns / 2 - 1)
-  val idx-w = to-tuple $ reverse $ (maximum(idx-s) + 1) through (maximum(idx-s) + 1 + num-pins-ew / 2 - 1)
-  val idx-n = to-tuple $ reverse $ (maximum(idx-w) + 1) through (maximum(idx-w) + 1 + num-pins-ns / 2 - 1)
-  QuadIdx(idx-e, idx-s, idx-w, idx-n)
-
-; Get the north/south indices, in one tuple
-defn north-south (q:QuadIdx):
-  to-tuple(cat-all([north(q), south(q)]))
-
-; Get the east/west indicies, in one tuple
-defn east-west (q:QuadIdx):
-  to-tuple(cat-all([east(q), west(q)]))
-
-public defn make-quad-landpattern (num-pins-north: Int, ; the number of pins on the north face
+; helper struct to contain information about how we plan 
+; to layout the pads on a single side of a quad land pattern
+public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on the west face
                                    num-pins-south: Int, ; the number of pins on the south face
                                    num-pins-east: Int,  ; the number of pins on the east face
-                                   num-pins-west: Int,  ; the number of pins on the west face
-                                   pitch-north:Double,  ; the pitch on the north face
+                                   num-pins-north: Int, ; the number of pins on the north face
+                                   pitch-west:Double,   ; the pithc on the west face
                                    pitch-south:Double,  ; the pitch on the south face
                                    pitch-east:Double,   ; the pitch on the east face
-                                   pitch-west:Double,   ; the pithc on the west face
-                                   outer-x: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
-                                   outer-y: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
-                                   part-x: Toleranced,  ; the size of the package in the x direction
-                                   part-y: Toleranced,  ; the size of hte package in the y direction
-                                   lead-dim-1: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
-                                   lead-dim-2: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
+                                   pitch-north:Double,  ; the pitch on the north face
+                                   component-length: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
+                                   component-width: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
+                                   package-length: Toleranced,  ; the size of the package in the x direction
+                                   package-width: Toleranced,  ; the size of hte package in the y direction
+                                   lead-length: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
+                                   lead-width: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
                                    lead-type:  LandProtrusionType, ; the type of the leads
                                    density-level: DensityLevel   ; the density level of the design
                                    ):
   val lead-fillets = lead-fillets(lead-type, density-level)  
-  inside pcb-landpattern:
-    layer(Courtyard(Bottom)) = Rectangle(max-value(part-x), max-value(part-y))
-    layer(Courtyard(Bottom)) = Rectangle(max-value(outer-x), max-value(outer-y))
-    
+  inside pcb-landpattern: 
     ;----------------------------------------------------------
     ; compute dimensions
-    ; layer(Courtyard(Bottom)) = Rectangle(typ(part-x), typ(part-y))
-    val ipc-ns = ipc-formula(outer-x, lead-dim-1, lead-dim-2, 0.0, 0.0, lead-fillets)
-    val ipc-ew = ipc-formula(outer-y, lead-dim-1, lead-dim-2, 0.0, 0.0, lead-fillets)
+    ; layer(Courtyard(Bottom)) = Rectangle(typ(package-length), typ(package-width))
+    val ipc-ns = ipc-formula(component-length, lead-length, lead-width, lead-fillets)
+    val ipc-ew = ipc-formula(component-width, lead-length, lead-width, lead-fillets)
     val pad-sz-ns = transpose(pad-size(ipc-ns))
     val pad-sz-ew = pad-size(ipc-ew)
-    ; layer(Courtyard(Top)) = Rectangle(Zmax(ipc-ew), Zmax(ipc-ns))
-    ; layer(Courtyard(Top)) = Rectangle(Gmin(ipc-ew), Gmin(ipc-ns))
 
     ;----------------------------------------------------------
-    ; compute pad locations
-    var acc = 0
-
-    val x-shift = 0.5 * (Zmax(ipc-ew) - x(pad-sz-ew))
-    val y-shift = 0.5 * (Zmax(ipc-ns) - y(pad-sz-ns))
-    val x-shift-nom = 0.5 * max-value(outer-x) - 0.5 * max-value(lead-dim-1)
-    val y-shift-nom = 0.5 * max-value(outer-y) - 0.5 * max-value(lead-dim-1)
-    
+    ; compute pad locations 
+    val x-shift = 0.5 * (Gmin(ipc-ew) + x(pad-sz-ew))
+    val y-shift = 0.5 * (Gmin(ipc-ns) + y(pad-sz-ns))
+    println("x-shift:%_, y-shift:%_" % [x-shift, y-shift])
     val pad-1-loc = to-tuple(grid-locs(num-pins-east, 2, 2.0 * x-shift, pitch-east))[0]
-    defn layout-pads (dir:Dir, n:Int, p:Double):
-      val nominal-locs = switch(dir):
-        Up: reverse $ to-list $ shift-locs(0.0, y-shift-nom, row-locs(n, p))
-        Down: shift-locs(0.0, (- y-shift-nom), row-locs(n, p))
-        Left: shift-locs((- x-shift-nom), 0.0, col-locs(n, p))
-        Right: reverse $ to-list $ shift-locs(x-shift-nom, 0.0, col-locs(n, p))
-      for loc in nominal-locs do:
-        layer(Courtyard(Bottom)) = 
-          if (dir == Up) or (dir == Down):
-            loc * Rectangle(max-value(lead-dim-2), max-value(lead-dim-1))
-          else:
-            loc * Rectangle(max-value(lead-dim-1), max-value(lead-dim-2))
-      
+    var pin-count = 0 ; accumulator, holds the number of pins we have laid out
+
+    defn layout-pads (dir:Dir, num-pins:Int, pitch:Double):
       val locs = switch(dir):
-        Up: reverse(to-list $ shift-locs(0.0, y-shift, row-locs(n, p)))
-        Down: shift-locs(0.0, (- y-shift), row-locs(n, p))
-        Left: shift-locs((- x-shift), 0.0, col-locs(n, p))
-        Right: reverse(to-list $ shift-locs(x-shift, 0.0, col-locs(n, p)))
-      val def = switch(dir):
-        Up: smd-pad(pad-sz-ns)
-        Down: smd-pad(pad-sz-ns)
-        Left: smd-pad(pad-sz-ew)
-        Right: smd-pad(pad-sz-ew)
-        
-      val idx = acc to (acc + n)
-      acc = acc + n
+        Up:    to-tuple $ shift-locs(-0.5 * x-shift,        y-shift, row-locs(W, num-pins, pitch))
+        Down:  to-tuple $ shift-locs( 0.5 * x-shift, -1.0 * y-shift, row-locs(E, num-pins, pitch))
+        Left:  to-tuple $ shift-locs(-1.0 * x-shift,  0.5 * y-shift, col-locs(N, num-pins, pitch))
+        Right: to-tuple $ shift-locs(       x-shift, -0.5 * y-shift, col-locs(S, num-pins, pitch))
+      ;println("%_:[%,]" % [dir, locs])
+      val pad-dims = 
+        if contains?([Left, Right], dir): pad-sz-ew
+        else: pad-sz-ns        
+      val idx = pin-count to (pin-count + num-pins)
       for (i in idx, loc in locs) do:
-        pad p[i + 1]: def at loc
+        pad p[i + 1]: smd-pad(pad-dims) at loc
+      pin-count = pin-count + num-pins
 
     layout-pads(Left, num-pins-east,  pitch-east)
     layout-pads(Down, num-pins-south, pitch-south)
@@ -1190,7 +1144,7 @@ public defn make-quad-landpattern (num-pins-north: Int, ; the number of pins on 
     
     ;----------------------------------------------------------
     ; Compute the courtyard
-    val part-sz = Dims(max-value(part-x), max-value(part-y))
+    val part-sz = Dims(max-value(package-length), max-value(package-width))
     val lp-sz   = enlarge(Dims(Zmax(ipc-ew), Zmax(ipc-ns)), 2.0 * SOLDER-MASK-REGISTRATION)
     val cy-sz   = enlarge(max(part-sz, lp-sz), courtyard-excess(lead-fillets))
     layer(Courtyard(Top)) = Rectangle(cy-sz)
@@ -1217,8 +1171,9 @@ public defn make-quad-landpattern (num-pins:Int,
                                    lead-x:Toleranced, 
                                    lead-y:Toleranced, 
                                    lead-type:LandProtrusionType):
-  fatal("make-quad-landpattern(...) failed: num-pins must be divisible by 4. Called with: %_." % [num-pins]) when (num-pins % 4 != 0) or (num-pins <= 0)
-  fatal("make-quad-landpattern(...) failed: pitch must be greater than 0. Called with: %_." % [pitch]) when pitch <= 0.0
+  ensure-divisible!(num-pins, 4, "make-quad-landpattern(num-pins, ...)")
+  if pitch <= 0.0:  
+    fatal("make-quad-landpattern(...) failed: pitch must be greater than 0. Called with: %_." % [pitch])
   make-quad-landpattern(num-pins / 4, num-pins / 4, num-pins / 4, num-pins / 4, 
                         pitch, pitch, pitch, pitch, 
                         outer-xy, outer-xy, 

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1102,8 +1102,8 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
                                    pitch-south:Double,  ; the pitch on the south face
                                    pitch-east:Double,   ; the pitch on the east face
                                    pitch-north:Double,  ; the pitch on the north face
-                                   component-length: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
-                                   component-width: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
+                                   lead-span-1: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
+                                   lead-span-2: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
                                    package-length: Toleranced,  ; the size of the package in the x direction
                                    package-width: Toleranced,  ; the size of hte package in the y direction
                                    lead-length: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
@@ -1115,8 +1115,8 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
   inside pcb-landpattern: 
     ;----------------------------------------------------------
     ; compute dimensions
-    val ipc-ns = ipc-formula(component-length, lead-length, lead-width, lead-fillets)
-    val ipc-ew = ipc-formula(component-width, lead-length, lead-width, lead-fillets)
+    val ipc-ns = ipc-formula(lead-span-1, lead-length, lead-width, lead-fillets)
+    val ipc-ew = ipc-formula(lead-span-2, lead-length, lead-width, lead-fillets)
     val pad-sz-ns = transpose(pad-size(ipc-ns))
     val pad-sz-ew = pad-size(ipc-ew)
 
@@ -1190,7 +1190,7 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
 
 public defn make-quad-landpattern (num-pins:Int, 
                                    pitch:Double, 
-                                   component-size:Toleranced, 
+                                   lead-span:Toleranced, 
                                    package-size:Toleranced, 
                                    lead-length:Toleranced, 
                                    lead-width:Toleranced, 
@@ -1200,44 +1200,46 @@ public defn make-quad-landpattern (num-pins:Int,
     fatal("make-quad-landpattern(...) failed: pitch must be greater than 0. Called with: %_." % [pitch])
   make-quad-landpattern(num-pins / 4, num-pins / 4, num-pins / 4, num-pins / 4, 
                         pitch, pitch, pitch, pitch, 
-                        component-size, component-size, 
+                        lead-span, lead-span, 
                         package-size, package-size, 
-                        lead-length, lead-width, lead-type, DensityLevelC)
+                        lead-length, lead-width, lead-type, DENSITY-LEVEL)
   
 public defn make-qfn-landpattern (num-pins:Int, 
                                   pitch:Double, 
-                                  package-size:Toleranced, 
-                                  lead-length:Toleranced, 
-                                  lead-width:Toleranced):
+                                  package-length:Toleranced, 
+                                  terminal-length:Toleranced, 
+                                  terminal-width:Toleranced):
   make-quad-landpattern(num-pins,
                         pitch,
-                        package-size,
-                        package-size, 
-                        lead-length, lead-width, QuadFlatNoLeads)
+                        package-length,
+                        package-length, 
+                        terminal-length, terminal-width, QuadFlatNoLeads)
 
 public defn make-qfn-landpattern (num-pins:[Int, Int, Int, Int], 
                                   pitch:Double, 
-                                  package-size:Toleranced, 
-                                  lead-length:Toleranced, 
-                                  lead-width:Toleranced):
+                                  package-length:Toleranced, 
+                                  terminal-length:Toleranced, 
+                                  terminal-width:Toleranced):
   make-quad-landpattern(num-pins[0], num-pins[1], num-pins[2], num-pins[3], 
                         pitch, pitch, pitch, pitch,
-                        package-size, package-size,
-                        package-size, package-size,
-                        lead-length, lead-width, QuadFlatNoLeads, DensityLevelC)
+                        package-length, package-length,
+                        package-length, package-length,
+                        terminal-length, terminal-width, 
+                        QuadFlatNoLeads, DENSITY-LEVEL)
 
 public defn make-qfp-landpattern (num-pins:Int, 
                                   pitch:Double, 
-                                  component-size:Toleranced, 
-                                  package-size:Toleranced, 
+                                  lead-span:Toleranced, 
+                                  package-length:Toleranced, 
                                   lead-length:Toleranced, 
                                   lead-width:Toleranced):
   val lead-type = BigGullWingLeads when pitch >= 0.0625 else SmallGullWingLeads
   make-quad-landpattern(num-pins, 
                         pitch,
-                        component-size, 
-                        package-size, 
-                        lead-length, lead-width, lead-type)
+                        lead-span, 
+                        package-length, 
+                        lead-length, lead-width, 
+                        lead-type)
 
 ; Create an `n` pin SOIC land pattern. 
 ;
@@ -1248,7 +1250,7 @@ public defn make-qfp-landpattern (num-pins:Int,
 ;
 public defn make-n-pin-soic-landpattern (num-pins:Int,                 ; number of pins of the component
                                          pitch:Double,                 ; pitch of the pins of the component
-                                         component-length:Toleranced,  ; the overall length of the component, from terminal-edge to terminal-edge
+                                         lead-span:Toleranced,  ; the overall length of the component, from terminal-edge to terminal-edge
                                          package-length:Toleranced,    ; the length of the package 
                                          package-width:Toleranced,     ; the width of the package
                                          lead-type:LandProtrusionType, ; the lead/land protrusion type of the part
@@ -1262,7 +1264,7 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,                 ; number 
     ;----------------------------------------------------
     ; Compute adjustments to dimensions using IPC formula
     val ipc = ipc-formula(
-      component-length, terminal-length, terminal-width, 
+      lead-span, terminal-length, terminal-width, 
       lead-fillets
     )
 
@@ -1306,7 +1308,7 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,                 ; number 
 
 public defn make-n-pin-soic-landpattern (num-pins:Int,
                                          pitch:Double,
-                                         component-length:Toleranced,
+                                         lead-span:Toleranced,
                                          package-length:Toleranced,
                                          package-width:Toleranced,
                                          terminal-length:Toleranced,
@@ -1314,19 +1316,19 @@ public defn make-n-pin-soic-landpattern (num-pins:Int,
   val lead-type = BigGullWingLeads when pitch > 0.0625 else SmallGullWingLeads
   make-n-pin-soic-landpattern(num-pins,
                               pitch
-                              component-length,
+                              lead-span,
                               package-length,
                               package-width,
                               lead-type,
                               terminal-length,
                               terminal-width,
-                              DensityLevelC)
+                              DENSITY-LEVEL)
 
 public defn make-two-pin-chip-landpattern (length:Toleranced, ; the length (vertical) dimension of the package
                                            width:Toleranced,  ; the width (horizontal) dimension of the package
                                            lead-length:Toleranced, ; the length (vertical) dimension of the conductors/leads of the package
                                            lead-width?:False|Toleranced, ; the width (horizontal) dimension of the conductors/leads of the package, if different from `length`
-                                           density-level:DensityLevel,   ; the density level of the design (DensityLevelA|DensityLevelB|DensityLevelC)
+                                           density-level:DensityLevel,   ; the density level of the design (DensityLevelA|DensityLevelB|DENSITY-LEVEL)
                                            anode-and-cathode?:True|False,; whether the pads should be named `a` and `c` (if false, p[1] and p[2])
                                            polarized?:True|False         ; whether a polarity marker is required or not
                                            ):
@@ -1447,5 +1449,5 @@ public defn two-pin-chip-landpattern (length:Toleranced,
                                       polarized?:True|False):
   two-pin-chip-landpattern(
     length, width, lead-length, false, 
-    DensityLevelC, polarized?
+    DENSITY-LEVEL, polarized?
   )

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1190,8 +1190,8 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
 
 public defn make-quad-landpattern (num-pins:Int, 
                                    pitch:Double, 
-                                   outer-xy:Toleranced, 
-                                   package-xy:Toleranced, 
+                                   component-size:Toleranced, 
+                                   package-size:Toleranced, 
                                    lead-x:Toleranced, 
                                    lead-y:Toleranced, 
                                    lead-type:LandProtrusionType):
@@ -1200,31 +1200,44 @@ public defn make-quad-landpattern (num-pins:Int,
     fatal("make-quad-landpattern(...) failed: pitch must be greater than 0. Called with: %_." % [pitch])
   make-quad-landpattern(num-pins / 4, num-pins / 4, num-pins / 4, num-pins / 4, 
                         pitch, pitch, pitch, pitch, 
-                        outer-xy, outer-xy, 
-                        package-xy, package-xy, 
-                        lead-x, lead-y, lead-type, DensityLevelC)
+                        component-size, component-size, 
+                        package-size, package-size, 
+                        lead-length, lead-width, lead-type, DensityLevelC)
   
-public defn make-qfn-landpattern (num-pins:Int, pitch:Double, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced):
+public defn make-qfn-landpattern (num-pins:Int, 
+                                  pitch:Double, 
+                                  package-size:Toleranced, 
+                                  lead-length:Toleranced, 
+                                  lead-width:Toleranced):
   make-quad-landpattern(num-pins,
                         pitch,
-                        package-xy,
-                        package-xy, 
-                        lead-x, lead-y, QuadFlatNoLeads)
+                        package-size,
+                        package-size, 
+                        lead-length, lead-width, QuadFlatNoLeads)
 
-public defn make-qfn-landpattern (num-pins:[Int, Int, Int, Int], pitch:Double, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced):
+public defn make-qfn-landpattern (num-pins:[Int, Int, Int, Int], 
+                                  pitch:Double, 
+                                  package-size:Toleranced, 
+                                  lead-length:Toleranced, 
+                                  lead-width:Toleranced):
   make-quad-landpattern(num-pins[0], num-pins[1], num-pins[2], num-pins[3], 
                         pitch, pitch, pitch, pitch,
-                        package-xy, package-xy,
-                        package-xy, package-xy,
-                        lead-x, lead-y, QuadFlatNoLeads, DensityLevelC)
+                        package-size, package-size,
+                        package-size, package-size,
+                        lead-length, lead-width, QuadFlatNoLeads, DensityLevelC)
 
-public defn make-qfp-landpattern (num-pins:Int, pitch:Double, outer-xy:Toleranced, package-xy:Toleranced, lead-x:Toleranced, lead-y:Toleranced):
+public defn make-qfp-landpattern (num-pins:Int, 
+                                  pitch:Double, 
+                                  component-size:Toleranced, 
+                                  package-size:Toleranced, 
+                                  lead-length:Toleranced, 
+                                  lead-width:Toleranced):
   val lead-type = BigGullWingLeads when pitch >= 0.0625 else SmallGullWingLeads
   make-quad-landpattern(num-pins, 
                         pitch,
-                        outer-xy, 
-                        package-xy, 
-                        lead-x, lead-y, lead-type)
+                        component-size, 
+                        package-size, 
+                        lead-length, lead-width, lead-type)
 
 ; Create an `n` pin SOIC land pattern. 
 ;

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -103,6 +103,17 @@ defn chamfered (anchor:Anchor, width:Double, height:Double, r:Double):
 ;==============================================================================
 ;=========================== Geometric Helpers ================================
 ;==============================================================================
+defn shift-locs (x:Double, y:Double, s:Seqable<Pose>):
+  seq({loc(x, y) * _}, s)
+
+defn max-distance (p1:Point, p2:Point) -> Point:
+  defn radius (p:Point):
+    sqrt(x(p) * x(p) + y(p) * y(p))
+  if radius(p1) > radius(p2):
+    p1
+  else:
+    p2
+
 ; ====== Land pattern utilities ===============================================
 ; Create a rectangle out of lines
 public defn LineRectangle (w:Double, h:Double, xc:Double, yc:Double, line-w:Double) :
@@ -158,12 +169,8 @@ public defn apply-soldermask (mask-shape:Shape):
 public defn apply-soldermask (amount:Double):
   val mask-shape = 
     match(pad-shape(self)):
-      (s:Rectangle|Circle|RoundedRectangle|Segment|Capsule|DShape|ChamferedRectangle):
-        offset(s, amount)
-      (s:ChamferedRectangle|DShape):
-        val d = dims(s)
-        val expansion-factor = 1.0 + amount / max(x(d), y(d))
-        expand(s, expansion-factor)
+      (s:Rectangle|Circle|RoundedRectangle|Capsule|DShape|ChamferedRectangle):
+        expand(s, amount)
       (s:Shape):
         ; FIXME: for other shapes we need an implementation of offset
         s
@@ -1108,7 +1115,6 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
   inside pcb-landpattern: 
     ;----------------------------------------------------------
     ; compute dimensions
-    ; layer(Courtyard(Bottom)) = Rectangle(typ(package-length), typ(package-width))
     val ipc-ns = ipc-formula(component-length, lead-length, lead-width, lead-fillets)
     val ipc-ew = ipc-formula(component-width, lead-length, lead-width, lead-fillets)
     val pad-sz-ns = transpose(pad-size(ipc-ns))
@@ -1116,19 +1122,27 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
 
     ;----------------------------------------------------------
     ; compute pad locations 
-    val x-shift = 0.5 * (Gmin(ipc-ew) + x(pad-sz-ew))
-    val y-shift = 0.5 * (Gmin(ipc-ns) + y(pad-sz-ns))
-    println("x-shift:%_, y-shift:%_" % [x-shift, y-shift])
+    val x-shift = 0.5 * (Zmax(ipc-ew) - x(pad-sz-ew))
+    val y-shift = 0.5 * (Zmax(ipc-ns) - y(pad-sz-ns))
+
     val pad-1-loc = to-tuple(grid-locs(num-pins-east, 2, 2.0 * x-shift, pitch-east))[0]
     var pin-count = 0 ; accumulator, holds the number of pins we have laid out
 
     defn layout-pads (dir:Dir, num-pins:Int, pitch:Double):
       val locs = switch(dir):
-        Up:    to-tuple $ shift-locs(-0.5 * x-shift,        y-shift, row-locs(W, num-pins, pitch))
-        Down:  to-tuple $ shift-locs( 0.5 * x-shift, -1.0 * y-shift, row-locs(E, num-pins, pitch))
-        Left:  to-tuple $ shift-locs(-1.0 * x-shift,  0.5 * y-shift, col-locs(N, num-pins, pitch))
-        Right: to-tuple $ shift-locs(       x-shift, -0.5 * y-shift, col-locs(S, num-pins, pitch))
-      ;println("%_:[%,]" % [dir, locs])
+        Up: 
+          shift-locs{0.0, y-shift, _ } $
+          reverse(to-list(row-locs(num-pins, pitch)))
+        Down: 
+          shift-locs{0.0, (- y-shift), _ } $
+          row-locs(num-pins, pitch)
+        Left:  
+          shift-locs{(- x-shift), 0.0, _ } $
+          col-locs(num-pins, pitch)
+        Right: 
+          shift-locs{x-shift, 0.0, _ } $
+          reverse(to-list(col-locs(num-pins, pitch)))
+      
       val pad-dims = 
         if contains?([Left, Right], dir): pad-sz-ew
         else: pad-sz-ns        
@@ -1154,10 +1168,20 @@ public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on 
     val line-width  = clearance(current-rules(), MinSilkscreenWidth)
     val line-length = 3.0 * line-width - line-width
     val dist  = SOLDER-MASK-REGISTRATION + SILK-SOLDER-MASK-CLEARANCE + line-width * 0.5 + 0.01
+    
     val pad-loc = center(pad-1-loc)
-    val pol-x = min(-0.5 * x(part-sz), x(pad-loc) - 0.5 * x(pad-sz-ew))
-    val pol-y = max( 0.5 * y(part-sz), y(pad-loc) + 0.5 * y(pad-sz-ew))
-    layer(Silkscreen("pol", Top)) = loc(pol-x, pol-y + dist) * Line(line-width, [Point(0.0, 0.0), Point(line-length, 0.0)])
+    val p1 = Point(
+      x(pad-loc) - 0.5 * x(pad-sz-ew),
+      y(pad-loc) + 0.5 * y(pad-sz-ew) + dist
+    )
+    val p2 = Point(
+      -0.5 * x(part-sz) - line-width * 0.5,
+       0.5 * y(part-sz) - line-width * 0.5,
+    )
+    val pol = max-distance(p1, p2)
+    layer(Silkscreen("pol", Top)) = Line(line-width, [
+      pol, pol + Point(line-length, 0.0)
+    ])
 
     ;----------------------------------------------------------
     ; Place the reference label

--- a/utils/land-protrusions.stanza
+++ b/utils/land-protrusions.stanza
@@ -49,6 +49,9 @@ public pcb-struct ocdb/land-patterns/packages/LeadFillets:
   side:Double ; space on the edges of the lead
   courtyard-excess:Double ; additional area to add to the courtyard 
 
+defmethod print (o:OutputStream, l:LeadFillets):
+  print(o, "LeadFillets(toe:%_, heel:%_, side:%_, courtyard-excess:%_" % [toe(l), heel(l), side(l), courtyard-excess(l)])
+
 public defn to-tuple (l:LeadFillets) -> [Double, Double, Double, Double]:
   [toe(l), heel(l), side(l), courtyard-excess(l)]
 


### PR DESCRIPTION
(blocked on internal support for `expand(...)`

Examples (generated using the code in tests/test-land-patterns.stanza):

![qfn-final](https://user-images.githubusercontent.com/28515218/128413320-1fd041ef-c921-4eeb-9ae0-0db8cf3b47c7.png)

![qfp-final](https://user-images.githubusercontent.com/28515218/128413324-3f045468-7f60-49a7-8581-5f194b803a89.png)

The following APIs are introduced:


```
public defn make-quad-landpattern (num-pins-west: Int,  ; the number of pins on the west face
                                   num-pins-south: Int, ; the number of pins on the south face
                                   num-pins-east: Int,  ; the number of pins on the east face
                                   num-pins-north: Int, ; the number of pins on the north face
                                   pitch-west:Double,   ; the pithc on the west face
                                   pitch-south:Double,  ; the pitch on the south face
                                   pitch-east:Double,   ; the pitch on the east face
                                   pitch-north:Double,  ; the pitch on the north face
                                   component-length: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the x direction
                                   component-width: Toleranced, ; the distance from pad-edge to pad-edge on the exterior of the part in the y direction
                                   package-length: Toleranced,  ; the size of the package in the x direction
                                   package-width: Toleranced,  ; the size of hte package in the y direction
                                   lead-length: Toleranced, ; the dimension of the leads in the x direction on the east/west faces
                                   lead-width: Toleranced, ; the dimension of the leads in the y direction on the east/west faces
                                   lead-type:  LandProtrusionType, ; the type of the leads
                                   density-level: DensityLevel   ; the density level of the design
                                   ):
```

This is the base generator for quad land patterns (pads on all four edges). 

Some additional helpers to simplify calling this generator:

```
public defn make-quad-landpattern (num-pins:Int, 
                                   pitch:Double, 
                                   outer-xy:Toleranced, 
                                   package-xy:Toleranced, 
                                   lead-x:Toleranced, 
                                   lead-y:Toleranced, 
                                   lead-type:LandProtrusionType):

public defn make-qfn-landpattern (num-pins:Int, 
                                  pitch:Double, 
                                  package-size:Toleranced, 
                                  lead-length:Toleranced, 
                                  lead-width:Toleranced):

public defn make-qfn-landpattern (num-pins:[Int, Int, Int, Int], 
                                  pitch:Double, 
                                  package-size:Toleranced, 
                                  lead-length:Toleranced, 
                                  lead-width:Toleranced):
           
public defn make-qfp-landpattern (num-pins:Int, 
                                  pitch:Double, 
                                  component-size:Toleranced, 
                                  package-size:Toleranced, 
                                  lead-length:Toleranced, 
                                  lead-width:Toleranced):

```