### PR TITLE
Updates to the ble-mote design and associated utilities

### DIFF
--- a/components/diodes-incorporated/AP2112.stanza
+++ b/components/diodes-incorporated/AP2112.stanza
@@ -50,3 +50,5 @@ public pcb-module module :
   net (ps.VOUT vout.vdd)
   net (gnd, ps.GND vout.gnd vin.gnd)
   net (en, ps.VEN)
+
+  schematic-group(self) = AP2112

--- a/components/espressif/ESP32-PICO-D4.stanza
+++ b/components/espressif/ESP32-PICO-D4.stanza
@@ -172,6 +172,8 @@ public pcb-module module :
       ocdb-uart.rx => io[1].p
       property(io[1].p.digital-input) = DigitalInput(0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)  
 
+  schematic-group(self) = ESP32
+
 pcb-landpattern pqfn50p700x700x104-49n :
   pad p[1] : smd-pad(0.45, 0.35) at loc(-3.265, 2.75, 0.0)
   pad p[2] : smd-pad(0.45, 0.35) at loc(-3.265, 2.25, 0.0)

--- a/components/espressif/ESP32-PICO-D4.stanza
+++ b/components/espressif/ESP32-PICO-D4.stanza
@@ -106,7 +106,7 @@ public pcb-component component :
     property(EN.reset-pin) = ResetPin(input-props)
 
   ; ESP supports crossbarred IO, so use generic supports
-  val reserved-io = [IO[0] IO[16] IO[17] IO[32] IO[33]]
+  val reserved-io = [IO[0] IO[16] IO[17] IO[32] IO[33] IO[34] IO[35]]
   for IO-pin in ports(IO) do :
     if not contains?(reserved-io, IO-pin) :
       supports io-pin:

--- a/components/maxim/MAX300x.stanza
+++ b/components/maxim/MAX300x.stanza
@@ -13,6 +13,7 @@ defpackage ocdb/maxim/MAX300x:
   import ocdb/symbols
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/checks
 
 public pcb-component component :
   name = "MAX3001EEUP+T"
@@ -50,6 +51,8 @@ public pcb-component component :
   eval-when has-property?(self.VCC.rail-voltage):
     property(self.VCC.power-pin) = PowerPin(Interval(1.65, property(self.VCC.rail-voltage), false))
 
+  check connected(self.EN)
+
 
 public pcb-module module :
   port vcc:power
@@ -59,9 +62,9 @@ public pcb-module module :
   pin en
 
   inst buffer : ocdb/maxim/MAX300x/component
-  bypass-cap-strap(buffer.VCC, buffer.GND, 0.1)
-  bypass-cap-strap(buffer.VCC, buffer.GND, 1.0)
-  bypass-cap-strap(buffer.VL, buffer.GND, 0.1)
+  bypass-cap-strap(buffer.VCC, buffer.GND, 0.1e-6)
+  bypass-cap-strap(buffer.VCC, buffer.GND, 1.0e-6)
+  bypass-cap-strap(buffer.VL, buffer.GND, 0.1e-6)
 
   net (vcc.gnd vl.gnd, buffer.GND)
   net (vcc.vdd, buffer.VCC)
@@ -70,3 +73,5 @@ public pcb-module module :
   for i in 1 through 8 do :
     net (io-vl[i], buffer.IO-VL[i])
     net (io-vcc[i], buffer.IO-VCC[i])
+
+  schematic-group(self) = max300x

--- a/components/si-labs/CP2105.stanza
+++ b/components/si-labs/CP2105.stanza
@@ -119,3 +119,5 @@ public pcb-module module :
   net (s-uart.tx  xcvr.TXD_SCI)
   net (s-uart.rts xcvr.RTS_SCI)
   net (s-uart.dtr xcvr.DTR_SCI)
+
+  schematic-group(self) = CP2105

--- a/components/st-microelectronics/stm-api.stanza
+++ b/components/st-microelectronics/stm-api.stanza
@@ -390,12 +390,13 @@ defn supports? (module:InstantiableType, bundle:PortType) -> True|False :
   val result = assign-pins?()
   result is-not False
 
