### PR TITLE
Remove default params in query that are empty lists - temporarily remove octopart params

### DIFF
--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -56,7 +56,7 @@ pcb-module sensor-mote :
 
   ; Create a protected power and data interface for USB-2
   val protected-usb = ocdb/protection/esd-clamp(usb.usb-2, gnd) as JITXObject
-  
+
   ; Specify a power regulator and name power nets
   public inst ldo : ocdb/diodes-incorporated/AP2112/module
   net (ldo.vin protected-usb.vbus)
@@ -100,11 +100,11 @@ pcb-module sensor-mote :
 
   ; Add a BRIGHT 60.0mcd RGB led indicator to the processor (to be visible outside)
   add-rgb-indicator(60.0, proc, P3V3)
-  
+
   ; Add probe loops
-  add-testpoint([ proc.uart.tx 
-                  proc.uart.rx 
-                  hum.i2c.sda 
+  add-testpoint([ proc.uart.tx
+                  proc.uart.rx
+                  hum.i2c.sda
                   hum.i2c.scl
                   proc.en
                   proc.boot
@@ -124,7 +124,7 @@ pcb-module sensor-mote :
   schematic-group([usb, ldo, cp2105]) = power
   schematic-group(hum) = hum
   schematic-group(particle-counter) = particle-counter
-  
+
   check-design(self)
 
 ; === Setup visualizations and exports ===

--- a/designs/mcu.stanza
+++ b/designs/mcu.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx)
-defpackage ocdb/designs/tutorial :
+defpackage ocdb/designs/mcu :
   import core
   import collections
   import jitx

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -17,7 +17,7 @@ public var OPERATING-TEMPERATURE = [0.0 25.0]
 public var OPTIMIZE-FOR = ["area"]
 public var MAX-Z = 500.0
 public var MIN-PKG = "0201"
-public var DESIGN-QUANTITY = 100
+public var DESIGN-QUANTITY = 0
 public var PREFERRED-MOUNTING = "smd" ; values in ["smd", "through-hole"]
 public var MIN-CAP-VOLTAGE = 10.0 ; Minimum voltage to allow for capacitors
 

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -17,7 +17,7 @@ public var OPERATING-TEMPERATURE = [0.0 25.0]
 public var OPTIMIZE-FOR = ["area"]
 public var MAX-Z = 500.0
 public var MIN-PKG = "0201"
-public var DESIGN-QUANTITY = 0
+public var DESIGN-QUANTITY = 100
 public var PREFERRED-MOUNTING = "smd" ; values in ["smd", "through-hole"]
 public var MIN-CAP-VOLTAGE = 10.0 ; Minimum voltage to allow for capacitors
 

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -107,7 +107,7 @@ public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>, so
   if DESIGN-QUANTITY > 0 :
     add(octopart-parameters, "_stock" => DESIGN-QUANTITY)
   match(vendors: Tuple<String>) :
-    if length(vendors) != 0 :
+    if not empty?(length(vendors)) :
       add(octopart-parameters, "_sellers" => vendors)
 
   val design-parameters = Vector<KeyValue<String, ?>>()

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -105,8 +105,9 @@ public defn MicroController (user-properties:Tuple<KeyValue>, exist:Tuple<String
   val optional-properties =
     generate<KeyValue<String, ?>> :
       ; Octopart parameters: if they exist, octopart will be queried
-      yield("_stock" => DESIGN-QUANTITY) when DESIGN-QUANTITY > 0
-      yield("_sellers" => vendors) when call?<Tuple>(empty?, vendors) is-not False
+      [FIXME]: uncomment when octopart quota issue is resolved
+      ;yield("_stock" => DESIGN-QUANTITY) when DESIGN-QUANTITY > 0
+      ;yield("_sellers" => vendors) when call?<Tuple>({not empty?(_)}, vendors) is-not False
       ; Other design parameters
       yield("_sort" => sort) when not empty?(sort)
       yield("_exist" => exist) when not empty?(exist)

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -3,6 +3,8 @@ defpackage ocdb/micro-controllers :
   import core
   import collections
   import json
+  import lang-utils
+
   import jitx
   import jitx/commands
   import jitx/param-sets
@@ -90,43 +92,41 @@ public defn MicroController (json: JObject) -> MicroController :
                   create-bundles(json),
                   create-supports(json))
 
-public defn MicroController (properties:Tuple<KeyValue>) -> MicroController :
-  MicroController(properties, [])
+public defn MicroController (user-properties:Tuple<KeyValue>) -> MicroController :
+  MicroController(user-properties, [])
 
-public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>) -> MicroController :
-  MicroController(properties, exist, OPTIMIZE-FOR, OPERATING-TEMPERATURE)
+public defn MicroController (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> MicroController :
+  MicroController(user-properties, exist, OPTIMIZE-FOR, OPERATING-TEMPERATURE)
 
-public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>, sort:Tuple<String>, operating-temperature:[Double, Double]|False) -> MicroController :
+public defn MicroController (user-properties:Tuple<KeyValue>, exist:Tuple<String>, sort:Tuple<String>, operating-temperature:[Double, Double]|False) -> MicroController :
   val params = jitx-params()
   val vendors = bom-vendors(params)
 
-  val octopart-parameters = Vector<KeyValue<String, ?>>()
-  if DESIGN-QUANTITY > 0 :
-    add(octopart-parameters, "_stock" => DESIGN-QUANTITY)
-  match(vendors: Tuple<String>) :
-    if not empty?(length(vendors)) :
-      add(octopart-parameters, "_sellers" => vendors)
+  val optional-properties =
+    generate<KeyValue<String, ?>> :
+      ; Octopart parameters: if they exist, octopart will be queried
+      yield("_stock" => DESIGN-QUANTITY) when DESIGN-QUANTITY > 0
+      yield("_sellers" => vendors) when call?<Tuple>(empty?, vendors) is-not False
+      ; Other design parameters
+      yield("_sort" => sort) when not empty?(sort)
+      yield("_exist" => exist) when not empty?(exist)
+      match(operating-temperature:[Double, Double]):
+        yield("max-rated-temperature.min" => operating-temperature[0])
+        yield("min-rated-temperature.max" => operating-temperature[1])
 
-  val design-parameters = Vector<KeyValue<String, ?>>()
-  if not empty?(sort) :
-    add(design-parameters, "_sort" => sort)
-  if not empty?(exist) :
-    add(design-parameters, "_exist" => exist)
-  match(operating-temperature: [Double, Double]) :
-    add-all(design-parameters, ["max-rated-temperature.min" => operating-temperature[0],
-                                "min-rated-temperature.max" => operating-temperature[1]])
+  ; `user-properties` override default properties
+  val query-properties = to-tuple $ hashtable-union<String, ?> $ [["category" => "microcontroller"],
+                                                                  optional-properties,
+                                                                  user-properties]
 
-  val query-properties = to-tuple $ cat-all([["category" => "microcontroller"],
-                                             octopart-parameters,
-                                             design-parameters,
-                                             properties])
+  val jobjects = dbquery-all(query-properties) as Tuple<JObject>
+  throw(NoComponentMeetingRequirements(query-properties)) when empty?(jobjects)
+  MicroController(jobjects[0])
 
-
-  val jsons = dbquery-all(query-properties) as Tuple<JObject>
-  if length(jsons) == 0 :
-    throw(NoComponentMeetingRequirements(query-properties))
-  else :
-    MicroController(jsons[0])
+; FIXME: add to collections.stanza with hashset-union used in query.stanza ?
+; Behaviour: to-tuple $ hashtable-union $ [["category" => "microcontroller"], ["c" => 2], ["category" => "qwerty"]] -> ["c" => 2 "category" => "qwerty"]
+public defn hashtable-union<K, V> (hs:Seqable<Seqable<KeyValue<K&Equalable&Hashable, V>>>) -> HashTable<K, V> :
+  to-hashtable<K, V>(cat-all(hs))
 
 ;============================================================
 ;======================= MCU to JITX ========================

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -97,33 +97,34 @@ public defn MicroController (properties:Tuple<KeyValue>) -> MicroController :
   MicroController(properties, [])
 
 public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>) -> MicroController :
-  MicroController(properties, exist, OPTIMIZE-FOR, ["max-rated-temperature.min" => OPERATING-TEMPERATURE[0],
-                                                    "min-rated-temperature.max" => OPERATING-TEMPERATURE[1]])
+  MicroController(properties, exist, OPTIMIZE-FOR, OPERATING-TEMPERATURE)
 
-public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>, sort:Tuple<String>, temperature-properties:Tuple<KeyValue>) -> MicroController :
+public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>, sort:Tuple<String>, operating-temperature:[Double, Double]|False) -> MicroController :
   val params = jitx-params()
   val vendors = bom-vendors(params)
