### PR TITLE
Bundles Enhancements

### DIFF
--- a/components/microsemi/A2F200M3F-FGG256I.stanza
+++ b/components/microsemi/A2F200M3F-FGG256I.stanza
@@ -387,7 +387,7 @@ public pcb-component component :
   supports reset :
     reset.reset => MSS_RESET_N
 
-  val jtag = jtag([JTAG-TRSTN])
+  val jtag = jtag()
   supports jtag :
     jtag.trstn => TRSTB 
     jtag.tms => TMS   

--- a/components/nordic/nRF52832.stanza
+++ b/components/nordic/nRF52832.stanza
@@ -169,7 +169,7 @@ public pcb-module module :
       require pins:io-pin[2] from proc
       uart().tx => pins[0].p
       uart().rx => pins[1].p
-  supports swd :
-    swd.swdio => proc.SWDIO
-    swd.swdclk => proc.SWDCLK
+  supports swd() :
+    swd().swdio => proc.SWDIO
+    swd().swdclk => proc.SWDCLK
 

--- a/components/st-microelectronics/STM32F031F_4-6_Px.supports.stanza
+++ b/components/st-microelectronics/STM32F031F_4-6_Px.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F031F_4-6_Px/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports gpio:
       gpio.gpio => self.PF[0]

--- a/components/st-microelectronics/STM32F038G6Ux.supports.stanza
+++ b/components/st-microelectronics/STM32F038G6Ux.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F038G6Ux/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports gpio:
       gpio.gpio => self.PF[0]

--- a/components/st-microelectronics/STM32F102C_4-6_Tx.supports.stanza
+++ b/components/st-microelectronics/STM32F102C_4-6_Tx.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F102C_4-6_Tx/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports jtag():
       jtag().tck => self.PA[14]

--- a/components/st-microelectronics/STM32F102C_4-6_Tx.supports.stanza
+++ b/components/st-microelectronics/STM32F102C_4-6_Tx.supports.stanza
@@ -15,12 +15,12 @@ public defn make-supports ():
       swd.swdio  => self.PA[13]
       swd.swdclk => self.PA[14]
 
-    supports jtag([JTAG-TRSTN]):
-      jtag([JTAG-TRSTN]).tck => self.PA[14]
-      jtag([JTAG-TRSTN]).tdi => self.PA[15]
-      jtag([JTAG-TRSTN]).tdo => self.PB[3]
-      jtag([JTAG-TRSTN]).tms => self.PA[13]
-      jtag([JTAG-TRSTN]).trstn => self.PB[4]
+    supports jtag():
+      jtag().tck => self.PA[14]
+      jtag().tdi => self.PA[15]
+      jtag().tdo => self.PB[3]
+      jtag().tms => self.PA[13]
+      jtag().trstn => self.PB[4]
 
     supports gpio:
       gpio.gpio => self.PC[13]

--- a/components/st-microelectronics/STM32F102R_4-6_Tx.supports.stanza
+++ b/components/st-microelectronics/STM32F102R_4-6_Tx.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F102R_4-6_Tx/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports jtag():
       jtag().tck => self.PA[14]

--- a/components/st-microelectronics/STM32F102R_4-6_Tx.supports.stanza
+++ b/components/st-microelectronics/STM32F102R_4-6_Tx.supports.stanza
@@ -15,12 +15,12 @@ public defn make-supports ():
       swd.swdio  => self.PA[13]
       swd.swdclk => self.PA[14]
 
-    supports jtag([JTAG-TRSTN]):
-      jtag([JTAG-TRSTN]).tck => self.PA[14]
-      jtag([JTAG-TRSTN]).tdi => self.PA[15]
-      jtag([JTAG-TRSTN]).tdo => self.PB[3]
-      jtag([JTAG-TRSTN]).tms => self.PA[13]
-      jtag([JTAG-TRSTN]).trstn => self.PB[4]
+    supports jtag():
+      jtag().tck => self.PA[14]
+      jtag().tdi => self.PA[15]
+      jtag().tdo => self.PB[3]
+      jtag().tms => self.PA[13]
+      jtag().trstn => self.PB[4]
 
     supports gpio:
       gpio.gpio => self.PC[13]

--- a/components/st-microelectronics/STM32F103R_4-6_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F103R_4-6_Hx.supports.stanza
@@ -15,12 +15,12 @@ public defn make-supports ():
       swd.swdio  => self.PA[13]
       swd.swdclk => self.PA[14]
 
