### PR TITLE
Feature/jitx 1197 check 2 pin connected

### DIFF
--- a/designs/usb-light.stanza
+++ b/designs/usb-light.stanza
@@ -12,6 +12,7 @@ defpackage ocdb/designs/usb-light :
   import ocdb/tolerance
   import ocdb/symbols
   import ocdb/property-structs
+  import ocdb/checks
 
 val BOARD-SHAPE = RoundedRectangle(25.0, 25.0, 0.25)
 
@@ -41,6 +42,7 @@ pcb-module main-board:
   place(conn) at loc(10.75, 0.0, 90.0) on Top
 
   println("Calculated Resistance = %_, Standard Value Resistance = %_" % [exact-resistance property(res[0].resistance)])
+  check-design(self)
 make-default-board(main-board, 4, BOARD-SHAPE)
 view-board()
 view-schematic()

--- a/tests/test-checks.stanza
+++ b/tests/test-checks.stanza
@@ -1,0 +1,57 @@
+#use-added-syntax(tests, jitx)
+defpackage ocdb/test/test-checks :
+  import core
+  import collections
+  import math
+  import jitx
+  import jitx/commands
+  import ocdb/defaults
+  import ocdb/checks
+  import ocdb/generator-utils
+
+  import ocdb/generic-components
+  import ocdb/stackups
+  import ocdb/rules
+  import ocdb/symbols
+
+pcb-module checks :
+  ; Design goes here
+  inst c1 : ceramic-cap(1.0e-6)
+  inst c2 : tantalum-cap(1.0e-6)
+  inst c3 : gen-cap-cmp(1.0e-6)
+  inst c4 : gen-tant-cap-cmp(1.0e-6)
+
+  inst r1 : chip-resistor(1.0e3)
+  inst r2 : gen-res-cmp(1.0e3)
+
+  inst i1 : smd-inductor(4.7e-6)
+  inst i2 : gen-ind-cmp(4.7e-6)
+  inst d1 : gen-led-cmp("0603")
+
+  net gnd ()
+  net single-pin1 ()
+  net single-pin2 ()
+  net single-pin3 ()
+  res-strap(gnd, single-pin1,10.0e3)
+  cap-strap(gnd, single-pin2,10.0e-9)
+  ind-strap(gnd, single-pin3,2.2e-6)
+
+  net (gnd c1.p[1] c2.c c3.p[1] c4.c r1.p[1] r2.p[1] d1.c)
+
+  #EXPECT(connected?([c1.p[1] c2.c c3.p[1] c4.c r1.p[1] r2.p[1] d1.c]))
+  #EXPECT(connected?(c1.p[2]) == false)
+  #EXPECT(connected?(c2.a) == false)
+  #EXPECT(connected?(c3.p[2]) == false)
+  #EXPECT(connected?(c4.a) == false)
+  #EXPECT(connected?(r1.p[2]) == false)
+  #EXPECT(connected?(r2.p[2]) == false)
+  #EXPECT(connected?(d1.a) == false)
+
+val brd-outline = Rectangle(50.0, 50.0)
+pcb-board B :
+  stackup = sierra-circuits-6-layer-62-mil
+  boundary = brd-outline
+  signal-boundary = brd-outline
+set-main-module(checks)
+set-board(B)
+set-rules(sierra-adv-rules)

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -17,7 +17,7 @@ defpackage ocdb/db-parts :
   import ocdb/generator-utils
   import ocdb/symbols
   import ocdb/design-vars
-
+  import ocdb/checks
 
 public deftype Component
 public defmulti x (component: Component) -> Double
@@ -190,7 +190,8 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
     match(TCR: TCR): property(self.TCR) = [positive(TCR), negative(TCR)]
     spice :
       "[R] {p[1]} {p[2]} {resistance}"
-
+    check connected(self.p[1])
+    check connected(self.p[2])
   my-resistor
 
 ; ========================================================
@@ -379,6 +380,8 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
       else :
         spice :
           "[C] {a} {c} {capacitance(capacitor)}"
+      check connected(self.a)
+      check connected(self.c)
 
     else :
       port p : pin[1 through 2]
@@ -405,6 +408,8 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
       else :
         spice :
           "[C] {p[1]} {p[2]} {capacitance(capacitor)}"
+      check connected(self.p[1])
+      check connected(self.p[2])
 
     emodel = EModel-Capacitor(capacitance(capacitor),
                              emodel-pourcentage-tolerance(tolerance(capacitor)),
@@ -620,7 +625,8 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
     property(self.self-resonant-frequency) = self-resonant-frequency(inductor)
     spice :
       "[L] {p[1]} {p[2]} {inductance}"
-
+    check connected(self.p[1])
+    check connected(self.p[2])
   my-inductor
 
 ; ========================================================

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -17,6 +17,7 @@ defpackage ocdb/generic-components:
   import ocdb/property-structs
   import ocdb/symbol-utils
   import ocdb/tolerance
+  import ocdb/checks
 
 ; ========================================================
 ; ====== Standard packages for the passive solver ========
@@ -295,6 +296,8 @@ public pcb-component gen-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg-name
   property(self.tolerance) = tol
   property(self.rated-voltage) = max-v
   property(self.rated-temperature) = [-55.0 125.0]
+  check connected(self.p[1])
+  check connected(self.p[2])
 
 public defn gen-cap-cmp (cap:Double, tol:Double, max-v:Double) :
   gen-cap-cmp(cap, tol, max-v, "0402")
@@ -338,6 +341,8 @@ public pcb-component gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg
   property(self.rated-current-pk) = 3.7
   property(self.rated-current-rms) = [[25.0 0.298] [85.0 0.268] [125.0 0.119]]
   property(self.rated-temperature) = [-55.0 125.0]
+  check connected(self.a)
+  check connected(self.c)
 
 public defn gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double) :
   gen-tant-cap-cmp(cap, tol, max-v, "0402")
@@ -376,6 +381,8 @@ public pcb-component gen-res-cmp (r-type:ResistorSymbolType, res:Double, tol:Dou
   property(self.resistance) = res
   spice :
     "[R] {p[1]} {p[2]} {res}"
+  check connected(self.p[1])
+  check connected(self.p[2])
 
 public defn gen-res-cmp (res:Double, tol:Double, pkg:String) :
   gen-res-cmp(ResistorStd, res, tol, 0.0625, pkg)
@@ -407,6 +414,8 @@ public pcb-component gen-ind-cmp (l-type:InductorSymbolType, ind:Double, tol:Dou
   property(self.inductance) = ind
   property(self.tolerance) = (tol * 0.01)
   property(self.max-current) = max-i
+  check connected(self.p[1])
+  check connected(self.p[2])
 
 public defn gen-ind-cmp (ind:Double, tol:Double) :
   gen-ind-cmp(InductorStd, ind, tol, 0.1) ; 100mA default
@@ -433,6 +442,8 @@ public pcb-component gen-led-cmp (vf:Toleranced, itest:Double, color:String, pkg
   property(self.forward-voltage) = vf-center ; Vf
   property(self.test-current) = itest ; If or Itest
   property(self.NamedColor) = color
+  check connected(self.a)
+  check connected(self.c)
 
 public defn gen-led-cmp (vf:Toleranced, itest:Double, color:String, pkg-name:String) :
   gen-led-cmp(vf, itest, color, pkg-name, DENSITY-LEVEL)


### PR DESCRIPTION
Add schematic checks: each pin of database and generic two pin resistors, capacitors, inductors, and leds are connected to at least one other pin in the design.