### PR TITLE
extended get-valid-pkg-list to accept optional package

### DIFF
--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -22,13 +22,15 @@ defpackage ocdb/generic-components:
 val PKGS = ["01005", "0201", "02016", "0202", "0303", "0402", "0404", "0503", "0505", "0603", "0612", "0805", "1206",
             "1210", "1218", "1812", "2010", "2512", "2525", "2615", "2616", "3920", "4122", "4823", "5329", "6030"]
 
-public defn get-valid-pkg-list () :
-  val min-pkg-idx = find({PKGS[_] == MIN-PKG}, 0 to length(PKGS))
+public defn get-valid-pkg-list (min-pkg: String) :
+  val min-pkg-idx = find({PKGS[_] == min-pkg}, 0 to length(PKGS))
   match(min-pkg-idx: Int) :
     PKGS[min-pkg-idx to false]
   else :
     throw(Exception("Invalid MIN-PKG."))
 
+public defn get-valid-pkg-list () :
+  get-valid-pkg-list(MIN-PKG)
 ; ========================================================
 ; ==== EIA Standard Tolerances and Logarithmic Values ====
 ; ========================================================


### PR DESCRIPTION
extended get-valid-pkg-list to accept optional package, which in turn adds function to specify a min package for a specific instance of a generic component