### PR TITLE
Better alphabetical sort for schematic pins

### DIFF
--- a/designs/tutorial.stanza
+++ b/designs/tutorial.stanza
@@ -59,7 +59,7 @@ pcb-module first-design :
   add-mounting-holes(board-shape, "M2", [2 3])
   place(connector.connector) at loc(-4.0, -12.5) on Top
 
-  ; Run the schematic review 
+  ; Run the schematic review
   check-design(self)
 
 val powered-design = run-final-passes(transform-module(generate-power, first-design))

--- a/utils/stm.stanza
+++ b/utils/stm.stanza
@@ -337,7 +337,7 @@ defn rename-duplicate-pins (pp:STMPinProperties) -> STMPinProperties :
 ;This function returns STMPinProperties with the same rows reordered.
 public defn alphabetize-pins (pp:STMPinProperties) -> STMPinProperties :
   val pin-to-row = to-hashtable(pin, rows(pp))
-  val sorted-pins = qsort(map(pin, rows(pp)))
+  val sorted-pins = alphabetical-sort(map(pin, rows(pp)))
 
   ;Construct a new pin properties with reordered rows.
   STMPinProperties{generic-pin(pp), power-pin(pp), _} $
@@ -349,6 +349,54 @@ defn run-passes (pp:STMPinProperties) -> STMPinProperties :
   pp $> rename-duplicate-pins
      $> alphabetize-pins
 
+;=================================================
+;==================== Sorting ====================
+;=================================================
+
+defn parse (p: String) -> List<Char|Int> :
+  parse(p, "")
+
+defn parse (p: String, number-buffer: String) -> List<Char|Int> :
+  if p == "" :
+    if number-buffer == "" :
+      List()
+    else :
+      List(to-int!(number-buffer))
+  else :
+    if contains?("0123456789", p[0]) :
+      parse(p[1 to false], append(number-buffer, p[0 to 1]))
+    else :
+      if number-buffer == "":
+        cons(p[0], parse(p[1 to false]))
+      else :
+        cons(to-int!(number-buffer), p[0], parse(p[1 to false]))
+
+defn unparse (l: Seqable<Char|Int>) -> String :
+  append-all $ seq(to-string, l)
+
+; We need to create a wrapper struct to define an order on Int|Char
+defstruct ComparableIntChar <: Comparable :
+  element: Int|Char
+
+; Char < Int
+defmethod compare (a: ComparableIntChar, b: ComparableIntChar) -> Int :
+  ; We extend the order on Int and Char to get an order on Int|Char
+  match(element(a), element(b)) :
+    (e1: Int, e2: Char): 1
+    (e1: Char, e2: Int): -1
+    (e1: Int, e2: Int): compare(e1, e2)
+    (e1: Char, e2: Char): compare(e1, e2)
+
+public defn alphabetical-sort (elements: Seqable<String>) -> Seqable<String> :
+  elements $> seq{parse, _}
+           $> alphabetical-sort
+           $> seq{unparse, _}
+
+public defn alphabetical-sort (elements: Seqable<Seqable<Int|Char>>) -> Tuple<Tuple<Int|Char>> :
+  elements $> seq{to-tuple{seq(ComparableIntChar, _)}, _}
+           $> qsort
+           $> seq{map{element, _}, _}
+           $> to-tuple
 
 ;=================================================
 ;==================== Errors =====================


### PR DESCRIPTION
Behaviour:
```
val pins = ["P5" "P0" "PIO" "P12" "P13IO4" "P12IO5" "P14IO3"]

val sorted-pins = qsort $ pins
println $ sorted-pins
println $ map(parse, sorted-pins)
println $ to-tuple $ alphabetical-sort(sorted-pins)
```