### PR TITLE
Bugfix/stm alternate alphabetize

### DIFF
--- a/utils/stm-to-jitx.stanza
+++ b/utils/stm-to-jitx.stanza
@@ -27,15 +27,14 @@ defn stm-to-jitx (voltage-limits:STMVoltageLimits) -> Interval :
   Interval(min-val(voltage-limits), max-val(voltage-limits), false)
 
 ;Generate pin-properties inside of a component.
-public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTable<String, String> :
-  val pin-pad-remapping = HashTable<String, String|Int>()
+public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTable<Ref, Ref> :
   inside pcb-component :
     val generic-props = stm-to-jitx $ generic-pin(pin-properties)
     val power-props = stm-to-jitx $ power-pin(pin-properties)
     
     ;Determine if the pads numeric (Double -> Int) or named (Ref -> String).
     val numeric-pads? = any?({pad(_) is Int}, rows(pin-properties))
-    val named-pads? = any?({pad(_) is String}, rows(pin-properties))
+    val named-pads? = any?({pad(_) is Ref}, rows(pin-properties))
     
     ;If the pads are neither or both, then we are using malformed data.
     if numeric-pads? and named-pads? :
@@ -44,10 +43,8 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTabl
       fatal("Generated a micro-controller without pads.") 
     
     ; We need to compile a list of reused pad to pin mappings.
-    val pad-mappings = HashTable<String|Int, Vector<String>>()
-    defn check-pad (pad:String|Int, pin:String):
-      if get?(pad-mappings, pad) is False : 
-        pad-mappings[pad] = Vector<String>()
+    val pad-mappings = HashTable-init<Ref|Int, Vector<Ref>>(Vector<Ref>{})
+    defn check-pad (pad:Ref|Int, pin:Ref):
       add(pad-mappings[pad], pin)
       length(pad-mappings[pad]) == 1
 
@@ -56,10 +53,8 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTabl
     pin-properties : 
       [pin:Ref | pads : (Ref|Int) ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
       for row in rows(pin-properties) do : 
-        val pin-ref = ref-string-to-ref(pin(row))
-        val pad-ref = match(pad(row)):
-          (i:Int): i
-          (s:String): raw-string-to-ref(s)
+        val pin-ref = pin(row)
+        val pad-ref = pad(row)
 
         if check-pad(pad(row), pin(row)) : 
           match(generic-props?(row), power-props?(row)) :
@@ -68,13 +63,13 @@ public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTabl
             (g:False, p:True)  : [(pin-ref) | (pad-ref) | side(row) |       -       | power-props]
             (g:False, p:False) : [(pin-ref) | (pad-ref) | side(row) |       -       |      -     ]
     
-    to-hashtable<String, String> $ 
+    to-hashtable<Ref, Ref> $ 
       for shared in values(pad-mappings) seq-cat : 
-        var root: String|False = false
+        var root: Ref|False = false
         for pin in shared seq : 
           if root is False:
             root = pin
-          pin => (root as String)
+          pin => (root as Ref)
 
 ;Generate all bundles and store them in a table indexed by name.
 public defn to-jitx-bundles (bundles:Tuple<STMBundle>) -> HashTable<String, Bundle> :
@@ -88,12 +83,13 @@ public defn to-jitx-bundles (bundles:Tuple<STMBundle>) -> HashTable<String, Bund
   bundle-table
 
 ;Generate all support statements inside of a component which will include bundles from bundle-table.
-public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTable<String, Bundle>, pin-name-table:HashTable<String, String>) -> False :
-  defn lookup-pin (pin-name:String) : 
-    ref-string-to-ref $ 
-      match(get?(pin-name-table, pin-name)) : 
-        (s:String): s
-        (f:False): pin-name
+public defn to-jitx-supports (supports:Tuple<STMSupports>,
+                              bundle-table:HashTable<String, Bundle>,
+                              pin-name-table:HashTable<Ref, Ref>) -> False :
+  defn lookup-pin (pin-name:Ref) :
+    match(get?(pin-name-table, pin-name)) : 
+      (r:Ref): r
+      (f:False): pin-name
   
   ;Generate a supports statement for a bundle with the given mappings.
   defn generate-support (b:Bundle, mappings:Tuple<STMSupportMapping>) :
@@ -101,7 +97,7 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
       supports b :
         for mapping in mappings do :
           ;Left hand side of the mapping is the bundle pin.