-public defn connect-debug (stm:JITXObject, debug-interface:PortType, connector:Instantiable) :
+public defn connect-debug (stm:JITXObject, debug-interface:Bundle, connector:Instantiable) :
   inside pcb-module:
     if supports?(instantiable-type(stm), debug-interface) and supports?(connector, debug-interface) :
       inst debug-con : connector
       require debug-m:debug-interface from stm
       require debug-c:debug-interface from debug-con
+      
       net DEBUG (debug-m debug-c)
       schematic-group(debug-con) = debug
       val power-pins = power-pins-list(stm, VDD)

--- a/components/st-microelectronics/stm-api.stanza
+++ b/components/st-microelectronics/stm-api.stanza
@@ -265,7 +265,6 @@ public defn connect-reference (stm:JITXObject, ref-net:ReferencePinNames, vdd-ne
 public defn connect-reset (stm:JITXObject, reset-net:ResetPinNames, vdd-net:PwrPinNames, gnd-net:GndPinNames, reset-pullup:Double, reset-cap:Double) :
   inside pcb-module :
     pin reset
-<<<<<<< HEAD
     val reset-pin-list = get-pin-list(stm, reset-net)
     if not empty?(reset-pin-list) :
       val power-pins = power-pins-list(stm, VDD)
@@ -287,24 +286,6 @@ public defn connect-reset (stm:JITXObject, reset-net:ResetPinNames, vdd-net:PwrP
 
 public defn connect-reset (stm:JITXObject, reset-net:ResetPinNames, reset-pullup:Double, reset-cap:Double) :
   connect-reset(stm reset-net VDD VSS reset-pullup reset-cap)
-=======
-    net (stm.NRST reset)
-    
-    val power-pin = power-pins(stm)[0]
-    val gnd-pin = gnd-pins(stm)[0]
-    res-strap(power-pin, stm.NRST, 10.0e3)
-    cap-strap(power-pin, stm.NRST, 10.0e-9)
-        
-    ; Look for power-on reset pins
-    if has-pin?(stm, "NPOR") :
-      val v-range = recommended-voltage(property(power-pin.power-pin))
-      if contains?(v-range, 1.8):
-        inst mon : ocdb/on-semiconductor/NCP30x/component(1.8)
-        bypass-cap-strap(stm.NPOR, gnd-pin, 0.1e-6)
-        net (mon.gnd, gnd-pin)
-        net (mon.input, power-pin)
-        net (mon.output, stm.NPOR)
->>>>>>> fac02805c31fce1aa6bd138f9c1c69989f4a74f2
 
 public defn connect-reset (stm:JITXObject, reset-net:ResetPinNames) :
   val settings = Settings(DEFAULT-SETTINGS)
@@ -377,7 +358,6 @@ public defn set-boot (stm:JITXObject, boot-net:BootPinNames, vdd-net:PwrPinNames
     if num-boot-pins > 1 :
       check connected(stm.BOOT[1])
 
-<<<<<<< HEAD
 public defn set-boot (stm:JITXObject, boot-net:BootPinNames, vdd-net:PwrPinNames, gnd-net:GndPinNames, boot-from:String) :
   val settings = Settings(DEFAULT-SETTINGS)
   set-boot(stm, boot-net, vdd-net, gnd-net, boot-from, settings[`boot-resistor])
@@ -403,9 +383,6 @@ public defn set-boot (stm:JITXObject, boot-from:String) :
   set-boot(stm, BOOT, VDD, VSS, boot-from, settings[`boot-resistor])
 
 defn supports? (module:InstantiableType, bundle:PortType) -> True|False :
-=======
-defn supports? (module:InstantiableType, bundle:Bundle) -> True|False :
->>>>>>> fac02805c31fce1aa6bd138f9c1c69989f4a74f2
   pcb-module temp :
     inst i : module
     require r:bundle from i
@@ -413,40 +390,20 @@ defn supports? (module:InstantiableType, bundle:Bundle) -> True|False :
   val result = assign-pins?()
   result is-not False
 
-public defn connect-debug (stm:JITXObject, debug-interface:Bundle, connector:Instantiable) :
+public defn connect-debug (stm:JITXObject, debug-interface:PortType, connector:Instantiable) :
   inside pcb-module:
-<<<<<<< HEAD
     if supports?(instantiable-type(stm), debug-interface) and supports?(connector, debug-interface) :
       inst debug-con : connector
-=======
-    if supports?(instantiable-type(stm), debug-interface) and supports?(connector, debug-interface):
-      public inst debug-con : connector
->>>>>>> fac02805c31fce1aa6bd138f9c1c69989f4a74f2
       require debug-m:debug-interface from stm
       require debug-c:debug-interface from debug-con
-      
       net DEBUG (debug-m debug-c)
       schematic-group(debug-con) = debug
-<<<<<<< HEAD
       val power-pins = power-pins-list(stm, VDD)
       val gnd-pins = gnd-pins-list(stm, VSS)
       if not empty?(power-pins) and not empty?(gnd-pins) :
         if has-port?(debug-con, "power") :
           net (debug-con.power.vdd, power-pins[0])
           net (debug-con.power.gnd, gnd-pins[0])
-=======
-
-      if has-port?(debug-con, "power") :
-        require debug-p: power from debug-con
-        net (debug-p.vdd, power-pins(stm)[0])
-        net (debug-p.gnd, gnd-pins(stm)[0])
-
-      ; only connect reset to NRST if using the SWD bundle      
-      if name(debug-interface) == name(swd()) : 
-        require debug-reset: reset from self.debug-con
-        net (debug-reset.reset, stm.NRST)
-
->>>>>>> fac02805c31fce1aa6bd138f9c1c69989f4a74f2
     else :
       fatal("Unsupported debug-interface on %_" % [ref(stm)])
 
@@ -480,7 +437,6 @@ public defn setup-clocks (stm:JITXObject, HSE-freq:Double, HSE-ppm:Double, HSE-s
               net (hf-xtal.gnd, gnd-pin)
 
             require hf-osc:high-freq-oscillator from stm
-<<<<<<< HEAD
             net (hf-osc.in hf-xtal.p[1])
             net (hf-osc.out hf-xtal.p[2])
             val hf-cb = add-xtal-caps(hf-xtal, gnd-pin)
@@ -588,27 +544,3 @@ public defn connect-stm (stm:JITXObject, settings:?) :
 
 
 
-=======
-            inst osc :  ocdb/abracon/AMPM/module(HSE-freq)
-            net (hf-osc.in osc.out)
-            net (osc.power.gnd, gnd-pin)
-            net (osc.power.vdd, power-pin)
-          else : 
-            println("MEMS oscillators in library can't meet ppm. Try a 'crystal' source.")
-    if supports?(instantiable-type(stm), low-freq-oscillator) and LSE-ppm < 0.03 :
-      switch(LSE-source):
-        "crystal" :
-          if LSE-freq == 32.768e3 :
-            require lf-osc:low-freq-oscillator from stm
-            inst losc : ocdb/epson/FC-135/component
-            net (lf-osc.in losc.p[1])
-            net (lf-osc.out losc.p[2])
-            val lf-cb = add-xtal-caps(losc, gnd-pin)
-            check-oscillator(losc, CrystalOscillator(3.1e-6, 0.5e-6, 4.0e-12, 50.0e-6 * 32.768e3, 32.768e3), lf-cb)
-          else:
-            println("Unsupported frequency for LSE: %_. Try 32.768e3." % [LSE-freq])
-        else:
-          println("Unsupported sourece for LSE. Try a 'crystal' source.")
-    else if LSE-ppm < 0.03:
-      println("%_ does not support an external LSE source." % [ref(stm)])
->>>>>>> fac02805c31fce1aa6bd138f9c1c69989f4a74f2

--- a/components/texas-instruments/HDC1080.stanza
+++ b/components/texas-instruments/HDC1080.stanza
@@ -58,3 +58,5 @@ public pcb-module module :
   net (i2c.sda, sensor.SDA)
   net (i2c.scl, sensor.SCL)
   bypass-cap-strap(sensor.VDD, sensor.GND, 0.1e-6)
+
+  schematic-group(self) = HDC1080

--- a/components/texas-instruments/TPD3S0x4.stanza
+++ b/components/texas-instruments/TPD3S0x4.stanza
@@ -48,6 +48,8 @@ public pcb-module module :
   cap-strap(tpd.IN, tpd.GND, 0.1e-6)
   cap-strap(tpd.OUT, tpd.GND, 10.0e-6)
 
+  schematic-group(self) = TPD3S0x4
+
   ; Pass through the supplied voltage
   ; eval-when has-property?(tpd.IN.rail-voltage):
     ; property(tpd.OUT.power-supply-pin) = PowerSupplyPin(property(tpd.IN.rail-voltage), 0.6) 

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/designs/ble-mote :
   import ocdb/generic-components
   import ocdb/property-structs
   import ocdb/checks
+  import ocdb/rules
 
 
 OPERATING-TEMPERATURE = [-20.0 50.0]
@@ -134,6 +135,7 @@ pcb-module sensor-mote :
   net VBUS (usb.usb-2.vbus.vdd)
   net USB-N (usb.usb-2.data.N)
   net USB-P (usb.usb-2.data.P)
+
   ; Set up netclasses
   val power-net-class = NetClass(`Power, [`min-trace => 0.50])
   for n in [P5V0 P3V3 VBUS] do :
@@ -145,19 +147,22 @@ pcb-module sensor-mote :
 
   check-design(self)
 
+val final-design = run-final-passes(sensor-mote)
+
 ; === Setup visualizations and exports ===
 ; Set the active design directory for CAD
 set-design("hardware/ble-mote")
-
-val final-design = run-final-passes(sensor-mote)
-
 ; Configure design to have a default 4-layer stackup and design rules.
-make-default-board(final-design, 4, board-shape)
+set-main-module(final-design)
+set-board(default-board(4, board-shape))
+set-rules(jlcpcb-rules)
+run-checks("checks.txt")
 
-; set-export-board?(false)
+; set-config-sets([`groups])
+set-paper(ANSI-A4)
 
-set-config-sets([`groups])
 ; Export CAD
+; set-export-board?(false)
 export-cad()
 
 ; Solve and export Bill of Materials

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -118,6 +118,7 @@ pcb-module sensor-mote :
   ; Add a ground plane
   geom(gnd):
     copper-pour(LayerIndex(1), isolate = 0.1, rank = 1) = board-shape
+    copper-pour(LayerIndex(2), isolate = 0.1, rank = 1) = board-shape
 
   ; Apply groups to sub-circuits for schematic
   schematic-group([proc, ant]) = proc

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -126,13 +126,26 @@ pcb-module sensor-mote :
   schematic-group(hum) = hum
   schematic-group(particle-counter) = particle-counter
 
+  net VBUS (usb.usb-2.vbus.vdd)
+  net USB-N (usb.usb-2.data.N)
+  net USB-P (usb.usb-2.data.P)
+  ; Set up netclasses
+  val power-net-class = NetClass(`Power, [`min-trace => 0.50])
+  for n in [P5V0 P3V3 VBUS] do :
+    property(n.net-class) = power-net-class
+  ; Rules for JLC2313 Stackup, 45-Ohm characteristic impedance
+  val usb-net-class = NetClass(`USB, [`min-trace => 0.224 `min-space => 0.3])
+  for n in [USB-N USB-P] do :
+    property(n.net-class) = usb-net-class
+
   check-design(self)
 
 ; === Setup visualizations and exports ===
 ; Set the active design directory for CAD
-set-design("ble-mote")
+set-design("hardware/ble-mote")
 
 val final-design = run-final-passes(sensor-mote)
+
 ; Configure design to have a default 4-layer stackup and design rules.
 make-default-board(final-design, 4, board-shape)
 

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -126,6 +126,11 @@ pcb-module sensor-mote :
   schematic-group(hum) = hum
   schematic-group(particle-counter) = particle-counter
 
+  layout-group([proc, ant]) = proc
+  layout-group([usb, ldo, cp2105]) = power
+  layout-group(hum) = hum
+  layout-group(particle-counter) = particle-counter
+
   net VBUS (usb.usb-2.vbus.vdd)
   net USB-N (usb.usb-2.data.N)
   net USB-P (usb.usb-2.data.P)
@@ -149,12 +154,15 @@ val final-design = run-final-passes(sensor-mote)
 ; Configure design to have a default 4-layer stackup and design rules.
 make-default-board(final-design, 4, board-shape)
 
-; Show the Schematic and PCB for the design
-view-board()
-view-schematic()
+; set-export-board?(false)
 
+set-config-sets([`groups])
 ; Export CAD
 export-cad()
 
 ; Solve and export Bill of Materials
 ; export-bom()
+
+; Show the Schematic and PCB for the design
+view-board()
+view-schematic()

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -80,7 +80,7 @@ pcb-module sensor-mote :
   public inst hum : ocdb/texas-instruments/HDC1080/module
   require i2c:i2c from proc
   net H-I2C (i2c, hum.i2c)
-  add-open-drain-pullups(i2c, ldo.vout.vdd)
+  val i2c-pullups = add-open-drain-pullups(i2c, ldo.vout.vdd)
 
   ; Add the particle counter interface and place on bottom, and connect
   public inst particle-counter : pms7003
@@ -100,21 +100,26 @@ pcb-module sensor-mote :
   net (protected-usb.vbus particle-counter.vin)
 
   ; Add a BRIGHT 60.0mcd RGB led indicator to the processor (to be visible outside)
-  add-rgb-indicator(60.0, proc, P3V3)
+  val rgb = add-rgb-indicator(60.0, proc, P3V3)
 
   ; Add probe loops
-  add-testpoint([ proc.uart.tx
-                  proc.uart.rx
-                  hum.i2c.sda
-                  hum.i2c.scl
-                  proc.en
-                  proc.boot
-                  PC-TX
-                  PC-RX
-                  P5V0
-                  P3V3
-                  gnd gnd gnd
-                  ], "smd-loop")
+  val debug-tps = add-testpoint([ proc.uart.tx
+                                  proc.uart.rx
+                                  proc.en
+                                  gnd
+                                  proc.boot], Testpoint-SMDLoop)
+
+  val power-tps = add-testpoint([ P5V0
+                                  P3V3
+                                  gnd ], Testpoint-SMDLoop)
+
+  val hum-tps = add-testpoint([   hum.i2c.sda
+                                  hum.i2c.scl], Testpoint-SMDLoop)
+
+  val pms-tps = add-testpoint([   PC-TX
+                                  PC-RX
+                                  gnd ], Testpoint-SMDLoop)
+ 
 
   ; Add a ground plane
   geom(gnd):
@@ -122,19 +127,19 @@ pcb-module sensor-mote :
     copper-pour(LayerIndex(2), isolate = 0.1, rank = 1) = board-shape
 
   ; Apply groups to sub-circuits for schematic
-  schematic-group([proc, ant]) = proc
-  schematic-group([usb, ldo, cp2105]) = power
-  schematic-group(hum) = hum
-  schematic-group(particle-counter) = particle-counter
+  schematic-group([proc, ant, debug-tps rgb, i2c-pullups]) = esp32
+  schematic-group([usb, ldo, cp2105, power-tps containing-instance(protected-usb) as JITXObject]) = power
+  schematic-group([hum hum-tps]) = humidity-sensor
+  schematic-group([particle-counter pms-tps]) = particle-counter
 
   layout-group([proc, ant]) = proc
-  layout-group([usb, ldo, cp2105]) = power
-  layout-group(hum) = hum
+  layout-group([usb, ldo, cp2105 containing-instance(protected-usb) as JITXObject]) = power
+  layout-group([hum hum-tps]) = hum
   layout-group(particle-counter) = particle-counter
 
   net VBUS (usb.usb-2.vbus.vdd)
-  net USB-N (usb.usb-2.data.N)
-  net USB-P (usb.usb-2.data.P)
+  net D- (usb.usb-2.data.N)
+  net D+ (usb.usb-2.data.P)
 
   ; Set up netclasses
   val power-net-class = NetClass(`Power, [`min-trace => 0.50])
