### PR TITLE
Allow default-component to accept padless land patterns

### DIFF
--- a/utils/defaults.stanza
+++ b/utils/defaults.stanza
@@ -103,15 +103,15 @@ public defn make-single-module-design (module:Instantiable) :
 ; Create a component given its land pattern
 public pcb-component default-component (lp:LandPattern) : 
   val pads = to-tuple(pads(lp))
-  if empty?(pads) :
+  if empty?(pads):
     landpattern = lp()
-  else if length(pads) == 1 :
+  else if length(pads) == 1:
     val r = ref(pads[0])
     pin-properties: 
       [pin: Ref | pads: Ref ... | side: Dir]
       [(r) | (r) | Down ]
     assign-landpattern(lp)
-  else :
+  else:
     val n = length(pads) / 2
     val [left, right] = [
       pads[0 to n],

--- a/utils/defaults.stanza
+++ b/utils/defaults.stanza
@@ -103,13 +103,15 @@ public defn make-single-module-design (module:Instantiable) :
 ; Create a component given its land pattern
 public pcb-component default-component (lp:LandPattern) : 
   val pads = to-tuple(pads(lp))
-  fatal("Missing pads") when empty?(pads)
-  if length(pads) == 1:
+  if empty?(pads) :
+    landpattern = lp()
+  else if length(pads) == 1 :
     val r = ref(pads[0])
     pin-properties: 
       [pin: Ref | pads: Ref ... | side: Dir]
       [(r) | (r) | Down ]
-  else:
+    assign-landpattern(lp)
+  else :
     val n = length(pads) / 2
     val [left, right] = [
       pads[0 to n],

--- a/utils/defaults.stanza
+++ b/utils/defaults.stanza
@@ -103,21 +103,21 @@ public defn make-single-module-design (module:Instantiable) :
 ; Create a component given its land pattern
 public pcb-component default-component (lp:LandPattern) : 
   val pads = to-tuple(pads(lp))
-  if empty?(pads):
+  if empty?(pads) :
     landpattern = lp()
-  else if length(pads) == 1:
+  else if length(pads) == 1 :
     val r = ref(pads[0])
-    pin-properties: 
+    pin-properties:
       [pin: Ref | pads: Ref ... | side: Dir]
       [(r) | (r) | Down ]
     assign-landpattern(lp)
-  else:
+  else :
     val n = length(pads) / 2
     val [left, right] = [
       pads[0 to n],
       pads[n to false]
     ]
-    pin-properties: 
+    pin-properties:
       [pin: Ref | pads: Ref ... | side: Dir]
       for p in left do: 
         [(ref(p)) | (ref(p)) | Left]

--- a/utils/defaults.stanza
+++ b/utils/defaults.stanza
@@ -107,7 +107,7 @@ public pcb-component default-component (lp:LandPattern) :
     landpattern = lp()
   else if length(pads) == 1 :
     val r = ref(pads[0])
-    pin-properties:
+    pin-properties: 
       [pin: Ref | pads: Ref ... | side: Dir]
       [(r) | (r) | Down ]
     assign-landpattern(lp)
@@ -117,7 +117,7 @@ public pcb-component default-component (lp:LandPattern) :
       pads[0 to n],
       pads[n to false]
     ]
-    pin-properties:
+    pin-properties: 
       [pin: Ref | pads: Ref ... | side: Dir]
       for p in left do: 
         [(ref(p)) | (ref(p)) | Left]


### PR DESCRIPTION
Currently there is a `fatal` preventing `default-component` in `ocdb/defaults` from accepting a padless land pattern.
Also, single-pad land patterns broke in `default-component`.
JITX allows both of these assignments, provided they are done correctly.

Test code (not included in CI):
```
pcb-landpattern empty-lp :
  layer(SolderMask(Top)) = Circle(1.0, 2.0, 3.0)

pcb-landpattern one-pad-lp :  
  pad p[1] : smd-pad(Circle(1.0)) at loc(0.0, 0.0)
  layer(SolderMask(Top)) = Circle(1.0, 2.0, 3.0)

pcb-landpattern multi-pad-lp :
  pad p[1] : smd-pad(Circle(1.0)) at loc(0.0, 0.0)
  pad p[2] : smd-pad(Circle(1.0)) at loc(2.0, 2.0)
  layer(SolderMask(Top)) = Circle(1.0, 2.0, 3.0)

pcb-module main-module :
  inst i : default-component(empty-lp)
  inst j : default-component(one-pad-lp)
  inst k : default-component(multi-pad-lp)

make-default-board(main-module, 4, Rectangle(100.0, 100.0))
view-board()
view-schematic()
```