### PR TITLE
Added a simple unit test for land patterns

### DIFF
--- a/tests/test-landpattern-generators.stanza
+++ b/tests/test-landpattern-generators.stanza
@@ -5,8 +5,84 @@ defpackage ocdb/test/landpattern-generators:
   import jitx
   import jitx/commands
   import ocdb/land-patterns
+  import ocdb/st-microelectronics/landpatterns
 
-deftest bga-pad-names:
-  for (ch in "ABCDEFGHJKLMNPRTUVWY", r in 0 to false) do:
-    #EXPECT(bga-pin-name(r, 0) == Ref(to-string(ch))[1])
+deftest bga-pad-names : 
+  val s = "ABCDEFGHJKLMNPRTUVWY"
+  val pin-names = BGAPadNames(length(s), length(s), false)
+  for (ch in s, r in 0 to false) do:
+    #EXPECT(pin-names[r, 0] == Ref(to-string(ch))[1])
 
+defn find-silkscreen (x, name) : 
+  for layer in layers(x) find : 
+    val spec = specifier(layer)
+    match(spec:Silkscreen):
+      /name(spec) == name
+
+defn test-landpattern (lp:LandPattern, expect-pol?:True) : 
+  ; check that it has a courtyard
+  val courtyard = find({specifier(_) is Courtyard}, layers(lp))
+  #EXPECT(courtyard is-not False)
+
+  ; check that there is an indicator, if necessary
+  if expect-pol?:
+    #EXPECT(find-silkscreen(lp, "pol") is-not False)
+
+  ; check that the reference label exists
+  val ref-label = find-silkscreen(lp, "values")
+  #EXPECT(ref-label is-not False)
+
+val stm-lps = [
+  UFBGA64
+  UFBGA132
+  LFBGA100
+  LFBGA144
+  LFBGA354
+  TFBGA100
+  TFBGA216
+  TFBGA225
+  TFBGA64
+  UFBGA100
+  UFBGA121
+  UFBGA129
+  UFBGA144
+  UFBGA169
+  UFBGA73
+  WLCSP18
+  WLCSP20
+  WLCSP25
+  WLCSP36
+  WLCSP49
+  WLCSP52
+  WLCSP63
+  WLCSP64
+  WLCSP66
+  WLCSP72
+  WLCSP81
+  WLCSP90
+  WLCSP100
+  WLCSP104
+  WLCSP115
+  WLCSP132
+  WLCSP143
+  WLCSP144
+  WLCSP156
+  WLCSP168
+  WLCSP180
+  TSSOP20 
+  LQFP100
+  LQFP128
+  LQFP144
+  LQFP176
+  LQFP208
+  LQFP32
+  LQFP48
+  LQFP64
+  LQFP80
+  UFQFPN28
+  UFQFPN32
+  UFQFPN48
+]
+for lp in stm-lps do : 
+  deftest (to-string(name(lp))) : 
+    test-landpattern(lp, true)


### PR DESCRIPTION
This is a simple sanity check applied to internal land patterns : 

- Is there a courtyard
- Is there a reference label
- Is there a polarity marker, if necessary