@@ -142,7 +147,7 @@ pcb-module sensor-mote :
     property(n.net-class) = power-net-class
   ; Rules for JLC2313 Stackup, 45-Ohm characteristic impedance
   val usb-net-class = NetClass(`USB, [`min-trace => 0.224 `min-space => 0.3])
-  for n in [USB-N USB-P] do :
+  for n in [D- D+] do :
     property(n.net-class) = usb-net-class
 
   check-design(self)

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -126,7 +126,7 @@ pcb-module sensor-mote :
     copper-pour(LayerIndex(1), isolate = 0.1, rank = 1) = board-shape
     copper-pour(LayerIndex(2), isolate = 0.1, rank = 1) = board-shape
 
-  ; Apply groups to sub-circuits for schematic
+  ; Apply groups to sub-circuits for schematic and layout
   schematic-group([proc, ant, debug-tps rgb, i2c-pullups]) = esp32
   schematic-group([usb, ldo, cp2105, power-tps containing-instance(protected-usb) as JITXObject]) = power
   schematic-group([hum hum-tps]) = humidity-sensor
@@ -163,16 +163,16 @@ set-board(default-board(4, board-shape))
 set-rules(jlcpcb-rules)
 run-checks("checks.txt")
 
-; set-config-sets([`groups])
 set-paper(ANSI-A4)
