### PR TITLE
improved footprint name for Tag-Connect components (helpful on export)

### DIFF
--- a/components/tag-connect/TC2030-IDC-NL.stanza
+++ b/components/tag-connect/TC2030-IDC-NL.stanza
@@ -17,7 +17,7 @@ defpackage ocdb/tag-connect/TC2030-IDC-NL :
 ; NOTE PINOUT ORDER DIFFERENT THAN 10-PIN
 ; Datasheet showing pinout: https://www.tag-connect.com/wp-content/uploads/bsk-pdf-manager/2019/12/TC2030-IDC-NL-Datasheet-Rev-B.pdf
 
-pcb-landpattern footprint :
+pcb-landpattern TC2030-IDC-NL-footprint :
   ; landing pads
   for (l in grid-locs(2, 3, 1.27, 1.27), i in [2 4 6 1 3 5]) do :
     pad p[i] : testpoint-pad(0.787) at l
@@ -32,11 +32,13 @@ pcb-landpattern footprint :
 
 public pcb-component component :
   description = "Insertion point for TC-2030-NL connector"
+  manufacturer = "Tag-Connect"
+  mpn = "TC2030-IDC-NL"
   port p: pin[1 through 6]
 
   val sym = header-symbol(6,2)
   symbol = sym(for i in 1 through 6 do : p[i] => sym.p[i])
-  landpattern = footprint(for i in 1 through 6 do : p[i] => footprint.p[i])
+  landpattern = TC2030-IDC-NL-footprint(for i in 1 through 6 do : p[i] => TC2030-IDC-NL-footprint.p[i])
   reference-prefix = "J"
 
   supports swd([SWD-SWO, SWD-TRACESWO]) :

--- a/components/tag-connect/TC2030-IDC.stanza
+++ b/components/tag-connect/TC2030-IDC.stanza
@@ -17,7 +17,7 @@ defpackage ocdb/tag-connect/TC2030-IDC :
 ; NOTE PINOUT ORDER DIFFERENT THAN 10-PIN
 ; Datasheet showing pinout: https://www.tag-connect.com/wp-content/uploads/bsk-pdf-manager/2019/12/TC2030-IDC-Datasheet-Rev-B.pdf
 
-pcb-landpattern footprint :
+pcb-landpattern TC2030-IDC-footprint :
   ; landing pads
   for (l in grid-locs(2, 3, 1.27, 1.27), i in [2 4 6 1 3 5]) do :
     pad p[i] : testpoint-pad(0.787) at l
@@ -38,12 +38,14 @@ pcb-landpattern footprint :
 
 public pcb-component component :
   description = "Insertion point for TC-2030 connector"
+  manufacturer = "Tag-Connect"
+  mpn = "TC2030-IDC"
   property(self.trust) = "built"
   port p: pin[1 through 6]
 
   val sym = header-symbol(6,2)
   symbol = sym(for i in 1 through 6 do : p[i] => sym.p[i])
-  landpattern = footprint(for i in 1 through 6 do : p[i] => footprint.p[i])
+  landpattern = TC2030-IDC-footprint(for i in 1 through 6 do : p[i] => TC2030-IDC-footprint.p[i])
   reference-prefix = "J"
 
   supports swd([SWD-SWO, SWD-TRACESWO]) :

--- a/components/tag-connect/TC2050-IDC-NL.stanza
+++ b/components/tag-connect/TC2050-IDC-NL.stanza
@@ -17,7 +17,7 @@ defpackage ocdb/tag-connect/TC2050-IDC-NL :
 ; NOTE UNUSUAL PINOUT
 ; Datasheet showing pinout: https://www.tag-connect.com/wp-content/uploads/bsk-pdf-manager/TC2050-IDC-NL_Datasheet_8.pdf
 
-pcb-landpattern footprint :
+pcb-landpattern TC2050-IDC-NL-footprint :
   for (l in grid-locs(2, 5, 1.27, 1.27), i in [10 9 8 7 6 1 2 3 4 5]) do :
     pad p[i] : testpoint-pad(0.787) at l
   layer(Cutout()) = Circle((- 3.81), 0.0, 0.5)
@@ -28,6 +28,8 @@ pcb-landpattern footprint :
 
 public pcb-component component :
   description = "Insertion point for TC-2050-NL connector"
+  manufacturer = "Tag-Connect"
+  mpn = "TC2050-IDC-NL"
   port p: pin[1 through 10]
   pin-properties :
     [pin:Ref     | pads:Int ... | side:Dir]
@@ -41,7 +43,7 @@ public pcb-component component :
     [p[8]          | 8             | Right    ]
     [p[7]          | 7             | Right    ]
     [p[6]          | 6             | Right    ]
-  landpattern = footprint(for i in 1 through 10 do : p[i] => footprint.p[i])
+  landpattern = TC2050-IDC-NL-footprint(for i in 1 through 10 do : p[i] => TC2050-IDC-NL-footprint.p[i])
   reference-prefix = "J"
   make-box-symbol()
 

--- a/components/tag-connect/TC2050-IDC.stanza
+++ b/components/tag-connect/TC2050-IDC.stanza
@@ -18,7 +18,7 @@ defpackage ocdb/tag-connect/TC2050-IDC :
 ; NOTE UNUSUAL PINOUT
 ; Datasheet showing pinout: https://www.tag-connect.com/wp-content/uploads/bsk-pdf-manager/TC2050-IDC_Datasheet_7.pdf
 
-pcb-landpattern footprint :
+pcb-landpattern TC2050-IDC-footprint :
   for (l in grid-locs(2, 5, 1.27, 1.27), i in [10 9 8 7 6 1 2 3 4 5]) do :
     pad p[i] : testpoint-pad(0.787) at l
   layer(Cutout()) = Circle((- 3.81), 0.0, 0.5)
@@ -35,6 +35,8 @@ pcb-landpattern footprint :
 
 public pcb-component component :
   description = "Insertion point for TC-2050 connector"
+  manufacturer = "Tag-Connect"
+  mpn = "TC2050-IDC"
   port p: pin[1 through 10]
   pin-properties :
     [pin:Ref     | pads:Int ... | side:Dir]
@@ -48,7 +50,7 @@ public pcb-component component :
     [p[8]          | 8             | Right    ]
     [p[7]          | 7             | Right    ]
     [p[6]          | 6             | Right    ]
-  landpattern = footprint(for i in 1 through 10 do : p[i] => footprint.p[i])
+  landpattern = TC2050-IDC-footprint(for i in 1 through 10 do : p[i] => TC2050-IDC-footprint.p[i])
   reference-prefix = "J"
   make-box-symbol()
 


### PR DESCRIPTION
Small PR to improve footprint name for Tag-Connect components. The exported footprint is no longer called just 'footprint` rather it is more descriptive now.