### PR TITLE
Comprehensive landpattern generation

### DIFF
--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -1605,6 +1605,42 @@ public defn make-two-pin-chip-landpattern (length:Toleranced,
     density-level, polarized?
   )
 
+; Create a two pin chip land pattern with default density level and optional polarity
+public defn make-two-pin-chip-landpattern (length:Toleranced,
+                                           width:Toleranced,
+                                           lead-length:Toleranced,
+                                           polarized?:True|False):
+  make-two-pin-chip-landpattern(
+    length, width, lead-length, false, 
+    DENSITY-LEVEL, polarized?
+  )
+
+; Create a two pin chip land pattern with default density level and default polarity
+public defn make-two-pin-chip-landpattern (length:Toleranced,
+                                           width:Toleranced,
+                                           lead-length:Toleranced):
+  make-two-pin-chip-landpattern(length, width, lead-length, false)
+
+; Create a two pin chip land pattern with default density level, optional polarity and custom 
+; lead dimensions
+public defn make-two-pin-chip-landpattern (length:Toleranced,
+                                           width:Toleranced,
+                                           lead-length:Toleranced,
+                                           lead-width:Toleranced
+                                           polarized?:True|False):
+  make-two-pin-chip-landpattern(
+    length, width, lead-length, lead-width, 
+    DENSITY-LEVEL, polarized?
+  )
+
+; Create a two pin chip land pattern with default density level, default polarity and custom 
+; lead dimensions
+public defn make-two-pin-chip-landpattern (length:Toleranced,
+                                           width:Toleranced,
+                                           lead-length:Toleranced
+                                           lead-width:Toleranced):
+  make-two-pin-chip-landpattern(length, width, lead-length, lead-width, false)
+
 ; Create a two pin chip landpattern factoring in factory tolerances and controlling 
 ; whether the pads should be considered "solder mask defined" 
 public pcb-landpattern two-pin-chip-landpattern (length:Toleranced,


### PR DESCRIPTION
Adds two variants to `make-two-pin-chip-landpattern` to mirror the comprehensiveness of `make-xxx` and `xxx` generator families. 

These are useful when you wish to use the form

```
pcb-landpattern MyPassive : 
  make-two-pin-chip-landpattern(...)
```

as opposed to 

```
val MyPassive = two-pin-chip-landpattern(...)
```
