### PR TITLE
Stm error handling

### DIFF
--- a/components/st-microelectronics/landpatterns.stanza
+++ b/components/st-microelectronics/landpatterns.stanza
@@ -257,3 +257,55 @@ public pcb-landpattern UFQFPN48:
                       tol(0.4, 0.1),   ;Lead size in x direction:   L
                       tol(0.25, 0.05), ;Lead size in y direction:   b
                       GeneralChamferedRectangle(5.6, 5.6, [0.5 0. 0. 0.]))
+
+public val STM32-LAND-PATTERNS = [
+  UFBGA64
+  UFBGA132
+  LFBGA100
+  LFBGA144
+  LFBGA354
+  TFBGA100
+  TFBGA216
+  TFBGA225
+  TFBGA64
+  UFBGA100
+  UFBGA121
+  UFBGA129
+  UFBGA144
+  UFBGA169
+  UFBGA73
+  WLCSP18
+  WLCSP20
+  WLCSP25
+  WLCSP36
+  WLCSP49
+  WLCSP52
+  WLCSP63
+  WLCSP64
+  WLCSP66
+  WLCSP72
+  WLCSP81
+  WLCSP90
+  WLCSP100
+  WLCSP104
+  WLCSP115
+  WLCSP132
+  WLCSP143
+  WLCSP144
+  WLCSP156
+  WLCSP168
+  WLCSP180
+  TSSOP20 
+  LQFP100
+  LQFP128
+  LQFP144
+  LQFP176
+  LQFP208
+  LQFP32
+  LQFP48
+  LQFP64
+  LQFP80
+  UFQFPN28
+  UFQFPN32
+  UFQFPN48
+]

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -62,6 +62,7 @@ public defstruct MicroController <: Component :
   bundles: Tuple<STMBundle>
   supports: Tuple<STMSupports>
 
+
 public defn MicroController (json: JObject) -> MicroController :
   val [x, y, z] = parse-dimensions(json["dimensions"] as JObject)
 
@@ -130,68 +131,20 @@ public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>, so
 ;============================================================
 ;======================= MCU to JITX ========================
 ;============================================================
+pcb-component mcu-component (manu:String, pn:String, pp:STMPinProperties, supports:Tuple<STMSupports>, bundles:Tuple<STMBundle>, pkg:String) :
+  manufacturer = manu
+  mpn = pn
+  to-jitx-pin-properties(pp)
+  ; println(pp)
+  val bundle-table = to-jitx-bundles(bundles)
+  to-jitx-supports(supports, bundle-table)
+  val lp = find({name(_) == pkg}, STM32-LAND-PATTERNS)
+  throw(Exception("%_ is not a supported package." % [pkg])) when lp is False
+  assign-landpattern(lp as LandPattern)
+  make-box-symbol()
 
-defmethod to-jitx (mcu: MicroController) -> Instantiable :
-  pcb-component my-microcontroller :
-    manufacturer = manufacturer(mcu)
-    mpn = mpn(mcu)
-
-    to-jitx-pin-properties(pin-properties(mcu))
-    val bundle-table = to-jitx-bundles(bundles(mcu))
-    to-jitx-supports(supports(mcu), bundle-table)
-
-    assign-landpattern $
-      switch(mfg-package(mcu)) :
-        "LQFP100" : LQFP100
-        "LQFP128" : LQFP128
-        "LQFP144" : LQFP144
-        "LQFP176" : LQFP176
-        "LQFP208" : LQFP208
-        "LQFP48" : LQFP48
-        "UFQFPN28" : UFQFPN28
-        "UFQFPN32" : UFQFPN32
-        "UFQFPN48" : UFQFPN48
-        "LFBGA100" : LFBGA100
-        "LFBGA144" : LFBGA144
-        "LFBGA354" : LFBGA354
-        "TFBGA100" : TFBGA100
-        "TFBGA216" : TFBGA216
-        "TFBGA225" : TFBGA225
-        "TFBGA64" : TFBGA64
-        "UFBGA100" : UFBGA100
-        "UFBGA121" : UFBGA121
-        "UFBGA129" : UFBGA129
-        "UFBGA132" : UFBGA132
-        "UFBGA144" : UFBGA144
-        "UFBGA169" : UFBGA169
-        "UFBGA64" : UFBGA64
-        "UFBGA73" : UFBGA73
-        "WLCSP100" : WLCSP100
-        "WLCSP104" : WLCSP104
-        "WLCSP115" : WLCSP115
-        "WLCSP132" : WLCSP132
-        "WLCSP143" : WLCSP143
-        "WLCSP144" : WLCSP144
-        "WLCSP156" : WLCSP156
-        "WLCSP168" : WLCSP168
-        "WLCSP18" : WLCSP18
-        "WLCSP180" : WLCSP180
-        "WLCSP20" : WLCSP20
-        "WLCSP25" : WLCSP25
-        "WLCSP36" : WLCSP36
-        "WLCSP49" : WLCSP49
-        "WLCSP52" : WLCSP52
-        "WLCSP63" : WLCSP63
-        "WLCSP64" : WLCSP64
-        "WLCSP66" : WLCSP66
-        "WLCSP72" : WLCSP72
-        "WLCSP81" : WLCSP81
-        "WLCSP90" : WLCSP90
-        else :
-          fatal("MCU package %_ is not supported." % [mfg-package(mcu)])
-    make-box-symbol()
-  my-microcontroller
-
+public defmethod to-jitx (m:MicroController) : 
+  mcu-component(manufacturer(m), mpn(m), pin-properties(m), supports(m), bundles(m), mfg-package(m))
 
 ;============================================================
 ;====================== Printer =============================

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -135,7 +135,6 @@ pcb-component mcu-component (manu:String, pn:String, pp:STMPinProperties, suppor
   manufacturer = manu
   mpn = pn
   to-jitx-pin-properties(pp)
-  ; println(pp)
   val bundle-table = to-jitx-bundles(bundles)
   to-jitx-supports(supports, bundle-table)
   val lp = find({name(_) == pkg}, STM32-LAND-PATTERNS)

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -134,9 +134,9 @@ public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>, so
 pcb-component mcu-component (manu:String, pn:String, pp:STMPinProperties, supports:Tuple<STMSupports>, bundles:Tuple<STMBundle>, pkg:String) :
   manufacturer = manu
   mpn = pn
-  to-jitx-pin-properties(pp)
+  val mappings = to-jitx-pin-properties(pp)
   val bundle-table = to-jitx-bundles(bundles)
-  to-jitx-supports(supports, bundle-table)
+  to-jitx-supports(supports, bundle-table, mappings)
   val lp = find({name(_) == pkg}, STM32-LAND-PATTERNS)
   throw(Exception("%_ is not a supported package." % [pkg])) when lp is False
   assign-landpattern(lp as LandPattern)

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -9,7 +9,6 @@ defpackage ocdb/micro-controllers :
   import jitx/params
   import jitx/param-manager
   import jitx/errors
-
   import ocdb/land-patterns
   import ocdb/design-vars
   import ocdb/property-structs
@@ -101,25 +100,19 @@ public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>) ->
 public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>, sort:Tuple<String>, temperature-properties:Tuple<KeyValue>) -> MicroController :
   val params = jitx-params()
   val vendors = bom-vendors(params)