-    supports jtag([JTAG-TRSTN]):
-      jtag([JTAG-TRSTN]).tck => self.PA[14]
-      jtag([JTAG-TRSTN]).tdi => self.PA[15]
-      jtag([JTAG-TRSTN]).tdo => self.PB[3]
-      jtag([JTAG-TRSTN]).tms => self.PA[13]
-      jtag([JTAG-TRSTN]).trstn => self.PB[4]
+    supports jtag():
+      jtag().tck => self.PA[14]
+      jtag().tdi => self.PA[15]
+      jtag().tdo => self.PB[3]
+      jtag().tms => self.PA[13]
+      jtag().trstn => self.PB[4]
 
     supports gpio:
       gpio.gpio => self.PC[14]

--- a/components/st-microelectronics/STM32F103R_4-6_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F103R_4-6_Hx.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F103R_4-6_Hx/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports jtag():
       jtag().tck => self.PA[14]

--- a/components/st-microelectronics/STM32F103R_8-B_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F103R_8-B_Hx.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F103R_8-B_Hx/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports jtag():
       jtag().tck => self.PA[14]

--- a/components/st-microelectronics/STM32F103R_8-B_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F103R_8-B_Hx.supports.stanza
@@ -15,12 +15,12 @@ public defn make-supports ():
       swd.swdio  => self.PA[13]
       swd.swdclk => self.PA[14]
 
-    supports jtag([JTAG-TRSTN]):
-      jtag([JTAG-TRSTN]).tck => self.PA[14]
-      jtag([JTAG-TRSTN]).tdi => self.PA[15]
-      jtag([JTAG-TRSTN]).tdo => self.PB[3]
-      jtag([JTAG-TRSTN]).tms => self.PA[13]
-      jtag([JTAG-TRSTN]).trstn => self.PB[4]
+    supports jtag():
+      jtag().tck => self.PA[14]
+      jtag().tdi => self.PA[15]
+      jtag().tdo => self.PB[3]
+      jtag().tms => self.PA[13]
+      jtag().trstn => self.PB[4]
 
     supports gpio:
       gpio.gpio => self.PC[14]

--- a/components/st-microelectronics/STM32F103T_4-6_Ux.supports.stanza
+++ b/components/st-microelectronics/STM32F103T_4-6_Ux.supports.stanza
@@ -15,12 +15,12 @@ public defn make-supports ():
       swd.swdio  => self.PA[13]
       swd.swdclk => self.PA[14]
 
-    supports jtag([JTAG-TRSTN]):
-      jtag([JTAG-TRSTN]).tck => self.PA[14]
-      jtag([JTAG-TRSTN]).tdi => self.PA[15]
-      jtag([JTAG-TRSTN]).tdo => self.PB[3]
-      jtag([JTAG-TRSTN]).tms => self.PA[13]
-      jtag([JTAG-TRSTN]).trstn => self.PB[4]
+    supports jtag():
+      jtag().tck => self.PA[14]
+      jtag().tdi => self.PA[15]
+      jtag().tdo => self.PB[3]
+      jtag().tms => self.PA[13]
+      jtag().trstn => self.PB[4]
 
     supports gpio:
       gpio.gpio => self.PD[0]

--- a/components/st-microelectronics/STM32F103T_4-6_Ux.supports.stanza
+++ b/components/st-microelectronics/STM32F103T_4-6_Ux.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F103T_4-6_Ux/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports jtag():
       jtag().tck => self.PA[14]

--- a/components/st-microelectronics/STM32F105V_8-B_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F105V_8-B_Hx.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F105V_8-B_Hx/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports jtag():
       jtag().tck => self.PA[14]

--- a/components/st-microelectronics/STM32F105V_8-B_Hx.supports.stanza
+++ b/components/st-microelectronics/STM32F105V_8-B_Hx.supports.stanza
@@ -15,12 +15,12 @@ public defn make-supports ():
       swd.swdio  => self.PA[13]
       swd.swdclk => self.PA[14]
 
-    supports jtag([JTAG-TRSTN]):
-      jtag([JTAG-TRSTN]).tck => self.PA[14]
-      jtag([JTAG-TRSTN]).tdi => self.PA[15]
-      jtag([JTAG-TRSTN]).tdo => self.PB[3]
-      jtag([JTAG-TRSTN]).tms => self.PA[13]
-      jtag([JTAG-TRSTN]).trstn => self.PB[4]
+    supports jtag():
+      jtag().tck => self.PA[14]
+      jtag().tdi => self.PA[15]
+      jtag().tdo => self.PB[3]
+      jtag().tms => self.PA[13]
+      jtag().trstn => self.PB[4]
 
     supports gpio:
       gpio.gpio => self.PC[14]