-          val key = dot(b, ref-string-to-ref(bundle-pin(mapping)))
+          val key = dot(b, bundle-pin(mapping))
           ;Right hand side of the mapping is a local or required pin.
           val value = match(require(mapping)): 
             (req:False): dot(self, lookup-pin(pin(mapping)))
@@ -118,7 +114,7 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
         option :
           for mapping in mappings do :
             ;Left hand side of the mapping is the bundle pin.
-            val key = dot(b1, ref-string-to-ref(bundle-pin(mapping)))
+            val key = dot(b1, bundle-pin(mapping))
             ;Right hand side of the mapping is a local or required pin.
             val value = match(require(mapping)): 
               (req:False): 
@@ -130,7 +126,7 @@ public defn to-jitx-supports (supports:Tuple<STMSupports>, bundle-table:HashTabl
         option :
           require p : b2
           for mapping in mappings do :
-            val bundle-pin-name = ref-string-to-ref(bundle-pin(mapping))
+            val bundle-pin-name = bundle-pin(mapping)
             ;Left hand side of the mapping is the bundle pin.
             val key = dot(b1, bundle-pin-name)
             ;Right hand side of the mapping is a required pin from the alternate bundle.
@@ -243,39 +239,3 @@ public defn mcu-module (component:Instantiable) -> (Tuple<KeyValue<Symbol,?>> ->
     connect-debug(mcu, settings[`debug-interface], settings[`debug-connector])
     setup-clocks(mcu, settings[`HSE-freq], settings[`HSE-ppm], settings[`HSE-source], settings[`LSE-freq], settings[`LSE-ppm], settings[`LSE-source])
   module
-
-;=========================================
-;=============== Utilities ===============
-;=========================================
-
-;Convert a String that may have brackets to a Ref.
-defn ref-string-to-ref (text:String) -> Ref :
-  ;regex-match implementation incomplete so we can't do exact matches with "^mypattern$"
-  ;val match-result = regex-match("^(\\w+).([\\w\.])+$", text)
-  if text[length(text) - 1] == ']' :
-    val idx = last-index-of-char(text, '[') as Int
-    IndexRef(ref-string-to-ref(text[0 to idx]), to-int!(text[(idx + 1) to (length(text) - 1)]))
-  else :
-    val idx = last-index-of-char(text, '.')
-    match(idx: Int) :
-      FieldRef(ref-string-to-ref(text[0 to idx]), Ref(text[(idx + 1) to length(text)]))
-    else :
-      Ref(text)
-
-;Convert a String without brackets to a Ref.
-defn raw-string-to-ref (text:String) -> Ref :
-  val last-digit-index = label<Int> break :
-    for i in (length(text) - 1) through 0 by -1 do :
-      if not digit?(text[i]) :
-        break(i + 1)
-    0
-  if last-digit-index == 0 :
-    val ref = Ref("p")
-    val index = to-int!(text)
-    IndexRef(ref, index)
-  else if last-digit-index == length(text) :
-    Ref(text)
-  else :
-    val ref = Ref(text[0 to last-digit-index])
-    val index = to-int!(text[last-digit-index to false])
-    IndexRef(ref, index)

--- a/utils/stm.stanza
+++ b/utils/stm.stanza
@@ -32,8 +32,8 @@ public pcb-struct ocdb/stm/STMVoltageLimits:
 
 ;[{pin} | {pad} | {side} | {generic-props?} | {power-props?}]
 public pcb-struct ocdb/stm/STMPinPropertiesRow :
-  pin: String
-  pad: Int|String
+  pin: Ref
+  pad: Ref|Int
   side: Dir
   generic-props?: True|False
   power-props?: True|False
@@ -58,9 +58,9 @@ public pcb-struct ocdb/stm/STMSupportsBundle:
 ;  require p0:{require}
 ;{bundle-pin} => self/p0.{pin}
 public pcb-struct ocdb/stm/STMSupportMapping :
-  bundle-pin: String
+  bundle-pin: Ref
   require: String|False
-  pin: String
+  pin: Ref
 
 ;=================================================
 ;=================== Printers ====================
@@ -156,7 +156,7 @@ public defn create-supports (json:JSON) -> Tuple<STMSupports> :
               ;Example map: bund.p => required-pin.q
               ;Read the name of the bundle pin (ex. "p")
               val bundle-pin = match(mapping["bundle-pin"]) :
-                (bundle-pin:String) : bundle-pin
+                (bundle-pin:String) : ref-string-to-ref(bundle-pin)
                 (bundle-pin) : stm-exception!("Invalid Mapping Bundle Pin")
               ;Read the name of the required pin (ex. "required-pin")
               val require = match(mapping["require"]) :
@@ -164,7 +164,7 @@ public defn create-supports (json:JSON) -> Tuple<STMSupports> :
                 (require) : stm-exception!("Invalid Mapping Require")
               ;Read the name of the mapped pin (ex. "q")
               val pin = match(mapping["pin"]) :
-                (pin:String) : pin
+                (pin:String) : ref-string-to-ref(pin)
                 (pin) : stm-exception!("Invalid Mapping Pin")
               STMSupportMapping(bundle-pin, require, pin)
           (mappings) : stm-exception!("Invalid Support Mappings")
@@ -254,11 +254,11 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
     (pins:Tuple<JObject>) :
       for pin-item in pins do :
         val pin-name = match(pin-item["pin"]) :
-          (pin-name:String) : pin-name
+          (pin-name:String) : ref-string-to-ref(pin-name)
           (pin-name) : stm-exception!("Invalid Pin Name: %_" % [pin-name])
         val pad-name = match(pin-item["pad"]) :
           (pad-double:Double) : to-int(pad-double)
-          (pad-str:String) : pad-str
+          (pad-str:String) : raw-string-to-ref(pad-str)
           (pad-data) : stm-exception!("Invalid Pad Value:%_" % [pad-data])
         val side = match(pin-item["side"]) :
           (side-val:String) : 
@@ -304,7 +304,7 @@ defn rename-duplicate-pins (pp:STMPinProperties) -> STMPinProperties :
   val pinname-table = group-by(pin, rows(pp))
 
   ;Track used pin names.
-  val seen-pins = HashSet<String>()
+  val seen-pins = HashSet<Ref>()
 
   ;Store updated rows.
   ;A row's index in this array corresponds to its original index.
@@ -324,7 +324,7 @@ defn rename-duplicate-pins (pp:STMPinProperties) -> STMPinProperties :
     if length(pin-list) > 1 :
       updated-rows[i] = STMPinPropertiesRow{_, pad(row), side(row), generic-props?(row), power-props?(row)} $
         for i in 0 to false first! :
-          val new-pinname = to-string("%_[%_]" % [pinname i])
+          val new-pinname = IndexRef(pinname, i)
           if add(seen-pins, new-pinname) :
             One(new-pinname)
           else :
@@ -359,3 +359,40 @@ public defstruct StmError <: Exception :
 
 defmethod print (o:OutputStream, e:StmError) : 
   print(o, "Could not extract STM component. %_." % [message(e)])
+
+
+;=========================================
+;=============== Utilities ===============
+;=========================================
+
+;Convert a String that may have brackets to a Ref.
+defn ref-string-to-ref (text:String) -> Ref :
+  ;regex-match implementation incomplete so we can't do exact matches with "^mypattern$"
+  ;val match-result = regex-match("^(\\w+).([\\w\.])+$", text)
+  if text[length(text) - 1] == ']' :
+    val idx = last-index-of-char(text, '[') as Int
+    IndexRef(ref-string-to-ref(text[0 to idx]), to-int!(text[(idx + 1) to (length(text) - 1)]))
+  else :
+    val idx = last-index-of-char(text, '.')
+    match(idx: Int) :
+      FieldRef(ref-string-to-ref(text[0 to idx]), Ref(text[(idx + 1) to length(text)]))
+    else :
+      Ref(text)
+
+;Convert a String without brackets to a Ref.
+defn raw-string-to-ref (text:String) -> Ref :
+  val last-digit-index = label<Int> break :
+    for i in (length(text) - 1) through 0 by -1 do :
+      if not digit?(text[i]) :
+        break(i + 1)
+    0
+  if last-digit-index == 0 :
+    val ref = Ref("p")
+    val index = to-int!(text)
+    IndexRef(ref, index)
+  else if last-digit-index == length(text) :
+    Ref(text)
+  else :
+    val ref = Ref(text[0 to last-digit-index])
+    val index = to-int!(text[last-digit-index to false])
+    IndexRef(ref, index)


### PR DESCRIPTION
Convert `String` to `Ref` earlier in STM generation for neat ordering of `PA0` through `PA15`
![image](https://user-images.githubusercontent.com/23412242/137037278-a50884a9-db4a-493a-b4c1-da16ff417a1b.png)
