### PR TITLE
Explorer run functions

### DIFF
--- a/modules/voltage-divider.stanza
+++ b/modules/voltage-divider.stanza
@@ -140,7 +140,9 @@ defn query-resistors (resistance: Double, tol: Double) -> Tuple<Resistor> :
              "minimum_quantity" => 1,
              "mounting" => PREFERRED-MOUNTING,
              "case" => get-valid-pkg-list(),
-             "min-stock" => 5 * DESIGN-QUANTITY], ["tcr"])
+             "min-stock" => 5 * DESIGN-QUANTITY,
+             "_exist" => ["tcr"]],
+            25)
 
 defn study-solution (v-in: [Double, Double, Double], r-hi: Resistor, r-lo: Resistor) -> [Double, Double, Double] :
   val lo-drs = [delta-resistance(r-lo, OPERATING-TEMPERATURE[0]), 0., delta-resistance(r-lo, OPERATING-TEMPERATURE[1])]

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -74,7 +74,7 @@ You can check by yourselves doing:
 ```stanza
 $ jitx repl
 stanza> import ocdb/db-parts
-stanza> do(println, Resistors(["mpn" => "ERJ-XGNJ1R0Y"], []))
+stanza> do(println, Resistors(["mpn" => "ERJ-XGNJ1R0Y"], 25))
 ```
 
 Check the [properties reference](../utilities/properties.md) for a description of supported attributes.
