### PR TITLE
Docs/jitx 1032 examples to ocdb

### DIFF
--- a/designs/doc-examples.stanza
+++ b/designs/doc-examples.stanza
@@ -47,7 +47,8 @@ pcb-module example-instances :
 ; res7 = First, the value is calculated ( (5-3)/0.005 =  400 Ω), then it's rounded to the closest 5% resistor value (402 Ω), then a 402 Ω resistor of 1% tolerance is returned.
   inst res7 : chip-resistor(closest-std-val( (5.0 - some-voltage) / some-current,5.0), 0.01)
 ; ANCHOR_END: resistor-examples
-
+  schematic-group([res1 res2 res3 res4 res5 res6 res7]) = chip-resistor-examples
+  layout-group([res1 res2 res3 res4 res5 res6 res7]) = chip-resistor-examples
 ; ANCHOR: resistor-strap
   pin gnd
   pin power-5v
@@ -61,6 +62,7 @@ pcb-module example-instances :
 ; 0.01 Ω, 1% tolerance, 0.5 Watt or more between power-5v and signal
   res-strap(power-5v, signal, ["resistance" => 0.01 "tolerance" => 0.005 "min-rated-power" => 0.5]) 
 ; ANCHOR_END: resistor-strap
+
 ; ANCHOR: resistor-generic
 ; instantiating a 5Ω generic resistor
   inst r-gen1 : gen-res-cmp(5.0)
@@ -71,6 +73,8 @@ pcb-module example-instances :
 ; instantiating a 120Ω photo resistor, 10% tolerance, 0.5W, with a 0805 package
   inst r-gen3 : gen-res-cmp(ResistorPhoto, 120.0, 0.10, 0.5, "0805")
 ; ANCHOR_END: resistor-generic
+  schematic-group([r-gen1 r-gen2 r-gen3]) = resistor-generic
+  layout-group([r-gen1 r-gen2 r-gen3]) = resistor-generic
 ; ANCHOR: resistor-struct
   val resistor = Resistor(["resistance" => 0.01 "case" => "1206" "min-rated-power" => 0.5])
   inst res : to-jitx(resistor)
@@ -119,6 +123,9 @@ pcb-module example-instances :
 ; c13 = the largest value capacitor in case size 0805, 100V minimum rated voltage, and `metadata.applications` matches one of the fields in the `automotive-metadata` value.
   inst c13 : ceramic-cap(["_sort" => ["-capacitance"] "case" => "0805" "min-rated-voltage" => 30.0 "metadata.applications" => automative-metadata])
 ; ANCHOR_END: capacitor-examples
+  schematic-group([c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13]) = ceramic-cap-examples
+  layout-group([c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13]) = ceramic-cap-examples
+
 ; ANCHOR: capacitor-strap
   pin reset
   pin vio
@@ -132,24 +139,54 @@ pcb-module example-instances :
 ; 1uF ceramic capacitor, 100V minimum rated voltage.
   cap-strap(reset, vio, ["capacitance" => 1.0e-6 "min-rated-voltage" => 100.0])
 ; ANCHOR_END: capacitor-strap
+
+; Examples of using the generic capacitor call
 ; ANCHOR: capacitor-generic
 ; 10nF ceramic capacitor
   inst gen-c1 : gen-cap-cmp(5.0e-9)
 
-; 100nF, 10V capacitor
+; 100nF, 10V ceramic capacitor
   inst gen-c2 : gen-cap-cmp(0.1e-6, 10.0)
 
-; 1uF ceramic capacitor, 1206 case size
+; 1uF, ceramic capacitor, 1206 case size
   inst gen-c3 : gen-cap-cmp(1.0e-6, "1206")
 
-; 4.7uF ceramic capacitor, 10%, 35V, 1206 case size
-  inst gen-c4 : gen-cap-cmp(4.7e-6, 0.1, 35.0, "1206")
+; 4.7uF, ceramic capacitor, 10%, 35V, 1206 case size
+  inst gen-c4 : gen-cap-cmp(4.7e-6, 10.0, 35.0, "1206")
+
+; 10nF, 10%, 35V, ceramic capacitor (0402 case size)
+  inst gen-c5 : gen-cap-cmp(0.01e-6, 10.0, 35.0)
+
 ; ANCHOR_END: capacitor-generic
