### PR TITLE
Jitx 842/stm pin types

### DIFF
--- a/utils/stm-to-jitx.stanza
+++ b/utils/stm-to-jitx.stanza
@@ -54,7 +54,7 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTabl
     ;Generate the pin-properties.
     ;Cases are split between Int and Ref pads, and across generic and power properties usages.
     pin-properties : 
-      [pin:Ref | pads : (Ref|Int) ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
+      [pin:Ref | pads : (Ref|Int) ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin | types:String ... ]
       for row in rows(pin-properties) do : 
         val pin-ref = ref-string-to-ref(pin(row))
         val pad-ref = match(pad(row)):
@@ -63,10 +63,10 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTabl
 
         if check-pad(pad(row), pin(row)) : 
           match(generic-props?(row), power-props?(row)) :
-            (g:True, p:True)   : [(pin-ref) | (pad-ref) | side(row) | generic-props | power-props]
-            (g:True, p:False)  : [(pin-ref) | (pad-ref) | side(row) | generic-props |      -     ]
-            (g:False, p:True)  : [(pin-ref) | (pad-ref) | side(row) |       -       | power-props]
-            (g:False, p:False) : [(pin-ref) | (pad-ref) | side(row) |       -       |      -     ]
+            (g:True, p:True)   : [(pin-ref) | (pad-ref) | side(row) | generic-props | power-props | types(row)]
+            (g:True, p:False)  : [(pin-ref) | (pad-ref) | side(row) | generic-props |      -      | types(row)]
+            (g:False, p:True)  : [(pin-ref) | (pad-ref) | side(row) |       -       | power-props | types(row)]
+            (g:False, p:False) : [(pin-ref) | (pad-ref) | side(row) |       -       |      -      | types(row)]
     
     to-hashtable<String, String> $ 
       for shared in values(pad-mappings) seq-cat : 
@@ -137,10 +137,12 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
             val value = dot(p, bundle-pin-name)
             key => value
   
+  val bundle-counts = HashTable<String, Int>(0)
   for support in supports do :
     val supported-bundle = bundle(support)
     val options = qsort(options(supported-bundle))
     val bundle-name = name(supported-bundle)
+    bundle-counts[bundle-name] = bundle-counts[bundle-name] + 1
     val bundle:Bundle|[Bundle, Bundle] =
       match(get?(bundle-table, bundle-name)) :
         (b:Bundle) :
@@ -225,6 +227,9 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
     match(bundle) :
       (b:Bundle) : generate-support(b, mappings(support))
       ([b1, b2]:[Bundle, Bundle]) : generate-support(b1, b2, mappings(support))
+  ; println("")
+  ; do(println, qsort(value, bundle-counts))
+  ; println("")
 
 ;Generate a module that accepts user options and instantiates the given component.
 public defn mcu-module (component:Instantiable) -> (Tuple<KeyValue<Symbol,?>> -> Instantiable) :

--- a/utils/stm-to-jitx.stanza
+++ b/utils/stm-to-jitx.stanza
@@ -137,12 +137,10 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
             val value = dot(p, bundle-pin-name)
             key => value
   
-  val bundle-counts = HashTable<String, Int>(0)
   for support in supports do :
     val supported-bundle = bundle(support)
     val options = qsort(options(supported-bundle))
     val bundle-name = name(supported-bundle)
-    bundle-counts[bundle-name] = bundle-counts[bundle-name] + 1
     val bundle:Bundle|[Bundle, Bundle] =
       match(get?(bundle-table, bundle-name)) :
         (b:Bundle) :
@@ -227,9 +225,6 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
     match(bundle) :
       (b:Bundle) : generate-support(b, mappings(support))
       ([b1, b2]:[Bundle, Bundle]) : generate-support(b1, b2, mappings(support))
-  ; println("")
-  ; do(println, qsort(value, bundle-counts))
-  ; println("")
 
 ;Generate a module that accepts user options and instantiates the given component.
 public defn mcu-module (component:Instantiable) -> (Tuple<KeyValue<Symbol,?>> -> Instantiable) :

--- a/utils/stm.stanza
+++ b/utils/stm.stanza
@@ -44,6 +44,7 @@ public pcb-struct ocdb/stm/STMPinPropertiesRow :
   side: Dir
   generic-props?: True|False
   power-props?: True|False
+  types: Tuple<String>
 
 ;Bundle definition to be created in JITX
 ;pcb-bundle {name} :
@@ -109,7 +110,7 @@ defmethod print (o:OutputStream, s:STMVoltageLimits) :
 defmethod print (o:OutputStream, s:STMPinPropertiesRow) :
   val o2 = IndentedStream(o)
   print(o, "STMPinPropertiesRow:")
-  lnprint-fields-row(o2, s, [pin, pad, side, generic-props?, power-props?])
+  lnprint-fields-row(o2, s, [pin, pad, side, generic-props?, power-props?, types])
 
 defmethod print (o:OutputStream, s:STMBundle) :
   val o2 = IndentedStream(o)
@@ -285,8 +286,12 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
           (generic-val:True) : generic-val
           (generic-val:False) : generic-val
           (generic-val) : stm-exception!("Invalid Generic Value")
+        
+        val types = match(pin-item["types"]) :
+          (types:Tuple<String>) : types
+          (types) : stm-exception!("Invalid Pin Types")
 
-        add(pin-properties, STMPinPropertiesRow(pin-name, pad-name, side, generic-props?, power-props?))
+        add(pin-properties, STMPinPropertiesRow(pin-name, pad-name, side, generic-props?, power-props?, types))
     (j) :
       stm-exception!("Invalid JSON")
 


### PR DESCRIPTION
Add pin types (`power`, `io`, `reset`, etc.) to generated STM pins.