### PR TITLE
Integration tests using docker image pkgs instead of ocdb repo source files

### DIFF
--- a/.github/jitx-client/scripts/run-ocdb-tests.sh
+++ b/.github/jitx-client/scripts/run-ocdb-tests.sh
@@ -9,12 +9,24 @@ jitx check-install
 echo "/root/.jitx/user.params:"
 cat /root/.jitx/user.params
 
+#==============================================
+#==== public pcb-* macro evaluation tests =====
+#==============================================
+
+# Those macro evaluation tests take into account the root stanza.proj as it is included in the generated test-evaluate/stanza.proj
 echo "Searching for pcb objects and generating tests..."
 python3.8 scripts/evaluate_pcb_objects.py
 cd test-evaluate/
 echo "Launching pcb object tests..."
 jitx run-test test/evaluate/api
 cd ..
+
+#==============================================
+#====== Unit-tests and integration-tests ======
+#==============================================
+
+# Those tests need to take into account the root stanza.proj so that they find the source files from the ocdb repo and not a pkg from the jitx-client docker image
+export STANZA_CONFIG=/app/open-components-database/
 
 echo "Launching ocdb tests, they can depend on jitx-client..."
 cd open-components-database

--- a/.github/jitx-client/scripts/run-ocdb-tests.sh
+++ b/.github/jitx-client/scripts/run-ocdb-tests.sh
@@ -9,29 +9,33 @@ jitx check-install
 echo "/root/.jitx/user.params:"
 cat /root/.jitx/user.params
 
+# Tests need to take into account the root stanza.proj so that they find the source files from the ocdb repo and not a pkg from the jitx-client docker image
+export JITX_RUN="jitx run /app/open-components-database/stanza.proj"
+export JITX_RUN_TEST="jitx run-test /app/open-components-database/stanza.proj"
+
 #==============================================
 #==== public pcb-* macro evaluation tests =====
 #==============================================
 
-# Those macro evaluation tests take into account the root stanza.proj as it is included in the generated test-evaluate/stanza.proj
 echo "Searching for pcb objects and generating tests..."
 python3.8 scripts/evaluate_pcb_objects.py
 cd test-evaluate/
 echo "Launching pcb object tests..."
-jitx run-test test/evaluate/api
+$JITX_RUN_TEST test/evaluate/api
 cd ..
 
 #==============================================
-#====== Unit-tests and integration-tests ======
+#================= Unit-tests =================
 #==============================================
-
-# Those tests need to take into account the root stanza.proj so that they find the source files from the ocdb repo and not a pkg from the jitx-client docker image
-export STANZA_CONFIG=/app/open-components-database/
 
 echo "Launching ocdb tests, they can depend on jitx-client..."
 cd open-components-database
-jitx run-test tests/test-ocdb.stanza
+$JITX_RUN_TEST tests/test-ocdb.stanza
 cd ..
+
+#==============================================
+#============= Integration tests ==============
+#==============================================
 
 echo "Launching ocdb designs..."
 cd open-components-database/designs
@@ -45,7 +49,7 @@ designs=(ble-mote.stanza
 
 for filename in "${designs[@]}"; do
     echo "Running $filename..."
-    jitx run $filename
+    $JITX_RUN $filename
 done
 cd ../..
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         id: login-jitx-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Evaluate public pcb-* macros
+      - name: Evaluate public pcb-* macros + run unit-tests + run integration tests
         run: |
           # Excludes modules and only supports pcb-* macros that take 0 or 1 argument of primitive type
           cd .github/


### PR DESCRIPTION
Integration tests were using jitx-client docker pkgs instead of the source files from the ocdb repo of the PR