+
+; Examples of using the generic tantalum (polarized) capacitor call
+; ANCHOR: capacitor-generic-pol
+
+; 1uF 10% tolerance, 6.3 Volt, polarized tantalum capacitor (package is 0402)
+  inst gen-c6 : gen-tant-cap-cmp(1.0e-6, 10.0, 6.3)
+
+; 68uF, size 1206, polarized tantalum capacitor
+  inst gen-c7 : gen-tant-cap-cmp(68.0e-6, "1206")
+
+; 1uF, 25V, polarized tantalum capacitor (package is 0402)
+  inst gen-c8 : gen-tant-cap-cmp(68.0e-6, 25.0)
+
+; 1uF, polarized tantalum capacitor 
+  inst gen-c9 : gen-tant-cap-cmp(1.0e-6)
+
+; 68uF, 10% tolerance, 6.3 Volt, 1206 polarized tantalum capacitor
+  inst gen-c10 : gen-tant-cap-cmp(68.0e-6, 10.0, 6.3, "1206")
+; ANCHOR_END: capacitor-generic-pol
+  schematic-group([gen-c1 gen-c2 gen-c3 gen-c4 gen-c5 gen-c6 gen-c7 gen-c8 gen-c9 gen-c10]) = capacitor-generic
+  layout-group([gen-c1 gen-c2 gen-c3 gen-c4 gen-c5 gen-c6 gen-c7 gen-c8 gen-c9 gen-c10]) = capacitor-generic
+
 ; ANCHOR: capacitor-struct
   val capacitor = Capacitor(["tolerance" => 0.05 "min-rated-voltage" => 100.0])
   inst cap : to-jitx(capacitor)
   println(capacitor)
 ; ANCHOR_END: capacitor-struct
+
+; Examples of instantiating inductors from the database.
 ; ANCHOR: inductor-examples
 ; inductor1 = 4.7µH±5% SMD inductor
   inst inductor1 : smd-inductor(4.7e-6, 0.05)
@@ -160,31 +197,55 @@ pcb-module example-instances :
 ; inductor3 = inductor with value of 2µH or larger, saturation current of 200mA or larger, current rating of 1A or larger, 1210 size or larger, shielded or semi-shielded, rated to 40° C or above
   inst inductor3 : smd-inductor(["min-inductance" => 2.0e-6 "min-saturation-current" => 0.2 "min-current-rating" => 1.0 "case" => get-valid-pkg-list("1210") "shielding" => ["shielded" "semi-shielded"] "min-rated-temperature.max" => 40.0])
 ; ANCHOR_END: inductor-examples
+  schematic-group([inductor1 inductor2 inductor3]) = smd-inductor-examples
+  layout-group([inductor1 inductor2 inductor3]) = smd-inductor-examples
+
+; Examples of using the strap call for inductors.
 ; ANCHOR: inductor-strap
   pin filter-5v
   pin out-5v
 ; 5µH inductor connected between filter-5v and out-5v
-  ; inst strap-ind1 : ind-strap(filter-5v, out-5v, 1.0e-6)
+  ind-strap(filter-5v, out-5v, 1.0e-6)
 
-; 5µH 20% tolerance inductor connected between filter-5v and out-5v
-  ; inst strap-ind2 : ind-strap(filter-5v, out-5v, 5.0e-6, 0.2)
+; 10nH 20% tolerance inductor connected between filter-5v and out-5v
+  ind-strap(filter-5v, out-5v, 10.0e-9, 0.2)
 
