### PR TITLE
use swd() instead of swd

### DIFF
--- a/components/st-microelectronics/stm-api.stanza
+++ b/components/st-microelectronics/stm-api.stanza
@@ -39,7 +39,7 @@ public val DEFAULT-SETTINGS = [
     `bypass-package => 4.7e-6
     `bypass-pin => 100.0e-9
     `boot-from => "flash"
-    `debug-interface => swd
+    `debug-interface => swd()
     `debug-connector => ocdb/tag-connect/TC2050-IDC-NL/module
     `HSE-freq => 16.0e6   `HSE-ppm => 30.0e-6 `HSE-source => "crystal"
     `LSE-freq => 32.768e3 `LSE-ppm => 0.05 `LSE-source => "crystal"]


### PR DESCRIPTION
JITX-797
Filling in one spot that missed the `swd` bundle change.