--- a/components/st-microelectronics/STM32F107VCHx.supports.stanza
+++ b/components/st-microelectronics/STM32F107VCHx.supports.stanza
@@ -15,12 +15,12 @@ public defn make-supports ():
       swd.swdio  => self.PA[13]
       swd.swdclk => self.PA[14]
 
-    supports jtag([JTAG-TRSTN]):
-      jtag([JTAG-TRSTN]).tck => self.PA[14]
-      jtag([JTAG-TRSTN]).tdi => self.PA[15]
-      jtag([JTAG-TRSTN]).tdo => self.PB[3]
-      jtag([JTAG-TRSTN]).tms => self.PA[13]
-      jtag([JTAG-TRSTN]).trstn => self.PB[4]
+    supports jtag():
+      jtag().tck => self.PA[14]
+      jtag().tdi => self.PA[15]
+      jtag().tdo => self.PB[3]
+      jtag().tms => self.PA[13]
+      jtag().trstn => self.PB[4]
 
     supports gpio:
       gpio.gpio => self.PC[14]

--- a/components/st-microelectronics/STM32F107VCHx.supports.stanza
+++ b/components/st-microelectronics/STM32F107VCHx.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32F107VCHx/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports jtag():
       jtag().tck => self.PA[14]

--- a/components/st-microelectronics/STM32L031F_4-6_Px.supports.stanza
+++ b/components/st-microelectronics/STM32L031F_4-6_Px.supports.stanza
@@ -11,9 +11,9 @@ defpackage ocdb/components/STM32L031F_4-6_Px/supports:
 
 public defn make-supports ():
   inside pcb-component:
-    supports swd:
-      swd.swdio  => self.PA[13]
-      swd.swdclk => self.PA[14]
+    supports swd():
+      swd().swdio  => self.PA[13]
+      swd().swdclk => self.PA[14]
 
     supports gpio:
       gpio.gpio => self.PC[14]

--- a/components/tag-connect/TC2050-IDC-NL.stanza
+++ b/components/tag-connect/TC2050-IDC-NL.stanza
@@ -33,7 +33,7 @@ public pcb-component component :
   reference-prefix = "J"
 
 public pcb-module module :
-  port j : jtag([JTAG-TRSTN])
+  port j : jtag()
   port swd : swd
   port pwr : power
   public inst jtag : ocdb/tag-connect/TC2050-IDC-NL/component
@@ -45,7 +45,7 @@ public pcb-module module :
   net (pwr.vdd, jtag.p[1])
   net (pwr.gnd, jtag.p[9], jtag.p[5], jtag.p[3])
 
-  val jtag-bundle = /jtag([JTAG-TRSTN])
+  val jtag-bundle = /jtag()
   val con = jtag
   supports jtag-bundle:
     jtag-bundle.trstn => con.p[10]

--- a/components/tag-connect/TC2050-IDC-NL.stanza
+++ b/components/tag-connect/TC2050-IDC-NL.stanza
@@ -34,7 +34,7 @@ public pcb-component component :
 
 public pcb-module module :
   port j : jtag()
-  port swd : swd
+  port swd : swd()
   port pwr : power
   public inst jtag : ocdb/tag-connect/TC2050-IDC-NL/component
   net (j.trstn, jtag.p[10])
@@ -54,8 +54,8 @@ public pcb-module module :
     jtag-bundle.tck => con.p[4]
     jtag-bundle.tms => con.p[2]
 
-  supports /swd:
-    ;ocdb/bundles/swd.swdclk => con.p[4]
-    ;ocdb/bundles/swd.swdio => con.p[2]
-    /swd.swdclk => con.p[4]
-    /swd.swdio  => con.p[2]
+  supports /swd():
+    ;ocdb/bundles/swd().swdclk => con.p[4]
+    ;ocdb/bundles/swd().swdio => con.p[2]
+    /swd().swdclk => con.p[4]
+    /swd().swdio  => con.p[2]

--- a/components/texas-instruments/CC2640.stanza
+++ b/components/texas-instruments/CC2640.stanza
@@ -98,7 +98,7 @@ public pcb-component component :
     uart.rx    =>    pins[0].p
     uart.tx    =>    pins[1].p
 