-; SMD inductor with the 20% standard value closest to 2µH, tolerance 10%, wirewound, 1210 size or larger, rated to 40° C or above, connected between filter-5v and out-5v
-  ; inst strap-ind3 : ind-strap(filter-5v, out-5v, ["inductance" => closest-std-val(2.0e-6,20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("1210") "min-rated-temperature.max" => 40.0])
+; SMD inductor with the 20% standard value closest to 20nH, tolerance 10%, wirewound, 0603 size or larger, rated to 40° C or above, connected between filter-5v and out-5v
+  ind-strap(filter-5v, out-5v, ["inductance" => closest-std-val(20.0e-9,20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("0603") "min-rated-temperature.max" => 40.0])
 ; ANCHOR_END: inductor-strap
+
+; Examples of using the generic inductor call
 ; ANCHOR: inductor-generic
 ; Instantiating a 5µH generic inductor
   inst gen-ind1 : gen-ind-cmp(5.0e-6)
 
 ; Instantiating a 5µH, 20% generic inductor
   inst gen-ind2 : gen-ind-cmp(5.0e-6, 0.2)
+  reference-designator(gen-ind2) = "L22"
 
 ; Instantiating a 5µH, 10%, 2 Amp generic inductor with iron core symbol
   inst gen-ind3 : gen-ind-cmp(InductorIronCore, 1.0e-6, 0.1, 2.0)
+  reference-designator(gen-ind3) = "L33"
+
+; Instantiating a 5µH, 10%, 2 Amp generic inductor with ferrite core symbol
+  inst gen-ind4 : gen-ind-cmp(InductorFerriteCore, 1.0e-6, 0.1, 2.0)
+  reference-designator(gen-ind4) = "L44"
+
+; Instantiating a 5µH, 10%, 2 Amp generic inductor with variable symbol
+  inst gen-ind5 : gen-ind-cmp(InductorVariable, 1.0e-6, 0.1, 2.0)
+  reference-designator(gen-ind5) = "L55"
+
+; Instantiating a 5µH, 10%, 2 Amp generic inductor with preset symbol
+  inst gen-ind6 : gen-ind-cmp(InductorPreset, 1.0e-6, 0.1, 2.0)
+  reference-designator(gen-ind6) = "L66"
 ; ANCHOR_END: inductor-generic
+  schematic-group([gen-ind1 gen-ind2 gen-ind3 gen-ind4 gen-ind5 gen-ind6]) = inductor-generic
+  layout-group([gen-ind1 gen-ind2 gen-ind3 gen-ind4 gen-ind5 gen-ind6]) = inductor-generic
+
+; Example of how to use the inductor struct and print the properties of the database return.
 ; ANCHOR: inductor-struct 
-; SMD inductor with the 20% standard value closest to 4µH, tolerance 10%, wirewound, 1210 size or larger
-  val inductor = Inductor(["inductance" => closest-std-val(4.0e-6,20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("1210")])
+; SMD inductor with the 20% standard value closest to 4µH,10% tolerance, min 10mA current rating, shielded
+  val inductor = Inductor(["inductance" => closest-std-val(4.0e-6,20.0) "min-current-rating" => 10.0e-3 "tolerance" => 0.1 "shielding" => "shielded"])
   inst ind : to-jitx(inductor)
   println(inductor)
 ; ANCHOR_END: inductor-struct 

--- a/designs/doc-examples.stanza
+++ b/designs/doc-examples.stanza
@@ -1,0 +1,201 @@
+; Code in this project is directly linked to docs.jitx.com with the anchor calls.
+; More information on components is at: https://docs.jitx.com/lib/components.html
+; This is a small project full of different examples of:
+; - instantiating resistors
+; - instantiating capacitors
+; - instantiating inductors
+
+#use-added-syntax(jitx)
+defpackage doc-examples :
+  import core
+  import jitx
+  import jitx/commands
+  import ocdb/defaults
+  import ocdb/generic-components
+  import ocdb/symbols
+  import ocdb/db-parts
+; ANCHOR: design-vars
+  import ocdb/design-vars
+
+; Overrides default value set in ocdb/design-vars
+MIN-PKG = "0603"
+MIN-CAP-VOLTAGE = 6.3
+; ANCHOR_END: design-vars
+
+pcb-module example-instances :
+; ANCHOR: resistor-examples
+; res1 = 10 kΩ
+  inst res1 : chip-resistor(10.0e3)
+
+; res2 = 0.01 Ω, 0.5% tolerance
+  inst res2 : chip-resistor(0.01, 0.005)
+
+; res3 = 0.01 Ω, 0.5% tolerance, 0.5 Watt or more
+  inst res3 : chip-resistor(["resistance" => 0.01 "tolerance" => 0.005 "min-rated-power" => 0.5])
+
+; res4 = 1 Ω, 0.5% tolerance, 1206 size
+  inst res4 : chip-resistor(["resistance" => 1.0 "tolerance" => 0.005 "case" => "1206"])
+
+; res5 = 100 mΩ, 0.5% tolerance, 1210 size or larger
+  inst res5 : chip-resistor(["resistance" => 100.0e-3 "tolerance" => 0.005 "case" => get-valid-pkg-list("1210")])
+  
+; res6 = 100 mΩ, 0.5% tolerance, 1210 size or larger, rated to 60° C or above
+  inst res6 : chip-resistor(["resistance" => 0.1 "tolerance" => 0.005 "case" => get-valid-pkg-list("1210") "min-rated-temperature.max" => 60.0])
+
+  var some-voltage = 3.0
+  val some-current = 5.0e-3
+; res7 = First, the value is calculated ( (5-3)/0.005 =  400 Ω), then it's rounded to the closest 5% resistor value (402 Ω), then a 402 Ω resistor of 1% tolerance is returned.
+  inst res7 : chip-resistor(closest-std-val( (5.0 - some-voltage) / some-current,5.0), 0.01)
+; ANCHOR_END: resistor-examples
+
+; ANCHOR: resistor-strap
+  pin gnd
+  pin power-5v
+  pin signal
+; 10 kΩ between power-5v and signal
+  res-strap(power-5v, signal, 10.0e3) 
+  
+; 120 Ω, 1% tolerance between gnd and signal
+  res-strap(gnd, signal, 120.0, 0.01) 
+  
+; 0.01 Ω, 1% tolerance, 0.5 Watt or more between power-5v and signal
+  res-strap(power-5v, signal, ["resistance" => 0.01 "tolerance" => 0.005 "min-rated-power" => 0.5]) 
+; ANCHOR_END: resistor-strap
+; ANCHOR: resistor-generic
+; instantiating a 5Ω generic resistor
+  inst r-gen1 : gen-res-cmp(5.0)
+
+; instantiating a 5Ω generic resistor with a 1206 package
+  inst r-gen2 : gen-res-cmp(5.0, "1206")
+
+; instantiating a 120Ω photo resistor, 10% tolerance, 0.5W, with a 0805 package
+  inst r-gen3 : gen-res-cmp(ResistorPhoto, 120.0, 0.10, 0.5, "0805")
+; ANCHOR_END: resistor-generic
+; ANCHOR: resistor-struct
+  val resistor = Resistor(["resistance" => 0.01 "case" => "1206" "min-rated-power" => 0.5])
+  inst res : to-jitx(resistor)
+  println(resistor)
+; ANCHOR_END: resistor-struct
+
+; ANCHOR: capacitor-examples
+; c1 =  22pF ceramic capacitor
+  inst c1 : ceramic-cap(22.0e-12)
+
+; c2 =  10nF±5% ceramic capacitor
+  inst c2 : ceramic-cap(10.0e-9, 0.05)
+
+; c3 =  1uF ceramic capacitor, 100V minimum rated voltage.
+  inst c3 : ceramic-cap(["capacitance" => 1.0e-6 "min-rated-voltage" => 100.0])
+
+; c4 =  1uF±10% ceramic capacitor, 100V minimum rated voltage and a case of 1206.
+  inst c4 : ceramic-cap(["capacitance" => 1.0e-6 "tolerance" => 0.10 "min-rated-voltage" => 100.0 "case" => "1206"])
+
+; c5 =  1uF±10% ceramic capacitor, 100V minimum rated voltage and a case of 1206 or larger.
+  inst c5 : ceramic-cap(["capacitance" => 1.0e-6 "tolerance" => 0.10 "min-rated-voltage" => 100.0 "case" => get-valid-pkg-list("1206")])
+
+; c6 =  1uF ceramic capacitor, the negative tolerance between -5% and -22%. A tolerance of -20% +80% will satisfy this.
+  inst c6 : ceramic-cap(["capacitance" => 1.0e-6 "min-tolerance.min" => -0.22, "max-tolerance.min" => -0.05])
+
+; c7 =  1uF ceramic capacitor, the negative tolerance between -5% and -22%, the positive tolerance between 60% and 100%. A tolerance of -20% +80% will satisfy this.
+  inst c7 : ceramic-cap(["capacitance" => 1.0e-6 "min-tolerance.min" => -0.22, "max-tolerance.min" => -0.05, "min-tolerance.max" => 0.6, "max-tolerance.max" => 1.0])
+
+; c8 =  1uF, X7R ceramic capacitor.
+  inst c8 : ceramic-cap(["capacitance" => 1.0e-6 "temperature-coefficient.code" => "X7R"])
+
+; c9 =  68pF ceramic capacitor, 100V minimum rated voltage, type C0G
+  inst c9 : ceramic-cap(["capacitance" => 68.0e-12 "min-rated-voltage" => 100.0 "temperature-coefficient.code" => "C0G"])
+
+; c10 =  68pF ceramic capacitor, 100V minimum rated voltage, type X7R or C0G
+  inst c10 : ceramic-cap(["capacitance" => 68.0e-12 "min-rated-voltage" => 100.0 "temperature-coefficient.code" => ["C0G" "X7R"]])
+
+; c11 =  1uF± ceramic capacitor, 60V minimum rated voltage, and `metadata.applications` matches one of the fields in the `automotive-metadata` value.
+  val automative-metadata = ["Audio, Automotive" "Automotive" "Automotive, Boardflex Sensitive" "Automotive, Boardflex Sensitive, ESD Protection" "Automotive, Bypass, Decoupling" "Automotive, Bypass, Decoupling, Boardflex Sensitive" "Automotive, Bypass, Decoupling, Boardflex Sensitive, ESD Protection" "Automotive, Bypass, Decoupling, ESD Protection" "Automotive, EMI, RFI Suppression" "Automotive, ESD Protection" "Automotive, High Temperature Reflow" "Automotive, SMPS Filtering" "Automotive, SMPS Filtering, Boardflex Sensitive" "Automotive, SMPS Filtering, Bypass, Decoupling" "Automotive; DC Link, DC Filtering" "Automotive; DC Link, DC Filtering; High Frequency, Switching; High Pulse, DV/DT" "Automotive; DC Link, DC Filtering; High Pulse, DV/DT; Snubber" "Automotive; EMI, RFI Suppression" "Automotive; High Frequency, Switching" "Automotive; High Frequency, Switching; High Pulse, DV/DT" "Automotive; High Frequency, Switching; High Pulse, DV/DT; Snubber" "Automotive; Power Factor Correction (PFC)" "High Reliability, Automotive" "High Reliability, Automotive, Boardflex Sensitive" "RF, Microwave, High Frequency, Automotive" "Safety, Automotive" "Safety, Automotive, Boardflex Sensitive"]
+  inst c11 : ceramic-cap(["capacitance" => 1.0e-6 "min-rated-voltage" => 60.0 "metadata.applications" => automative-metadata])
+
+; c12 =  ceramic capacitor who's value is calculated based on a capacitance * a double, then rounded to the nearest 20% standard value, 60V minimum rated voltage.
+  val test-voltage = 5.0
+  inst c12 : ceramic-cap(["capacitance" => closest-std-val(test-voltage * 1.0e-6,20.0) "min-rated-voltage" => 60.0])
+
+; c13 = the largest value capacitor in case size 0805, 100V minimum rated voltage, and `metadata.applications` matches one of the fields in the `automotive-metadata` value.
+  inst c13 : ceramic-cap(["_sort" => ["-capacitance"] "case" => "0805" "min-rated-voltage" => 30.0 "metadata.applications" => automative-metadata])
+; ANCHOR_END: capacitor-examples
+; ANCHOR: capacitor-strap
+  pin reset
+  pin vio
+
+; 10nF ceramic capacitor
+  cap-strap(reset, vio, 10.0e-9)
+
+; 10nF±5% ceramic capacitor
+  cap-strap(reset, vio, 10.0e-9, 0.05)
+
+; 1uF ceramic capacitor, 100V minimum rated voltage.
+  cap-strap(reset, vio, ["capacitance" => 1.0e-6 "min-rated-voltage" => 100.0])
+; ANCHOR_END: capacitor-strap
+; ANCHOR: capacitor-generic
+; 10nF ceramic capacitor
+  inst gen-c1 : gen-cap-cmp(5.0e-9)
+
+; 100nF, 10V capacitor
+  inst gen-c2 : gen-cap-cmp(0.1e-6, 10.0)
+
+; 1uF ceramic capacitor, 1206 case size
+  inst gen-c3 : gen-cap-cmp(1.0e-6, "1206")
+
+; 4.7uF ceramic capacitor, 10%, 35V, 1206 case size
+  inst gen-c4 : gen-cap-cmp(4.7e-6, 0.1, 35.0, "1206")
+; ANCHOR_END: capacitor-generic
+; ANCHOR: capacitor-struct
+  val capacitor = Capacitor(["tolerance" => 0.05 "min-rated-voltage" => 100.0])
+  inst cap : to-jitx(capacitor)
+  println(capacitor)
+; ANCHOR_END: capacitor-struct
+; ANCHOR: inductor-examples
+; inductor1 = 4.7µH±5% SMD inductor
+  inst inductor1 : smd-inductor(4.7e-6, 0.05)
+
+; inductor2 = SMD inductor with the 20% standard value closest to 2µH, tolerance 10%, wirewound, 1210 size or larger, rated to 40° C or above
+  inst inductor2 : smd-inductor(["inductance" => closest-std-val(2.0e-6,20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("1210") "min-rated-temperature.max" => 40.0])
+
+; inductor3 = inductor with value of 2µH or larger, saturation current of 200mA or larger, current rating of 1A or larger, 1210 size or larger, shielded or semi-shielded, rated to 40° C or above
+  inst inductor3 : smd-inductor(["min-inductance" => 2.0e-6 "min-saturation-current" => 0.2 "min-current-rating" => 1.0 "case" => get-valid-pkg-list("1210") "shielding" => ["shielded" "semi-shielded"] "min-rated-temperature.max" => 40.0])
+; ANCHOR_END: inductor-examples
+; ANCHOR: inductor-strap
+  pin filter-5v
+  pin out-5v
+; 5µH inductor connected between filter-5v and out-5v
+  ; inst strap-ind1 : ind-strap(filter-5v, out-5v, 1.0e-6)
+
+; 5µH 20% tolerance inductor connected between filter-5v and out-5v
+  ; inst strap-ind2 : ind-strap(filter-5v, out-5v, 5.0e-6, 0.2)
+
+; SMD inductor with the 20% standard value closest to 2µH, tolerance 10%, wirewound, 1210 size or larger, rated to 40° C or above, connected between filter-5v and out-5v
+  ; inst strap-ind3 : ind-strap(filter-5v, out-5v, ["inductance" => closest-std-val(2.0e-6,20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("1210") "min-rated-temperature.max" => 40.0])
+; ANCHOR_END: inductor-strap
+; ANCHOR: inductor-generic
+; Instantiating a 5µH generic inductor
+  inst gen-ind1 : gen-ind-cmp(5.0e-6)
+
+; Instantiating a 5µH, 20% generic inductor
+  inst gen-ind2 : gen-ind-cmp(5.0e-6, 0.2)
+
+; Instantiating a 5µH, 10%, 2 Amp generic inductor with iron core symbol
+  inst gen-ind3 : gen-ind-cmp(InductorIronCore, 1.0e-6, 0.1, 2.0)
+; ANCHOR_END: inductor-generic
+; ANCHOR: inductor-struct 
+; SMD inductor with the 20% standard value closest to 4µH, tolerance 10%, wirewound, 1210 size or larger
+  val inductor = Inductor(["inductance" => closest-std-val(4.0e-6,20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("1210")])
+  inst ind : to-jitx(inductor)
+  println(inductor)
+; ANCHOR_END: inductor-struct 
+make-default-board(example-instances, 2, Rectangle(25.0, 25.0))
+
+; Export CAD with default options
+; export-cad()
+
+; Show the Schematic and PCB for the design
+view-board()
+view-schematic()
+
+; Print the MPN of the resistor from the design
+; println(mpn?(my-design.r))

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -438,38 +438,6 @@ public defn look-up-smd-inductors (attribute: String, filter-properties:Tuple<Ke
 ; ========================================================
 ; ===================== gen-cap-cmp ======================
 ; ========================================================
-
-doc: \<>
-```stanza
-public pcb-component gen-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg-name:String)
-```
-This is a generic capacitor component, this is not an actual part that can be bought. This call does not require internet access.
-Pins are `p[1]` and `p[2]`.
-Arguments:
-* `cap` : capacitance in Farads
-* `tol`: tolerance (1.0 means ±1%)
-* `max-v` : rated voltage in Volts
-* `pkg-name`: Package name (example: "0204")
-
-
-Here are the quick accessors:
-```stanza
-public defn gen-cap-cmp (cap:Double, max-v:Double)
-public defn gen-cap-cmp (cap:Double, pkg:String)
-public defn gen-cap-cmp (cap:Double)
-```
-Defaults used are:
-* `tol` : 0.2%
-* `max-v` : 10.0 V
-* `pkg-name` : "0402"
-
-Example : instantiating a 5nF generic capacitor
-```stanza
-pcb-module my-design :
-  inst r : gen-cap-cmp(5.0e-9)
-```
-<>
-
 public pcb-component gen-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg-name:String) :
   port p : pin[1 through 2]
   val sym = capacitor-sym()
@@ -488,6 +456,9 @@ public pcb-component gen-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg-name
   property(self.rated-voltage) = max-v
   property(self.rated-temperature) = [-55.0 125.0]
 
+public defn gen-cap-cmp (cap:Double, tol:Double, max-v:Double) :
+  gen-cap-cmp(cap, tol, max-v, "0402")
+
 public defn gen-cap-cmp (cap:Double, max-v:Double) :
   gen-cap-cmp(cap, 0.2, max-v, "0402")
 
@@ -497,7 +468,10 @@ public defn gen-cap-cmp (cap:Double, pkg:String) :
 public defn gen-cap-cmp (cap:Double) :
   gen-cap-cmp(cap, 10.0)
 
-;Generic Ceramic surface mount capacitors
+; ========================================================
+; ===================== gen-tant-cap-cmp ======================
+; ========================================================
+;Generic Tantalum surface mount capacitors
 public pcb-component gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg:String) :
   pin a 
   pin c
@@ -531,11 +505,10 @@ public defn gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double) :
 public defn gen-tant-cap-cmp (cap:Double, pkg:String) :
   gen-tant-cap-cmp(cap, 20.0, 10.0, pkg)
 
-public defn gen-tant-cap-cmp (cap:Double, tol:Double) :
-  gen-tant-cap-cmp(cap, tol, 10.0)
-; public defn default-bypass (component:Ref) :
-;   bypass-cap-strap(component.gnd, component.vdd, 0.1)
+public defn gen-tant-cap-cmp (cap:Double, max-v:Double) :
+  gen-tant-cap-cmp(cap, 10.0, max-v)
 
+public defn gen-tant-cap-cmp (cap:Double) :
   gen-tant-cap-cmp(cap, 20.0)
 
 ; ========================================================


### PR DESCRIPTION
Add doc-examples.stanza, so folks can quickly visualize all the examples in the docs, and use ocdb to find examples instead of docs if they wish. Fixed issue with `gen-tant-cap-cmp` quick accessor input not matching `gen-cap-cmp`, added new `gen-cap-cmp` quick accessor.