-  val vendor-properties =
-    match(vendors: Tuple<String>) :
-      ["_sellers" => vendors]
-    else :
-      []
-  var query-properties = []
-  if DESIGN-QUANTITY == 0:
-    query-properties = to-tuple $ cat-all([["category" => "microcontroller",
-                                                "_sort" => sort,
-                                                "_exist" => exist],
-                                              vendor-properties
-                                              temperature-properties,
-                                              properties])
-  else :
-    query-properties = to-tuple $ cat-all([["category" => "microcontroller",
-                                            "_sort" => sort,
-                                            "_exist" => exist,
-                                            "_stock" => DESIGN-QUANTITY],
-                                          vendor-properties
-                                          temperature-properties,
-                                          properties])
+
+  val octopart-parameters = Vector<KeyValue<String, ?>>()
+  if DESIGN-QUANTITY > 0 :
+    add(octopart-parameters, "_stock" => DESIGN-QUANTITY)
+  match(vendors: Tuple<String>) :
+    if length(vendors) != 0 :
+      add(octopart-parameters, "_sellers" => vendors)
+
+  val design-parameters = Vector<KeyValue<String, ?>>()
+  if not empty?(sort) :
+    add(design-parameters, "_sort" => sort)
+  if not empty?(exist) :
+    add(design-parameters, "_exist" => exist)
+  match(operating-temperature: [Double, Double]) :
+    add-all(design-parameters, ["max-rated-temperature.min" => operating-temperature[0],
+                                "min-rated-temperature.max" => operating-temperature[1]])
+
+
+  val query-properties = to-tuple $ cat-all([["category" => "microcontroller"],
+                                             octopart-parameters,
+                                             design-parameters,
+                                             properties])
+
   val jsons = dbquery-all(query-properties) as Tuple<JObject>
   if length(jsons) == 0 :
     throw(NoComponentMeetingRequirements(query-properties))

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -107,7 +107,7 @@ public defn MicroController (user-properties:Tuple<KeyValue>, exist:Tuple<String
       ; Octopart parameters: if they exist, octopart will be queried
       [FIXME]: uncomment when octopart quota issue is resolved
       ;yield("_stock" => DESIGN-QUANTITY) when DESIGN-QUANTITY > 0
-      ;yield("_sellers" => vendors) when call?<Tuple>({not empty?(_)}, vendors) is-not False
+      ;yield("_sellers" => vendors) when call?<Tuple>({not empty?(_)}, vendors)
       ; Other design parameters
       yield("_sort" => sort) when not empty?(sort)
       yield("_exist" => exist) when not empty?(exist)


### PR DESCRIPTION
I think I need to see what is going on with the octopart logic in the backend when stock != 0, in the mean time we can use stock=0 by default which won't call the octopart logic by default (thanks to jitx-client PR https://github.com/JITx-Inc/jitx-client/pull/356 that removes default sellers).

This will also remove the stock requirements on resistors / inductors / capacitors which was useful.
Will revert default stock when I find out if something is off with the octopart logic, will probably reduce it as 100 is small for resistors but a lot for mcus.