@@ -448,7 +448,7 @@ Resistor(
 ```
 
 ```stanza
-public defn Resistors (properties:Tuple<KeyValue>, exist:Tuple<String>) -> Tuple<Resistor>
+public defn Resistors (properties:Tuple<KeyValue>, limit: Int) -> Tuple<Resistor>
 ```
 Similar to `Resistor` but querying up to 25 resistors.
 
@@ -507,10 +507,10 @@ public defn Resistor (user-properties:Tuple<KeyValue>, exist:Tuple<String>, sort
   Resistor $ dbquery-first(query-properties) as JObject
   ; Resistor("manufacturer", "mpn", "trust", 0.0, 0.0, 0.0, "mounting", false, false, Sourcing(false, 0, 0), [], "type", false, 0.0, false, false, false)
 
-public defn Resistors (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> Tuple<Resistor> :
-  val query-properties = resistor-query-properties(user-properties, exist, OPTIMIZE-FOR, OPERATING-TEMPERATURE)
+public defn Resistors (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Resistor> :
+  val query-properties = resistor-query-properties(user-properties, [], OPTIMIZE-FOR, OPERATING-TEMPERATURE)
   ;Query the database with the given properties
-  map{Resistor, _} $ dbquery-all(query-properties) as Tuple<JObject>
+  map{Resistor, _} $ dbquery(query-properties, limit) as Tuple<JObject>
 
 defn resistor-query-properties (user-properties:Tuple<KeyValue>,
                                 exist:Tuple<String>,
@@ -607,7 +607,7 @@ You can check by yourselves doing:
 ```stanza
 $ jitx repl
 stanza> import ocdb/db-parts
-stanza> do(println, Capacitors(["mpn" => "BFC237934205"], []))
+stanza> do(println, Capacitors(["mpn" => "BFC237934205"], 25))
 ```
 
 Check the [properties reference](../utilities/properties.md) for a description of supported attributes.
@@ -915,7 +915,7 @@ Arguments:
 * `operating-temperature`: overrides the rated temperature range that would otherwise be `OPERATING-TEMPERATURE`.
 
 ```stanza
-public defn Capacitors (properties:Tuple<KeyValue>, exist:Tuple<String>) -> Tuple<Capacitor>
+public defn Capacitors (properties:Tuple<KeyValue>, limit: Int) -> Tuple<Capacitor>
 ```
 Similar to `Capacitor` but querying up to 25 capacitors.
 
@@ -980,10 +980,10 @@ public defn Capacitor (user-properties:Tuple<KeyValue>, exist:Tuple<String>, sor
   ;Query the database with the given properties
   Capacitor $ dbquery-first(query-properties) as JObject
 
-public defn Capacitors (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> Tuple<Capacitor> :
-  val query-properties = capacitor-query-properties(user-properties, exist, OPTIMIZE-FOR, OPERATING-TEMPERATURE)
+public defn Capacitors (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Capacitor> :
+  val query-properties = capacitor-query-properties(user-properties, [], OPTIMIZE-FOR, OPERATING-TEMPERATURE)
   ;Query the database with the given properties
-  map{Capacitor, _} $ dbquery-all(query-properties) as Tuple<JObject>
+  map{Capacitor, _} $ dbquery(query-properties, limit) as Tuple<JObject>
 
 defn capacitor-query-properties (user-properties:Tuple<KeyValue>,
                                 exist:Tuple<String>,
@@ -1082,7 +1082,7 @@ You can check by yourselves doing:
 ```stanza
 $ jitx repl
 stanza> import ocdb/db-parts
-stanza> do(println, Inductors(["mpn" => "LQP02TN10NH02D"], []))
+stanza> do(println, Inductors(["mpn" => "LQP02TN10NH02D"], 25))
 ```
 
 Check the [properties reference](../utilities/properties.md) for a description of supported attributes.
@@ -1316,7 +1316,7 @@ Arguments:
 * `operating-temperature`: overrides the rated temperature range that would otherwise be `OPERATING-TEMPERATURE`.
 
 ```stanza
-public defn Inductors (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> Tuple<Inductor>
+public defn Inductors (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Inductor>
 ```
 Similar to `Inductor` but querying up to 25 inductors.
 
@@ -1378,10 +1378,10 @@ public defn Inductor (user-properties:Tuple<KeyValue>, exist:Tuple<String>, sort
   ;Query the database with the given properties
   Inductor $ dbquery-first(query-properties) as JObject
 
-public defn Inductors (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> Tuple<Inductor> :
-  val query-properties = inductor-query-properties(user-properties, exist, OPTIMIZE-FOR, OPERATING-TEMPERATURE)
+public defn Inductors (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Inductor> :
+  val query-properties = inductor-query-properties(user-properties, [], OPTIMIZE-FOR, OPERATING-TEMPERATURE)
   ;Query the database with the given properties
-  map{Inductor, _} $ dbquery-all(query-properties) as Tuple<JObject>
+  map{Inductor, _} $ dbquery(query-properties, limit) as Tuple<JObject>
 
 ; ========================================================
 ; =============== inductor-query-properties ==============

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -14,7 +14,7 @@ public pcb-enum ocdb/design-vars/DensityLevel:
 public var OPERATING-TEMPERATURE = [0.0 25.0]
 
 ; Part selection parameters
-public var OPTIMIZE-FOR = ["area"]
+public var OPTIMIZE-FOR: Tuple<String> = ["area"]
 public var MAX-Z = 500.0
 public var MIN-PKG = "0201"
 public var DESIGN-QUANTITY = 100

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -207,17 +207,23 @@ pcb-module my-module :
 <>
 
 ; Generic ceramic capacitor from database (of 600k options)
-public defn ceramic-cap (user-params:Tuple<KeyValue>) :
+public defn ceramic-cap (user-params:Tuple<KeyValue>) -> Instantiable :
   val params = remove-duplicate-keys $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   to-jitx $ Capacitor(params)
 
-public defn ceramic-cap (cap:Double) :
+public defn ceramic-cap (cap:Double) -> Instantiable :
   ceramic-cap(["capacitance" => cap])
 
-public defn ceramic-cap (cap:Double, tolerance:Double) :
+public defn ceramic-cap (cap:Double, tolerance:Double) -> Instantiable :
   ceramic-cap(["capacitance" => cap "tolerance" => tolerance])
+
+public defn ceramic-caps (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
+  val params = remove-duplicate-keys $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+                                        smd-query-properties()
+                                        user-params]
+  map(to-jitx, Capacitors(params, limit))
 
 ; ========================================================
 ; =============== look-up-ceramic-caps ===================
@@ -323,15 +329,19 @@ pcb-module my-module :
 <>
 
 ; Generic chip resistor from database (of 600k options)
-public defn chip-resistor (user-params:Tuple<KeyValue>) :
+public defn chip-resistor (user-params:Tuple<KeyValue>) -> Instantiable :
   val params = remove-duplicate-keys([smd-query-properties() user-params])
   to-jitx $ Resistor(params)
 
-public defn chip-resistor (resistance:Double) :
+public defn chip-resistor (resistance:Double) -> Instantiable :
   chip-resistor(["resistance" => resistance])
 
-public defn chip-resistor (resistance:Double, tolerance:Double) :
+public defn chip-resistor (resistance:Double, tolerance:Double) -> Instantiable :
   chip-resistor(["resistance" => resistance "tolerance" => tolerance])
+
+public defn chip-resistors (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
+  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  map(to-jitx, Resistors(params, limit))
 
 ; ========================================================
 ; ================ look-up-chip-resistors ================
@@ -430,15 +440,19 @@ pcb-module my-module :
 <>
 
 ; Generic inductors from database of standard packages (0402, 0603... 10k options)
-public defn smd-inductor (user-params:Tuple<KeyValue>) :
+public defn smd-inductor (user-params:Tuple<KeyValue>) -> Instantiable :
   val params = remove-duplicate-keys([smd-query-properties() user-params])
   to-jitx $ Inductor(params)
 
-public defn smd-inductor (ind:Double) :
+public defn smd-inductor (ind:Double) -> Instantiable :
   smd-inductor(["inductance" => ind])
 
-public defn smd-inductor (ind:Double, tolerance:Double) :
+public defn smd-inductor (ind:Double, tolerance:Double) -> Instantiable :
   smd-inductor(["inductance" => ind "tolerance" => tolerance])
+
+public defn smd-inductors (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
+  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  map(to-jitx, Inductors(params, limit))
 
 ; ========================================================
 ; ================ look-up-smd-inductors =================

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -309,7 +309,7 @@ MicroController(
 ```
 
 ```stanza
-public defn MicroControllers (properties:Tuple<KeyValue>, exist:Tuple<String>) -> Tuple<MicroController>
+public defn MicroControllers (properties:Tuple<KeyValue>, limit: Int) -> Tuple<MicroController>
 ```
 Similar to `MicroController` but querying up to 25 micro-controllers.
 
@@ -381,10 +381,10 @@ public defn MicroController (user-properties:Tuple<KeyValue>, exist:Tuple<String
   val jobject = dbquery-first(query-properties) as JObject
   MicroController(jobject)
 
-public defn MicroControllers (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> Tuple<MicroController> :
-  val query-properties = micro-controller-query-properties(user-properties, exist, OPTIMIZE-FOR, OPERATING-TEMPERATURE)
+public defn MicroControllers (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<MicroController> :
+  val query-properties = micro-controller-query-properties(user-properties, [], OPTIMIZE-FOR, OPERATING-TEMPERATURE)
   ;Query the database with the given properties
-  map{MicroController, _} $ dbquery-all(query-properties) as Tuple<JObject>
+  map{MicroController, _} $ dbquery(query-properties, limit) as Tuple<JObject>
 
 defn micro-controller-query-properties (user-properties:Tuple<KeyValue>,
                                         exist:Tuple<String>,


### PR DESCRIPTION
Creates `chip-resistors`, `smd-inductors`, `ceramic-capacitors` to be used in the explorer. This is copy pasting the singular versions of those functions but returning several results.
To do so change `Resistors`, `Inductors` and `Capacitors` to take a limit arg instead of `exist` which was there only because I used it once in the voltage divider 1 year ago but nobody uses it.