-  val vendor-properties =
-    match(vendors: Tuple<String>) :
-      ["_sellers" => vendors]
-    else :
-      []
+
   var query-properties = []
   if DESIGN-QUANTITY == 0:
     query-properties = to-tuple $ cat-all([["category" => "microcontroller",
                                                 "_sort" => sort,
                                                 "_exist" => exist],
-                                              vendor-properties
                                               temperature-properties,
                                               properties])
   else :
     query-properties = to-tuple $ cat-all([["category" => "microcontroller",
                                             "_sort" => sort,
                                             "_exist" => exist,
-                                            "_stock" => DESIGN-QUANTITY],
-                                          vendor-properties
+                                            ],
                                           temperature-properties,
                                           properties])
   val jsons = dbquery-all(query-properties) as Tuple<JObject>

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -131,9 +131,9 @@ public defn MicroController (properties:Tuple<KeyValue>, exist:Tuple<String>, so
 ;============================================================
 ;======================= MCU to JITX ========================
 ;============================================================
-pcb-component mcu-component (manu:String, pn:String, pp:STMPinProperties, supports:Tuple<STMSupports>, bundles:Tuple<STMBundle>, pkg:String) :
-  manufacturer = manu
-  mpn = pn
+pcb-component mcu-component (manufacturer:String, mpn:String, pp:STMPinProperties, supports:Tuple<STMSupports>, bundles:Tuple<STMBundle>, pkg:String) :
+  manufacturer = manufacturer
+  mpn = mpn
   val mappings = to-jitx-pin-properties(pp)
   val bundle-table = to-jitx-bundles(bundles)
   to-jitx-supports(supports, bundle-table, mappings)

--- a/utils/stm-to-jitx.stanza
+++ b/utils/stm-to-jitx.stanza
@@ -27,7 +27,8 @@ defn stm-to-jitx (voltage-limits:STMVoltageLimits) -> Interval :
   Interval(min-val(voltage-limits), max-val(voltage-limits), false)
 
 ;Generate pin-properties inside of a component.
-public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> False :
+public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTable<String, String> :
+  val pin-pad-remapping = HashTable<String, String|Int>()
   inside pcb-component :
     val generic-props = stm-to-jitx $ generic-pin(pin-properties)
     val power-props = stm-to-jitx $ power-pin(pin-properties)
@@ -42,31 +43,35 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> False :
     if not numeric-pads? and not named-pads? :
       fatal("Generated a micro-controller without pads.") 
     
+    ; We need to compile a list of reused pad to pin mappings.
+    val pad-mappings = HashTable<String|Int, Vector<String>>()
+    defn check-pad (pad:String|Int, pin:String):
+      if get?(pad-mappings, pad) is False : 
+        pad-mappings[pad] = Vector<String>()
+      add(pad-mappings[pad], pin)
+      length(pad-mappings[pad]) == 1
+
     ;Generate the pin-properties.
     ;Cases are split between Int and Ref pads, and across generic and power properties usages.
-    if numeric-pads? :
-      pin-properties :
-        [pin:Ref | pads:Int ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
-        for row in rows(pin-properties) do :
-          val pin-ref = ref-string-to-ref(pin(row))
-          val pad-index = pad(row) as Int
+    pin-properties : 
+      [pin:Ref | pads : (String|Int) ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
+      for row in rows(pin-properties) do : 
+        val pin-ref = ref-string-to-ref(pin(row))
+        val pad-ref = pad(row)
+        if check-pad(pad-ref, pin(row)) : 
           match(generic-props?(row), power-props?(row)) :
-            (g:True, p:True)   : [(pin-ref) | pad-index | side(row) | generic-props | power-props]
-            (g:True, p:False)  : [(pin-ref) | pad-index | side(row) | generic-props |      -     ]
-            (g:False, p:True)  : [(pin-ref) | pad-index | side(row) |       -       | power-props]
-            (g:False, p:False) : [(pin-ref) | pad-index | side(row) |       -       |      -     ]
-    else :
-      pin-properties :
-        [pin:Ref | pads:Ref ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
-        for row in rows(pin-properties) do :
-          val pin-ref = ref-string-to-ref(pin(row))
-          val pad-name = raw-string-to-ref(pad(row) as String)
-          match(generic-props?(row), power-props?(row)) :
-            (g:True, p:True)   : [(pin-ref) | (pad-name) | side(row) | generic-props | power-props]
-            (g:True, p:False)  : [(pin-ref) | (pad-name) | side(row) | generic-props |      -     ]
-            (g:False, p:True)  : [(pin-ref) | (pad-name) | side(row) |       -       | power-props]
-            (g:False, p:False) : [(pin-ref) | (pad-name) | side(row) |       -       |      -     ]
-
+            (g:True, p:True)   : [(pin-ref) | (pad-ref) | side(row) | generic-props | power-props]
+            (g:True, p:False)  : [(pin-ref) | (pad-ref) | side(row) | generic-props |      -     ]
+            (g:False, p:True)  : [(pin-ref) | (pad-ref) | side(row) |       -       | power-props]
+            (g:False, p:False) : [(pin-ref) | (pad-ref) | side(row) |       -       |      -     ]
+    
+    to-hashtable<String, String> $ 
+      for shared in values(pad-mappings) seq-cat : 
+        var root: String|False = false
+        for pin in shared seq : 
+          if root is False:
+            root = pin
+          pin => (root as String) 
 ;Generate all bundles and store them in a table indexed by name.
 public defn to-jitx-bundles (bundles:Tuple<STMBundle>) -> HashTable<String, Bundle> :
   val bundle-table = HashTable<String, Bundle>()
@@ -79,7 +84,13 @@ public defn to-jitx-bundles (bundles:Tuple<STMBundle>) -> HashTable<String, Bund
   bundle-table
 
 ;Generate all support statements inside of a component which will include bundles from bundle-table.
-public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTable<String, Bundle>) -> False :
+public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTable<String, Bundle>, pin-name-table:HashTable<String, String>) -> False :
+  defn lookup-pin (pin-name:String) : 
+    ref-string-to-ref $ 
+      match(get?(pin-name-table, pin-name)) : 
+        (s:String): s
+        (f:False): pin-name
+  
   ;Generate a supports statement for a bundle with the given mappings.
   defn generate-support (b:Bundle, mappings:Tuple<STMSupportMapping>) :
     inside pcb-component :
@@ -88,14 +99,11 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
           ;Left hand side of the mapping is the bundle pin.
           val key = dot(b, ref-string-to-ref(bundle-pin(mapping)))
           ;Right hand side of the mapping is a local or required pin.
-          val value =
-            match(require(mapping)) :
-              (req:String) :
-                val req-bundle = bundle-table[req]
-                require p0 : req-bundle
-                dot(p0, ref-string-to-ref(pin(mapping)))
-              (req:False) :
-                dot(self, ref-string-to-ref(pin(mapping)))
+          val value = match(require(mapping)): 
+            (req:False): dot(self, lookup-pin(pin(mapping)))
+            (req:String):
+              require p0: bundle-table[req]
+              dot(p0, lookup-pin(pin(mapping)))
           key => value
 
   ;Generate a supports statement for a bundle b with the given mappings.
@@ -105,26 +113,25 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
       supports b1 :
         option :
           for mapping in mappings do :
+            println("mapping:%_" % [mapping])
             ;Left hand side of the mapping is the bundle pin.
             val key = dot(b1, ref-string-to-ref(bundle-pin(mapping)))
             ;Right hand side of the mapping is a local or required pin.
-            val value =
-              match(require(mapping)) :
-                (req:String) :
-                  val req-bundle = bundle-table[req]
-                  require p0 : req-bundle
-                  dot(p0, ref-string-to-ref(pin(mapping)))
-                (req:False) :
-                  dot(self, ref-string-to-ref(pin(mapping)))
+            val value = match(require(mapping)): 
+              (req:False): 
+                dot(self, lookup-pin(pin(mapping)))
+              (req:String): 
+                require p0: bundle-table[req]
+                dot(p0, lookup-pin(pin(mapping)))
             key => value
         option :
-          require myb2 : b2
+          require p : b2
           for mapping in mappings do :
             val bundle-pin-name = ref-string-to-ref(bundle-pin(mapping))
             ;Left hand side of the mapping is the bundle pin.
             val key = dot(b1, bundle-pin-name)
             ;Right hand side of the mapping is a required pin from the alternate bundle.
-            val value = dot(myb2, bundle-pin-name)
+            val value = dot(p, bundle-pin-name)
             key => value
   
   for support in supports do :

--- a/utils/stm-to-jitx.stanza
+++ b/utils/stm-to-jitx.stanza
@@ -33,7 +33,7 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> False :
     val power-props = stm-to-jitx $ power-pin(pin-properties)
     
     ;Determine if the pads numeric (Double -> Int) or named (Ref -> String).
-    val numeric-pads? = any?({pad(_) is Double}, rows(pin-properties))
+    val numeric-pads? = any?({pad(_) is Int}, rows(pin-properties))
     val named-pads? = any?({pad(_) is String}, rows(pin-properties))
     
     ;If the pads are neither or both, then we are using malformed data.
@@ -49,7 +49,7 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> False :
         [pin:Ref | pads:Int ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
         for row in rows(pin-properties) do :
           val pin-ref = ref-string-to-ref(pin(row))
-          val pad-index = to-int(pad(row) as Double)
+          val pad-index = pad(row) as Int
           match(generic-props?(row), power-props?(row)) :
             (g:True, p:True)   : [(pin-ref) | pad-index | side(row) | generic-props | power-props]
             (g:True, p:False)  : [(pin-ref) | pad-index | side(row) | generic-props |      -     ]

--- a/utils/stm-to-jitx.stanza
+++ b/utils/stm-to-jitx.stanza
@@ -44,8 +44,10 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTabl
       fatal("Generated a micro-controller without pads.") 
     
     ; We need to compile a list of reused pad to pin mappings.
-    val pad-mappings = HashTable<String|Int, Vector<String>>(Vector<String>)
-    defn check-pad (pad:String|Int, pin:String) : 
+    val pad-mappings = HashTable<String|Int, Vector<String>>()
+    defn check-pad (pad:String|Int, pin:String):
+      if get?(pad-mappings, pad) is False : 
+        pad-mappings[pad] = Vector<String>()
       add(pad-mappings[pad], pin)
       length(pad-mappings[pad]) == 1
 
@@ -115,6 +117,7 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
       supports b1 :
         option :
           for mapping in mappings do :
+            println("mapping:%_" % [mapping])
             ;Left hand side of the mapping is the bundle pin.
             val key = dot(b1, ref-string-to-ref(bundle-pin(mapping)))
             ;Right hand side of the mapping is a local or required pin.

--- a/utils/stm-to-jitx.stanza
+++ b/utils/stm-to-jitx.stanza
@@ -44,21 +44,22 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTabl
       fatal("Generated a micro-controller without pads.") 
     
     ; We need to compile a list of reused pad to pin mappings.
-    val pad-mappings = HashTable<String|Int, Vector<String>>()
-    defn check-pad (pad:String|Int, pin:String):
-      if get?(pad-mappings, pad) is False : 
-        pad-mappings[pad] = Vector<String>()
+    val pad-mappings = HashTable<String|Int, Vector<String>>(Vector<String>)
+    defn check-pad (pad:String|Int, pin:String) : 
       add(pad-mappings[pad], pin)
       length(pad-mappings[pad]) == 1
 
     ;Generate the pin-properties.
     ;Cases are split between Int and Ref pads, and across generic and power properties usages.
     pin-properties : 
-      [pin:Ref | pads : (String|Int) ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
+      [pin:Ref | pads : (Ref|Int) ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
       for row in rows(pin-properties) do : 
         val pin-ref = ref-string-to-ref(pin(row))
-        val pad-ref = pad(row)
-        if check-pad(pad-ref, pin(row)) : 
+        val pad-ref = match(pad(row)):
+          (i:Int): i
+          (s:String): raw-string-to-ref(s)
+
+        if check-pad(pad(row), pin(row)) : 
           match(generic-props?(row), power-props?(row)) :
             (g:True, p:True)   : [(pin-ref) | (pad-ref) | side(row) | generic-props | power-props]
             (g:True, p:False)  : [(pin-ref) | (pad-ref) | side(row) | generic-props |      -     ]
@@ -71,7 +72,8 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTabl
         for pin in shared seq : 
           if root is False:
             root = pin
-          pin => (root as String) 
+          pin => (root as String)
+
 ;Generate all bundles and store them in a table indexed by name.
 public defn to-jitx-bundles (bundles:Tuple<STMBundle>) -> HashTable<String, Bundle> :
   val bundle-table = HashTable<String, Bundle>()
@@ -113,7 +115,6 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
       supports b1 :
         option :
           for mapping in mappings do :
-            println("mapping:%_" % [mapping])
             ;Left hand side of the mapping is the bundle pin.
             val key = dot(b1, ref-string-to-ref(bundle-pin(mapping)))
             ;Right hand side of the mapping is a local or required pin.

--- a/utils/stm.stanza
+++ b/utils/stm.stanza
@@ -7,8 +7,8 @@ defpackage ocdb/stm:
   import reader
   import jitx
 
-defstruct StmError <: Exception : 
-  message:?
+public defstruct StmError <: Exception : 
+  message:String|Printable
 
 defmethod print (o:OutputStream, e:StmError) : 
   print(o, "Could not extract STM component. %_." % [message(e)])
@@ -23,12 +23,12 @@ public pcb-struct ocdb/stm/STMPinProperties :
   power-pin: STMPowerPin
   rows: Tuple<STMPinPropertiesRow>
 
-public pcb-struct  ocdb/stm/STMGenericPin :
+public pcb-struct ocdb/stm/STMGenericPin :
   pin-name: String
   max-voltage: STMVoltageLimits
   rated-esd: Double
 
-public pcb-struct  ocdb/stm/STMPowerPin :
+public pcb-struct ocdb/stm/STMPowerPin :
   pin-name: String
   recommended-voltage: STMVoltageLimits
 
@@ -136,7 +136,7 @@ defmethod print (o:OutputStream, s:STMSupportMapping) :
 ;=================================================
 ;================= Build Structs =================
 ;=================================================
-defn stm-error (x) : 
+defn stm-exception! (x) : 
   throw(StmError(x))
 
 ;This function creates STMSupports from the "supports" section in the JSON.
@@ -150,11 +150,11 @@ public defn create-supports (json:JSON) -> Tuple<STMSupports> :
             ;Read the bundle's name.
             val bundle-name = match(supported-bundle["name"]) :
               (bundle-name:String) : bundle-name
-              (bundle-name) : stm-error("Invalid Supported Bundle Name")
+              (bundle-name) : stm-exception!("Invalid Supported Bundle Name")
             ;Read the bundle's pin options.
             val bundle-options = match(supported-bundle["options"]) :
               (bundle-options:Tuple<String>) : bundle-options
-              (bundle-options) : stm-error("Invalid Supported Bundle Options")
+              (bundle-options) : stm-exception!("Invalid Supported Bundle Options")
             STMSupportsBundle(bundle-name, bundle-options)
         ;Build the collection of STMSupportMappings.
         val mappings = match(support["mappings"]) :
@@ -164,20 +164,20 @@ public defn create-supports (json:JSON) -> Tuple<STMSupports> :
               ;Read the name of the bundle pin (ex. "p")
               val bundle-pin = match(mapping["bundle-pin"]) :
                 (bundle-pin:String) : bundle-pin
-                (bundle-pin) : stm-error("Invalid Mapping Bundle Pin")
+                (bundle-pin) : stm-exception!("Invalid Mapping Bundle Pin")
               ;Read the name of the required pin (ex. "required-pin")
               val require = match(mapping["require"]) :
                 (require:String|False) : require
-                (require) : stm-error("Invalid Mapping Require")
+                (require) : stm-exception!("Invalid Mapping Require")
               ;Read the name of the mapped pin (ex. "q")
               val pin = match(mapping["pin"]) :
                 (pin:String) : pin
-                (pin) : stm-error("Invalid Mapping Pin")
+                (pin) : stm-exception!("Invalid Mapping Pin")
               STMSupportMapping(bundle-pin, require, pin)
-          (mappings) : stm-error("Invalid Support Mappings")
+          (mappings) : stm-exception!("Invalid Support Mappings")
         ;Bring the bundle and mappings together to create one STMSupports
         STMSupports(supported-bundle, mappings)
-    (supports) : stm-error("Invalid Supports")
+    (supports) : stm-exception!("Invalid Supports")
 
 public defn create-bundles (json1:JSON) -> Tuple<STMBundle> :
   val bundles = Vector<STMBundle>()
@@ -188,9 +188,9 @@ public defn create-bundles (json1:JSON) -> Tuple<STMBundle> :
       ;Each name should be a String bundle name
       for name in json do :
         match(name:String) : add(bundles, STMBundle(name))
-        else : stm-error("Invalid JSON")
+        else : stm-exception!("Invalid JSON")
     (json) :
-      stm-error("Invalid JSON")
+      stm-exception!("Invalid JSON")
   
   to-tuple(bundles)
 
@@ -205,26 +205,26 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
     (gen-pin: JObject) :
       val name = match(gen-pin["name"]) :
         (name : String) : name
-        (name) : stm-error("Invalid Generic Pin Name")
+        (name) : stm-exception!("Invalid Generic Pin Name")
       val rated-esd = match(gen-pin["rated-esd"]) :
         (rated-esd: Double) : rated-esd
-        (rated-esd) : stm-error("Invalid rated-esd")
+        (rated-esd) : stm-exception!("Invalid rated-esd")
       var max-voltage-data
       match(gen-pin["max-voltage"]) :
         (max-volt-data: JObject) :
           val min-volts = match(max-volt-data["min"]) :
             (min-volts-double:Double) : min-volts-double
-            (min-volts) : stm-error("Invalid max-voltage data")
+            (min-volts) : stm-exception!("Invalid max-voltage data")
           val max-volts = match(max-volt-data["max"]) :
             (max-volts-double:Double) : max-volts-double
-            (max-volts) : stm-error("Invalid max-voltage data")
+            (max-volts) : stm-exception!("Invalid max-voltage data")
           val nominal = match(max-volt-data["nominal"]) :
             (nominal:True) : nominal
             (nominal:False) : nominal
-            (nominal) : stm-error("Invalid nominal data")
+            (nominal) : stm-exception!("Invalid nominal data")
           max-voltage-data = STMVoltageLimits(min-volts, max-volts, nominal)
         (max-volt-data) :
-          stm-error("Invalid JSON")
+          stm-exception!("Invalid JSON")
       stm-gen-pin = STMGenericPin(name, max-voltage-data, rated-esd)
 
   val power-pin = pin-prop["power-pin"]
@@ -233,7 +233,7 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
     (pow-pin: JObject) :
       val name = match(pow-pin["name"]) :
         (name : String) : name
-        (name) : stm-error("Invalid Power Pin Name")
+        (name) : stm-exception!("Invalid Power Pin Name")
       val recommended-volt-data = pow-pin["recommended-voltage"]
       var recommended-voltage-data
 
@@ -241,17 +241,17 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
         (recommended-volt-data: JObject) :
           val min-volts = match(recommended-volt-data["min"]) :
             (min-volts-double:Double) : min-volts-double
-            (min-volts) : stm-error("Invalid recommended-voltage min data")
+            (min-volts) : stm-exception!("Invalid recommended-voltage min data")
           val max-volts = match(recommended-volt-data["max"]) :
             (max-volts-double:Double) : max-volts-double
-            (max-volts) : stm-error("Invalid recommended-voltage max data")
+            (max-volts) : stm-exception!("Invalid recommended-voltage max data")
           val nominal = match(recommended-volt-data["nominal"]) :
             (nominal:True) : nominal
             (nominal:False) : nominal
-            (nominal) : stm-error("Invalid nominal data")
+            (nominal) : stm-exception!("Invalid nominal data")
           recommended-voltage-data = STMVoltageLimits(min-volts, max-volts, nominal)
         (recommended-volt-data) :
-          stm-error("Invalid JSON") 
+          stm-exception!("Invalid JSON") 
 
       stm-pow-pin = STMPowerPin(name, recommended-voltage-data)
 
@@ -262,11 +262,11 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
       for pin-item in pins do :
         val pin-name = match(pin-item["pin"]) :
           (pin-name:String) : pin-name
-          (pin-name) : stm-error("Invalid Pin Name: %_" % [pin-name])
+          (pin-name) : stm-exception!("Invalid Pin Name: %_" % [pin-name])
         val pad-name = match(pin-item["pad"]) :
           (pad-double:Double) : to-int(pad-double)
           (pad-str:String) : pad-str
-          (pad-data) : stm-error("Invalid Pad Value:%_" % [pad-data])
+          (pad-data) : stm-exception!("Invalid Pad Value:%_" % [pad-data])
         val side = match(pin-item["side"]) :
           (side-val:String) : 
             switch(side-val) :
@@ -274,21 +274,21 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
               "Down" : Down,
               "Left" : Left,
               "Right" : Right
-          (side-val) : stm-error("Invalid Pin Name")
+          (side-val) : stm-exception!("Invalid Pin Name")
         
         val power-props? = match(pin-item["power-pin?"]) :
           (power-val:True) : power-val
           (power-val:False) : power-val
-          (power-val) : stm-error("Invalid Power Value")
+          (power-val) : stm-exception!("Invalid Power Value")
 
         val generic-props? = match(pin-item["generic-pin?"]) :
           (generic-val:True) : generic-val
           (generic-val:False) : generic-val
-          (generic-val) : stm-error("Invalid Generic Value")
+          (generic-val) : stm-exception!("Invalid Generic Value")
 
         add(pin-properties, STMPinPropertiesRow(pin-name, pad-name, side, generic-props?, power-props?))
     (j) :
-      stm-error("Invalid JSON")
+      stm-exception!("Invalid JSON")
 
   val stm-properties = STMPinProperties(stm-gen-pin, stm-pow-pin, to-tuple(pin-properties))
   stm-properties

--- a/utils/stm.stanza
+++ b/utils/stm.stanza
@@ -30,7 +30,6 @@ public pcb-struct ocdb/stm/STMPinProperties :
   generic-pin: STMGenericPin
   power-pin: STMPowerPin
   rows: Tuple<STMPinProperties-Row>
-  duplicates: Tuple<KeyValue<String, String>>
 
 public pcb-struct  ocdb/stm/STMGenericPin :
   pin-name: String
@@ -307,5 +306,5 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
   val multi-pins = to-tuple $ for p in pads-in-use filter : 
     length(value(p)) > 1
   throw(MultiplePinsMappedToSamePad(multi-pins)) when not empty?(multi-pins)
-  val stm-properties = STMPinProperties(stm-gen-pin, stm-pow-pin, to-tuple(pin-properties), [])
+  val stm-properties = STMPinProperties(stm-gen-pin, stm-pow-pin, to-tuple(pin-properties))
   stm-properties

--- a/utils/stm.stanza
+++ b/utils/stm.stanza
@@ -1,3 +1,4 @@
+#use-added-syntax(jitx)
 defpackage ocdb/stm:
   import core
   import collections
@@ -6,34 +7,49 @@ defpackage ocdb/stm:
   import reader
   import jitx
 
+defstruct StmError <: Exception : 
+  message:?
+
+defmethod print (o:OutputStream, e:StmError) : 
+  print(o, "Could not extract STM component. %_." % [message(e)])
+
+defstruct MultiplePinsMappedToSamePad <: Exception : 
+  multi-pins: Tuple<KeyValue<String|Int, Seqable<String|Int>>>
+
+defmethod print (o:OutputStream, e:MultiplePinsMappedToSamePad) :
+  print(o, "Multiple pins are mapped to the same pad:")
+  for mp in multi-pins(e) do : 
+    lnprint(IndentedStream(o), "pad %_: %," % [key(mp), value(mp)])
+
 ;=================================================
 ;========== STM JSON -> Stanza Structs ===========
 ;=================================================
 
 ;JITX Pin Properties to be created in JITX
-public defstruct STMPinProperties :
+public pcb-struct ocdb/stm/STMPinProperties :
   generic-pin: STMGenericPin
   power-pin: STMPowerPin
   rows: Tuple<STMPinProperties-Row>
+  duplicates: Tuple<KeyValue<String, String>>
 
-public defstruct STMGenericPin :
+public pcb-struct  ocdb/stm/STMGenericPin :
   pin-name: String
   max-voltage: STMVoltageLimits
   rated-esd: Double
 
-public defstruct STMPowerPin :
+public pcb-struct  ocdb/stm/STMPowerPin :
   pin-name: String
   recommended-voltage: STMVoltageLimits
 
-public defstruct STMVoltageLimits:
+public pcb-struct ocdb/stm/STMVoltageLimits:
   min-val: Double
   max-val: Double
   nominal?: True|False
 
 ;[{pin} | {pad} | {side} | {generic-props?} | {power-props?}]
-public defstruct STMPinProperties-Row :
+public pcb-struct ocdb/stm/STMPinProperties-Row :
   pin: String
-  pad: Double|String
+  pad: Int|String
   side: Dir
   generic-props?: True|False
   power-props?: True|False
@@ -41,23 +57,23 @@ public defstruct STMPinProperties-Row :
 ;Bundle definition to be created in JITX
 ;pcb-bundle {name} :
 ;  pin p
-public defstruct STMBundle :
+public pcb-struct ocdb/stm/STMBundle :
   name: String
 
 ;Support Statements to be created in JITX
-public defstruct STMSupports:
+public pcb-struct ocdb/stm/STMSupports:
   bundle: STMSupportsBundle
   mappings: Tuple<STMSupportMapping>
 
 ;supports {name({options})}:
-public defstruct STMSupportsBundle:
+public pcb-struct ocdb/stm/STMSupportsBundle:
   name: String
   options: Tuple<String>
 
 ;if require is String:
 ;  require p0:{require}
 ;{bundle-pin} => self/p0.{pin}
-public defstruct STMSupportMapping :
+public pcb-struct ocdb/stm/STMSupportMapping :
   bundle-pin: String
   require: String|False
   pin: String
@@ -129,6 +145,8 @@ defmethod print (o:OutputStream, s:STMSupportMapping) :
 ;=================================================
 ;================= Build Structs =================
 ;=================================================
+defn stm-error (x) : 
+  throw(StmError(x))
 
 ;This function creates STMSupports from the "supports" section in the JSON.
 public defn create-supports (json:JSON) -> Tuple<STMSupports> :
@@ -141,11 +159,11 @@ public defn create-supports (json:JSON) -> Tuple<STMSupports> :
             ;Read the bundle's name.
             val bundle-name = match(supported-bundle["name"]) :
               (bundle-name:String) : bundle-name
-              (bundle-name) : fatal("Invalid Supported Bundle Name")
+              (bundle-name) : stm-error("Invalid Supported Bundle Name")
             ;Read the bundle's pin options.
             val bundle-options = match(supported-bundle["options"]) :
               (bundle-options:Tuple<String>) : bundle-options
-              (bundle-options) : fatal("Invalid Supported Bundle Options")
+              (bundle-options) : stm-error("Invalid Supported Bundle Options")
             STMSupportsBundle(bundle-name, bundle-options)
         ;Build the collection of STMSupportMappings.
         val mappings = match(support["mappings"]) :
@@ -155,20 +173,20 @@ public defn create-supports (json:JSON) -> Tuple<STMSupports> :
               ;Read the name of the bundle pin (ex. "p")
               val bundle-pin = match(mapping["bundle-pin"]) :
                 (bundle-pin:String) : bundle-pin
-                (bundle-pin) : fatal("Invalid Mapping Bundle Pin")
+                (bundle-pin) : stm-error("Invalid Mapping Bundle Pin")
               ;Read the name of the required pin (ex. "required-pin")
               val require = match(mapping["require"]) :
                 (require:String|False) : require
-                (require) : fatal("Invalid Mapping Require")
+                (require) : stm-error("Invalid Mapping Require")
               ;Read the name of the mapped pin (ex. "q")
               val pin = match(mapping["pin"]) :
                 (pin:String) : pin
-                (pin) : fatal("Invalid Mapping Pin")
+                (pin) : stm-error("Invalid Mapping Pin")
               STMSupportMapping(bundle-pin, require, pin)
-          (mappings) : fatal("Invalid Support Mappings")
+          (mappings) : stm-error("Invalid Support Mappings")
         ;Bring the bundle and mappings together to create one STMSupports
         STMSupports(supported-bundle, mappings)
-    (supports) : fatal("Invalid Supports")
+    (supports) : stm-error("Invalid Supports")
 
 public defn create-bundles (json1:JSON) -> Tuple<STMBundle> :
   val bundles = Vector<STMBundle>()
@@ -179,9 +197,9 @@ public defn create-bundles (json1:JSON) -> Tuple<STMBundle> :
       ;Each name should be a String bundle name
       for name in json do :
         match(name:String) : add(bundles, STMBundle(name))
-        else : fatal("Invalid JSON")
+        else : stm-error("Invalid JSON")
     (json) :
-      fatal("Invalid JSON")
+      stm-error("Invalid JSON")
   
   to-tuple(bundles)
 
@@ -196,26 +214,26 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
     (gen-pin: JObject) :
       val name = match(gen-pin["name"]) :
         (name : String) : name
-        (name) : fatal("Invalid Generic Pin Name")
+        (name) : stm-error("Invalid Generic Pin Name")
       val rated-esd = match(gen-pin["rated-esd"]) :
         (rated-esd: Double) : rated-esd
-        (rated-esd) : fatal("Invalid rated-esd")
+        (rated-esd) : stm-error("Invalid rated-esd")
       var max-voltage-data
       match(gen-pin["max-voltage"]) :
         (max-volt-data: JObject) :
           val min-volts = match(max-volt-data["min"]) :
             (min-volts-double:Double) : min-volts-double
-            (min-volts) : fatal("Invalid max-voltage data")
+            (min-volts) : stm-error("Invalid max-voltage data")
           val max-volts = match(max-volt-data["max"]) :
             (max-volts-double:Double) : max-volts-double
-            (max-volts) : fatal("Invalid max-voltage data")
+            (max-volts) : stm-error("Invalid max-voltage data")
           val nominal = match(max-volt-data["nominal"]) :
             (nominal:True) : nominal
             (nominal:False) : nominal
-            (nominal) : fatal("Invalid nominal data")
+            (nominal) : stm-error("Invalid nominal data")
           max-voltage-data = STMVoltageLimits(min-volts, max-volts, nominal)
         (max-volt-data) :
-          fatal("Invalid JSON")
+          stm-error("Invalid JSON")
       stm-gen-pin = STMGenericPin(name, max-voltage-data, rated-esd)
 
   val power-pin = pin-prop["power-pin"]
@@ -224,7 +242,7 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
     (pow-pin: JObject) :
       val name = match(pow-pin["name"]) :
         (name : String) : name
-        (name) : fatal("Invalid Power Pin Name")
+        (name) : stm-error("Invalid Power Pin Name")
       val recommended-volt-data = pow-pin["recommended-voltage"]
       var recommended-voltage-data
 
@@ -232,20 +250,21 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
         (recommended-volt-data: JObject) :
           val min-volts = match(recommended-volt-data["min"]) :
             (min-volts-double:Double) : min-volts-double
-            (min-volts) : fatal("Invalid recommended-voltage min data")
+            (min-volts) : stm-error("Invalid recommended-voltage min data")
           val max-volts = match(recommended-volt-data["max"]) :
             (max-volts-double:Double) : max-volts-double
-            (max-volts) : fatal("Invalid recommended-voltage max data")
+            (max-volts) : stm-error("Invalid recommended-voltage max data")
           val nominal = match(recommended-volt-data["nominal"]) :
             (nominal:True) : nominal
             (nominal:False) : nominal
-            (nominal) : fatal("Invalid nominal data")
+            (nominal) : stm-error("Invalid nominal data")
           recommended-voltage-data = STMVoltageLimits(min-volts, max-volts, nominal)
         (recommended-volt-data) :
-          fatal("Invalid JSON") 
+          stm-error("Invalid JSON") 
 
       stm-pow-pin = STMPowerPin(name, recommended-voltage-data)
 
+  val pads-in-use = HashTable<String|Int, Vector<String|Int>>()
   val pin-properties = Vector<STMPinProperties-Row>()
   val pins = pin-prop["pins"]
   match(pins) :
@@ -253,11 +272,11 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
       for pin-item in pins do :
         val pin-name = match(pin-item["pin"]) :
           (pin-name:String) : pin-name
-          (pin-name) : fatal("Invalid Pin Name")
+          (pin-name) : stm-error("Invalid Pin Name: %_" % [pin-name])
         val pad-name = match(pin-item["pad"]) :
-          (pad-double:Double) : pad-double
+          (pad-double:Double) : to-int(pad-double)
           (pad-str:String) : pad-str
-          (pad-data) : fatal("Invalid Pad Value")
+          (pad-data) : stm-error("Invalid Pad Value:%_" % [pad-data])
         val side = match(pin-item["side"]) :
           (side-val:String) : 
             switch(side-val) :
@@ -265,19 +284,28 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
               "Down" : Down,
               "Left" : Left,
               "Right" : Right
-          (side-val) : fatal("Invalid Pin Name")
+          (side-val) : stm-error("Invalid Pin Name")
+        
         val power-props? = match(pin-item["power-pin?"]) :
           (power-val:True) : power-val
           (power-val:False) : power-val
-          (power-val) : fatal("Invalid Power Value")
+          (power-val) : stm-error("Invalid Power Value")
+
         val generic-props? = match(pin-item["generic-pin?"]) :
           (generic-val:True) : generic-val
           (generic-val:False) : generic-val
-          (generic-val) : fatal("Invalid Generic Value")
+          (generic-val) : stm-error("Invalid Generic Value")
 
-        add(pin-properties, STMPinProperties-Row(pin-name, pad-name, side, generic-props?, power-props?))
+        match(get?(pads-in-use, pad-name)):
+          (f:False): 
+            pads-in-use[pad-name] = to-vector<String|Int>([pin-name])
+            add(pin-properties, STMPinProperties-Row(pin-name, pad-name, side, generic-props?, power-props?))
+          (mapped-pins:Vector):
+            add(mapped-pins, pin-name)
     (pins) :
-      fatal("Invalid JSON")
- 
-  val stm-properties = STMPinProperties(stm-gen-pin, stm-pow-pin, to-tuple(pin-properties))
+      stm-error("Invalid JSON")
+  val multi-pins = to-tuple $ for p in pads-in-use filter : 
+    length(value(p)) > 1
+  throw(MultiplePinsMappedToSamePad(multi-pins)) when not empty?(multi-pins)
+  val stm-properties = STMPinProperties(stm-gen-pin, stm-pow-pin, to-tuple(pin-properties), [])
   stm-properties

--- a/utils/stm.stanza
+++ b/utils/stm.stanza
@@ -13,14 +13,6 @@ defstruct StmError <: Exception :
 defmethod print (o:OutputStream, e:StmError) : 
   print(o, "Could not extract STM component. %_." % [message(e)])
 
-defstruct MultiplePinsMappedToSamePad <: Exception : 
-  multi-pins: Tuple<KeyValue<String|Int, Seqable<String|Int>>>
-
-defmethod print (o:OutputStream, e:MultiplePinsMappedToSamePad) :
-  print(o, "Multiple pins are mapped to the same pad:")
-  for mp in multi-pins(e) do : 
-    lnprint(IndentedStream(o), "pad %_: %," % [key(mp), value(mp)])
-
 ;=================================================
 ;========== STM JSON -> Stanza Structs ===========
 ;=================================================
@@ -29,7 +21,7 @@ defmethod print (o:OutputStream, e:MultiplePinsMappedToSamePad) :
 public pcb-struct ocdb/stm/STMPinProperties :
   generic-pin: STMGenericPin
   power-pin: STMPowerPin
-  rows: Tuple<STMPinProperties-Row>
+  rows: Tuple<STMPinPropertiesRow>
 
 public pcb-struct  ocdb/stm/STMGenericPin :
   pin-name: String
@@ -46,7 +38,7 @@ public pcb-struct ocdb/stm/STMVoltageLimits:
   nominal?: True|False
 
 ;[{pin} | {pad} | {side} | {generic-props?} | {power-props?}]
-public pcb-struct ocdb/stm/STMPinProperties-Row :
+public pcb-struct ocdb/stm/STMPinPropertiesRow :
   pin: String
   pad: Int|String
   side: Dir
@@ -114,9 +106,9 @@ defmethod print (o:OutputStream, s:STMVoltageLimits) :
   print(o, "STMVoltageLimits:")
   lnprint-fields(o2, s, [min-val, max-val, nominal?])
 
-defmethod print (o:OutputStream, s:STMPinProperties-Row) :
+defmethod print (o:OutputStream, s:STMPinPropertiesRow) :
   val o2 = IndentedStream(o)
-  print(o, "STMPinProperties-Row:")
+  print(o, "STMPinPropertiesRow:")
   lnprint-fields-row(o2, s, [pin, pad, side, generic-props?, power-props?])
 
 defmethod print (o:OutputStream, s:STMBundle) :
@@ -263,8 +255,7 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
 
       stm-pow-pin = STMPowerPin(name, recommended-voltage-data)
 
-  val pads-in-use = HashTable<String|Int, Vector<String|Int>>()
-  val pin-properties = Vector<STMPinProperties-Row>()
+  val pin-properties = Vector<STMPinPropertiesRow>()
   val pins = pin-prop["pins"]
   match(pins) :
     (pins:Tuple<JObject>) :
@@ -295,16 +286,9 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
           (generic-val:False) : generic-val
           (generic-val) : stm-error("Invalid Generic Value")
 
-        match(get?(pads-in-use, pad-name)):
-          (f:False): 
-            pads-in-use[pad-name] = to-vector<String|Int>([pin-name])
-            add(pin-properties, STMPinProperties-Row(pin-name, pad-name, side, generic-props?, power-props?))
-          (mapped-pins:Vector):
-            add(mapped-pins, pin-name)
-    (pins) :
+        add(pin-properties, STMPinPropertiesRow(pin-name, pad-name, side, generic-props?, power-props?))
+    (j) :
       stm-error("Invalid JSON")
-  val multi-pins = to-tuple $ for p in pads-in-use filter : 
-    length(value(p)) > 1
-  throw(MultiplePinsMappedToSamePad(multi-pins)) when not empty?(multi-pins)
+
   val stm-properties = STMPinProperties(stm-gen-pin, stm-pow-pin, to-tuple(pin-properties))
   stm-properties


### PR DESCRIPTION
`fatal(...)` calls in the STM extractor now throw exceptions, allowing for recovery in higher level generators. 

Pending support for multiple pads mapped to the same pin, an error is introduced to handle this case:

```
FATAL ERROR: Multiple pins are mapped to the same pad:
  pad 19: PA[9], PA[11]
  pad 20: PA[10], PA[12].
```

---

The component generation is now cacheable, via converting the STMxxx structs to pcb-structs

---

Land pattern lookup is cleaned up and comprehensive using a table of symbols and the land pattner name directly. 

--- 

Integer pins are converted from doubles earlier in extraction to avoid confusion during printout of errors. 