### PR TITLE
Encode all MCU data as properties of the component

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -39,20 +39,21 @@ public defstruct Sourcing :
 ;================= External data souring ====================
 ;============================================================
 
-public defstruct Seller :
+public pcb-struct ocdb/db-parts/Seller :
   company-name: String
   resolved-price: Double
   offers: Tuple<SellerOffer>
 
-public defstruct SellerOffer :
+public pcb-struct ocdb/db-parts/SellerOffer :
   inventory-level: Int
   prices: Tuple<SellerOfferPrice>
 
-public defstruct SellerOfferPrice :
+public pcb-struct ocdb/db-parts/SellerOfferPrice :
   quantity: Int
   converted-price: Double
-with :
-  printer => true
+
+defmethod print (o:OutputStream, s:SellerOfferPrice) : 
+  print(o, "SellerOfferPrice(quantity = %_, converted-price = %_)" % [quantity(s), converted-price(s)])
 
 ;============================================================
 ;====================== Resistor ============================
@@ -1607,7 +1608,7 @@ public defn optional-double (json: JObject, field: String) -> Double|False :
   val j = get?(json, field)
   j as Double when not (j is False or j is JNull)
 
-public defstruct MinMaxRange :
+public pcb-struct ocdb/db-parts/MinMaxRange :
   min: Double
   max: Double
 

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -152,13 +152,13 @@ stanza> for attribute in ["manufacturer", "mpn", "trust", "dimensions", "mountin
 | rated-esd | 2000.0 |
 <>
 
-public defstruct MicroController <: Component :
+public pcb-struct ocdb/micro-controllers/MicroController <: Component :
   ; Generic properties
   manufacturer: String
   mpn: String
   trust: String
-  x: Double with: (as-method => true)
-  y: Double with: (as-method => true)
+  x_: Double ; with: (as-method => true)
+  y_: Double ; with: (as-method => true)
   z: Double|False
   mounting: String
   rated-temperature: MinMaxRange|False
@@ -176,11 +176,21 @@ public defstruct MicroController <: Component :
   series: String
   supply-voltage: MinMaxRange
   rated-esd: Double|False
-  sellers: Tuple<Seller>|False with: (as-method => true)
-  resolved-price: Double|False with: (as-method => true)
+  sellers_: Tuple<Seller>|False ; with: (as-method => true)
+  resolved-price_: Double|False ; with: (as-method => true)
   pin-properties: STMPinProperties
   bundles: Tuple<STMBundle>
   supports: Tuple<STMSupports>
+
+defmethod x (c:MicroController) : 
+  x_(c)
+defmethod y (c:MicroController) : 
+  y_(c)
+defmethod sellers (c:MicroController) : 
+  sellers_(c)
+defmethod resolved-price (c:MicroController) : 
+  resolved-price_(c)
+
 
 public defn MicroController (json: JObject) -> MicroController :
   val [x, y, z] = parse-dimensions(json["dimensions"] as JObject)
@@ -487,6 +497,20 @@ Available user settings are:
 | \`LSE-source | "crystal", "osc" | "crystal" |
 <>
 
+pcb-component mcu-component (mcu:MicroController) : 
+  manufacturer = manufacturer(mcu)
+  mpn = mpn(mcu)
+  val mappings = to-jitx-pin-properties(pin-properties(mcu))
+  val bundle-table = to-jitx-bundles(bundles(mcu))
+  to-jitx-supports(supports(mcu), bundle-table, mappings)
+  val lp = find({name(_) == mfg-package(mcu)}, STM32-LAND-PATTERNS)
+  throw(Exception("%_ is not a supported package." % [mfg-package(mcu)])) when lp is False
+  assign-landpattern(lp as LandPattern)
+  make-box-symbol()
+
+  #for field in [trust, x, y, z, mounting, rated-temperature, core, core-architecture, data-width, flash, frequency, io, line, ram, eeprom, series, supply-voltage, rated-esd, sellers, resolved-price] :
+    property(self.field) = field(mcu)  
+
 pcb-component mcu-component (manufacturer:String,
                              mpn:String,
                              pp:STMPinProperties,
@@ -502,7 +526,7 @@ pcb-component mcu-component (manufacturer:String,
   throw(Exception("%_ is not a supported package." % [pkg])) when lp is False
   assign-landpattern(lp as LandPattern)
   make-box-symbol()
-
+  
 ;============================================================
 ;======================== to-jitx ===========================
 ;============================================================

--- a/utils/micro-controllers.stanza
+++ b/utils/micro-controllers.stanza
@@ -157,8 +157,8 @@ public pcb-struct ocdb/micro-controllers/MicroController <: Component :
   manufacturer: String
   mpn: String
   trust: String
-  x_: Double ; with: (as-method => true)
-  y_: Double ; with: (as-method => true)
+  x*: Double ; with: (as-method => true)
+  y*: Double ; with: (as-method => true)
   z: Double|False
   mounting: String
   rated-temperature: MinMaxRange|False
@@ -176,20 +176,20 @@ public pcb-struct ocdb/micro-controllers/MicroController <: Component :
   series: String
   supply-voltage: MinMaxRange
   rated-esd: Double|False
-  sellers_: Tuple<Seller>|False ; with: (as-method => true)
-  resolved-price_: Double|False ; with: (as-method => true)
+  sellers*: Tuple<Seller>|False ; with: (as-method => true)
+  resolved-price*: Double|False ; with: (as-method => true)
   pin-properties: STMPinProperties
   bundles: Tuple<STMBundle>
   supports: Tuple<STMSupports>
 
 defmethod x (c:MicroController) : 
-  x_(c)
+  x*(c)
 defmethod y (c:MicroController) : 
-  y_(c)
+  y*(c)
 defmethod sellers (c:MicroController) : 
-  sellers_(c)
+  sellers*(c)
 defmethod resolved-price (c:MicroController) : 
-  resolved-price_(c)
+  resolved-price*(c)
 
 
 public defn MicroController (json: JObject) -> MicroController :
@@ -508,25 +508,13 @@ pcb-component mcu-component (mcu:MicroController) :
   assign-landpattern(lp as LandPattern)
   make-box-symbol()
 
-  #for field in [trust, x, y, z, mounting, rated-temperature, core, core-architecture, data-width, flash, frequency, io, line, ram, eeprom, series, supply-voltage, rated-esd, sellers, resolved-price] :
+  #for field in [trust, x, y, z, 
+                 mounting, rated-temperature, core, core-architecture, 
+                 data-width, flash, frequency, io, 
+                 line, ram, eeprom, series, 
+                 supply-voltage, rated-esd, sellers, resolved-price] :
     property(self.field) = field(mcu)  
 
-pcb-component mcu-component (manufacturer:String,
-                             mpn:String,
-                             pp:STMPinProperties,
-                             supports:Tuple<STMSupports>,
-                             bundles:Tuple<STMBundle>,
-                             pkg:String) :
-  manufacturer = manufacturer
-  mpn = mpn
-  val mappings = to-jitx-pin-properties(pp)
-  val bundle-table = to-jitx-bundles(bundles)
-  to-jitx-supports(supports, bundle-table, mappings)
-  val lp = find({name(_) == pkg}, STM32-LAND-PATTERNS)
-  throw(Exception("%_ is not a supported package." % [pkg])) when lp is False
-  assign-landpattern(lp as LandPattern)
-  make-box-symbol()
-  
 ;============================================================
 ;======================== to-jitx ===========================
 ;============================================================
@@ -552,7 +540,7 @@ pcb-module my-module :
 <>
 
 public defmethod to-jitx (m:MicroController) : 
-  mcu-component(manufacturer(m), mpn(m), pin-properties(m), supports(m), bundles(m), mfg-package(m))
+  mcu-component(m)
 
 ;============================================================
 ;====================== Printer =============================


### PR DESCRIPTION
This PR allows for generated microcontroller parts to encode all their metadata as properties of the component. Downstream APIs and generators can use this metadata for more advanced code features accordingly. 