-  val jtag = jtag([JTAG-TRSTN])
+  val jtag = jtag()
   supports jtag:
     require pins:io-pin[3]
     jtag.tms => self.JTAG_TMSC

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -132,7 +132,7 @@ defmethod print (o:OutputStream, s:SwdOption):
   println(os, "swd.swdclk => self.%_" % [pin-name(swclk(s))])
 
 defmethod print (o:OutputStream, j:JtagOption):
-  val jtag = "jtag()" when trstn(j) is False else "jtag()"
+  val jtag = "jtag([])" when trstn(j) is False else "jtag()"
   println(o, "supports %_:" % [jtag])
   val os = IndentedStream(o)
   println(os, "%_.tck => self.%_" % [jtag, pin-name(tck(j))])

--- a/scripts/cubemx-importer.stanza
+++ b/scripts/cubemx-importer.stanza
@@ -132,7 +132,7 @@ defmethod print (o:OutputStream, s:SwdOption):
   println(os, "swd.swdclk => self.%_" % [pin-name(swclk(s))])
 
 defmethod print (o:OutputStream, j:JtagOption):
-  val jtag = "jtag()" when trstn(j) is False else "jtag([JTAG-TRSTN])"
+  val jtag = "jtag()" when trstn(j) is False else "jtag()"
   println(o, "supports %_:" % [jtag])
   val os = IndentedStream(o)
   println(os, "%_.tck => self.%_" % [jtag, pin-name(tck(j))])

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -45,7 +45,7 @@ public pcb-bundle jtag (pins:Tuple<ocdb/bundles/JTAGPins>):
     switch(p) :
       JTAG-TRSTN : make-pin(`trstn)
 
-public pcb-bundle jtag ():
+public defn jtag ():
   jtag([JTAG-TRSTN])
 
 public pcb-bundle gpio :

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -46,7 +46,7 @@ public pcb-bundle jtag (pins:Tuple<ocdb/bundles/JTAGPins>):
       JTAG-TRSTN : make-pin(`trstn)
 
 public pcb-bundle jtag ():
-  jtag([])
+  jtag([JTAG-TRSTN])
 
 public pcb-bundle gpio :
   pin gpio

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -75,10 +75,21 @@ public pcb-bundle can-interface :
   pin rx
   pin tx
 
-public pcb-bundle swd:
+public pcb-enum ocdb/bundles/SWDPins :
+  SWD-SWO
+  SWD-TRACESWO
+
+public pcb-bundle swd (pins:Tuple<ocdb/bundles/SWDPins>):
   pin swdio
   pin swdclk
+  for p in pins do :
+    switch(p) :
+      SWD-SWO : make-pin(`swo)
+      SWD-TRACESWO : make-pin(`traceswo)
 
+public defn swd ():
+  swd([])
+      
 public pcb-enum ocdb/bundles/UARTPins :
   UART-DTR
   UART-CTS
@@ -106,7 +117,6 @@ public pcb-bundle uart (pins:Tuple<UARTPins>) :
       UART-CS : make-pin(`cs)
       UART-RX : make-pin(`rx)
       UART-TX : make-pin(`tx)
-
 
 public defn uart ():
   uart([UART-RX, UART-TX])

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -127,7 +127,7 @@ public pcb-bundle usart (pins:Tuple<ocdb/bundles/UARTPins>) :
       UART-TX : make-pin(`tx)
 
 public defn usart ():
-  usart([UART-RX, UART-TX])
+  usart([UART-RX, UART-TX, UART-CK])
 
 public pcb-enum ocdb/bundles/SPIPins :
   SPI-SDO

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -471,7 +471,7 @@ public defn attach-programming-connector (proc:JITXObject, vio:JITXObject, intf:
       require swd:swd from proc
       net (swd tag.swd)
     else if intf == "jtag" :
-      require jtag:jtag([JTAG-TRSTN]) from proc
+      require jtag:jtag() from proc
       net (jtag tag.jtag)
 
 ; ========================================================

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -468,7 +468,7 @@ public defn attach-programming-connector (proc:JITXObject, vio:JITXObject, intf:
     public inst tag : ocdb/tag-connect/TC2050-IDC-NL/module
     net (vio, tag.pwr)
     if intf == "swd" :
-      require swd:swd from proc
+      require swd:swd() from proc
       net (swd tag.swd)
     else if intf == "jtag" :
       require jtag:jtag() from proc


### PR DESCRIPTION
Add default bundles for jtag and usart
jtag() ==> jtag([JTAG-TRSTN])
usart() ==> usart([UART-RX, UART-TX, UART-CK])

So instead of writing usart([UART-RX, UART-TX, UART-CK]), we just write usart()