-
-; Export CAD
-; set-export-board?(false)
-export-cad()
-
-; Solve and export Bill of Materials
-; export-bom()
 
 ; Show the Schematic and PCB for the design
 view-board()
 view-schematic()
+
+; Export CAD
+; set-export-board?(false)
+; export-cad()
+
+; Solve and export Bill of Materials
+; export-bom()
+

--- a/modules/protection.stanza
+++ b/modules/protection.stanza
@@ -29,7 +29,6 @@ public defn esd-clamp (bundle:JITXObject, gnd:JITXObject) -> JITXObject :
           net (bundle, clamp.usb-in)
           net (clamp.usb-in.vbus.vdd, clamp.en)
           ; Return protected port
-          schematic-group(clamp) = power
           clamp.usb-out
         else if pb == gpio :
           inst tvs : ocdb/toshiba/DF2B6M4ASL-L3F/component

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -37,8 +37,13 @@ public defn add-open-drain-pullups (bus:JITXObject, vio:JITXObject, clk-rate:Dou
   inside pcb-module:
     val rise-time = 0.35 / (clk-rate * 5.0) ; Signal bandwidth~ 5x clock rate for fairly sharp edge
     val r = closest-std-val(rise-time / (0.8473 * bus-capacitance), 10.0)
-    for p in ports(bus) do :
-      res-strap(p, vio, r)
+    pcb-module collector (r-val:Double, count:Int):
+      public inst r : chip-resistor(r-val)[count]
+    inst rs:collector(r, length(ports(bus)))
+    for (p in ports(bus), i in 0 to false) do :
+      net (rs.r[i].p[1] p)
+      net (rs.r[i].p[2] vio)
+    rs
 
 ; Default is 100kHz clock rate, 100pF bus capacitance.
 public defn add-open-drain-pullups (bus:JITXObject, vio:JITXObject) :

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -966,10 +966,13 @@ public pcb-module micro-usb-connector :
   ; RC filter connection for chassis gnd
   res-strap(con.SHIELD, con.GND, 100.0e3)
   cap-strap(con.SHIELD, con.GND, 0.1e-6)
+  net SHIELD (con.SHIELD)
   net D+ (usb-2.data.P con.D+)
   net D- (usb-2.data.N con.D-)
   net ID (usb-2.id con.ID)
   property(con.VCC.power-supply-pin) = PowerSupplyPin(5.0, 0.5)
+
+  schematic-group(self) = micro-usb
 
 ; USB2 device connection via USBC connector
 public pcb-module usb2-on-a-usb-c-connector :
@@ -1184,6 +1187,8 @@ public pcb-module inverted-f-antenna :
   place(c0) at loc(-0.05, -1.45, 90.0) on Top
   place(l) at loc(-0.5, -2.6) on Top
 
+  schematic-group(self) = inverted-f-antenna
+
 ; ========================================================
 ; =================== Indicators =========================
 ; ========================================================
@@ -1194,15 +1199,22 @@ public pcb-module inverted-f-antenna :
 ; Adds an RGB led to a processor using PWM pins
 public defn add-rgb-indicator (brightness:Double, proc:JITXObject, vin:JITXObject):
   inside pcb-module:
-    val vio = 3.3 ; TODO: get this from the vin pin property
-    ; Calculate resistance to get appropriate brightness
-    defn calc-r (l:JITXObject, brightness:Double, vio:Double):
-      val i = PWL(property(l.mcd-current))[brightness]
-      closest-std-val((vio - property(l.forward-voltage)) / i, 1.0)
-    
-    public inst led : ocdb/foshan-optoelectronics/FM-B2020RGBA-HG/component ; TODO: make generic
+    pcb-module rgb-indicator :
+      port pwm : timer[3]
+      val vio = 3.3 ; TODO: get this from the vin pin property
+      ; Calculate resistance to get appropriate brightness
+      defn calc-r (l:JITXObject, brightness:Double, vio:Double):
+        val i = PWL(property(l.mcd-current))[brightness]
+        closest-std-val((vio - property(l.forward-voltage)) / i, 1.0)
+      public inst led : ocdb/foshan-optoelectronics/FM-B2020RGBA-HG/component ; TODO: make generic
+      
+      res-strap(pwm[0].timer, led.l.r, calc-r(led.l.r, brightness, vio))
+      res-strap(pwm[1].timer, led.l.g, calc-r(led.l.g, brightness, vio))
+      res-strap(pwm[2].timer, led.l.b, calc-r(led.l.b, brightness, vio))
+
+    inst rgb:rgb-indicator
     require pwm:timer[3] from proc
-    res-strap(pwm[0].timer, led.l.r, calc-r(led.l.r, brightness, vio))
-    res-strap(pwm[1].timer, led.l.g, calc-r(led.l.g, brightness, vio))
-    res-strap(pwm[2].timer, led.l.b, calc-r(led.l.b, brightness, vio))
-    net (vin, led.l.a)
+    net (vin, rgb.led.l.a)
+    net (pwm rgb.pwm)
+    rgb
+

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -1212,7 +1212,7 @@ public pcb-module inverted-f-antenna :
 public defn add-rgb-indicator (brightness:Double, proc:JITXObject, vin:JITXObject):
   inside pcb-module:
     pcb-module rgb-indicator :
-      port pwm : timer[3]
+      port control-pins : timer[3]
       val vio = 3.3 ; TODO: get this from the vin pin property
       ; Calculate resistance to get appropriate brightness
       defn calc-r (l:JITXObject, brightness:Double, vio:Double):
@@ -1220,13 +1220,13 @@ public defn add-rgb-indicator (brightness:Double, proc:JITXObject, vin:JITXObjec
         closest-std-val((vio - property(l.forward-voltage)) / i, 5.0)
       public inst led : ocdb/foshan-optoelectronics/FM-B2020RGBA-HG/component ; TODO: make generic
       
-      res-strap(pwm[0].timer, led.l.r, calc-r(led.l.r, brightness, vio))
-      res-strap(pwm[1].timer, led.l.g, calc-r(led.l.g, brightness, vio))
-      res-strap(pwm[2].timer, led.l.b, calc-r(led.l.b, brightness, vio))
+      res-strap(control-pins[0].timer, led.l.r, calc-r(led.l.r, brightness, vio))
+      res-strap(control-pins[1].timer, led.l.g, calc-r(led.l.g, brightness, vio))
+      res-strap(control-pins[2].timer, led.l.b, calc-r(led.l.b, brightness, vio))
 
     inst rgb:rgb-indicator
-    require pwm:timer[3] from proc
+    require control-pins:timer[3] from proc
     net (vin, rgb.led.l.a)
-    net (pwm rgb.pwm)
+    net (control-pins rgb.control-pins)
     rgb
 

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -1011,26 +1011,38 @@ public defn attach-programming-connector (proc:JITXObject, vio:JITXObject, intf:
 ; ================== Testpoint functions =================
 ; ========================================================
 
-public defn add-testpoint (rs:Tuple<JITXObject>, method:String) :
+public pcb-enum ocdb/generic-components/Testpoint :
+  Testpoint-SMDLoop
+  Testpoint-SMDPad
+  Testpoint-PTHLoop
+
+pcb-module test-points (count:Int, method:ocdb/generic-components/Testpoint) :
+  port tp : pin[count]
+  val points = match(method) :
+    (method:Testpoint-PTHLoop) :
+      var color = "yellow"
+      ; if r == #R(gnd):
+      ;   color = "black"
+      inst point : ocdb/keystone/500xx/component(color)[count]
+      point
+    (method:Testpoint-SMDLoop) :
+      inst point : ocdb/te-connectivity/RC/component[count]
+      point
+    (method:Testpoint-SMDPad) :
+      inst point : gen-testpad(2.0)[count]
+      point
+  for i in 0 to count do :
+    net (tp[i] points[i].p)
+
+public defn add-testpoint (rs:Tuple<JITXObject>, method:ocdb/generic-components/Testpoint) :
   inside pcb-module :
-    for r in rs do :
-      if method == "pth-loop" :
-        var color = "yellow"
-        ; if r == #R(gnd):
-        ;   color = "black"
-        inst tp : ocdb/keystone/500xx/component(color)
-        net (tp.p, r)
-      else if method == "smd-loop" :
-        inst tp : ocdb/te-connectivity/RC/component
-        net (tp.p, r)
-      else if method == "smd-pad" :
-        inst tp : gen-testpad(2.0)
-        net (tp.p, r)
-      else :
-        fatal("Unsupported add-testpoint method.")
+    inst test-points:test-points(length(rs), method)
+    for (r in rs, i in 0 to false) do :
+      net (test-points.tp[i] r)
+    test-points
 
 public defn add-testpoint (rs:Tuple<JITXObject>) :
-  add-testpoint(rs, "pth-loop")
+  add-testpoint(rs, Testpoint-PTHLoop)
 
 public pcb-component gen-testpad (d:Double) :
   pin tp
@@ -1205,7 +1217,7 @@ public defn add-rgb-indicator (brightness:Double, proc:JITXObject, vin:JITXObjec
       ; Calculate resistance to get appropriate brightness
       defn calc-r (l:JITXObject, brightness:Double, vio:Double):
         val i = PWL(property(l.mcd-current))[brightness]
-        closest-std-val((vio - property(l.forward-voltage)) / i, 1.0)
+        closest-std-val((vio - property(l.forward-voltage)) / i, 5.0)
       public inst led : ocdb/foshan-optoelectronics/FM-B2020RGBA-HG/component ; TODO: make generic
       
       res-strap(pwm[0].timer, led.l.r, calc-r(led.l.r, brightness, vio))


### PR DESCRIPTION
Updated to a way of writing functional generators like `add-open-drain-pullups` that returns the components added to the design inside a module. Now you can access/group those components.

Also added an example of design rules to ble mote, updated ESP32 to not map input only pins to gpio, added some groups.