### PR TITLE
Feature/jitx 1573 smd pad

### DIFF
--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -270,12 +270,22 @@ public pcb-pad testpoint-pad (testpoint-shape:Shape):
 public defn testpoint-pad (diameter:Double) :
   testpoint-pad(Circle(0.5 * diameter))
 
-public pcb-pad pth-pad (pad-shape:Shape, hole-shape:Shape):
+public pcb-pad pth-pad (pad-shape:Shape, solder-mask-layer:Shape|False, paste-layer:Shape|False, hole-shape:Shape):
   name = "PTH Pad"
   shape = pad-shape
   type = TH
-  apply-soldermask()
+  if paste-layer is Shape: ; Enables paste-in-pad
+    layer(Paste(Top)) = paste-layer as Shape
+  match(solder-mask-layer):
+    (mask:False) : 
+      apply-soldermask()
+    (mask:Shape) :
+      layer(SolderMask(Top)) = mask
+      layer(SolderMask(Bottom)) = mask
   layer(Cutout()) = hole-shape
+
+public defn pth-pad (pad-shape:Shape, hole-shape:Shape):
+  pth-pad(pad-shape, false, false, hole-shape)
 
 public defn pth-pad (drill-r:Double, pad-r:Double):
   pth-pad(Circle(pad-r), Circle(drill-r))

--- a/utils/land-patterns.stanza
+++ b/utils/land-patterns.stanza
@@ -217,12 +217,19 @@ public defn soldermask-defined (lp:LandPattern):
 
   SMD-l
 
-public pcb-pad smd-pad (s:Shape):
+public pcb-pad smd-pad (copper-layer:Shape,solder-mask-layer:Shape|False,paste-layer:Shape):
   name  = "SMD Pad"
   type  = SMD
-  shape = s
-  apply-soldermask()
-  layer(Paste(Top)) = s
+  shape = copper-layer
+  layer(Paste(Top)) = paste-layer
+  match(solder-mask-layer):
+    (mask:False) : 
+      apply-soldermask()
+    (mask:Shape) :
+      layer(SolderMask(Top)) = mask
+
+public defn smd-pad (s:Shape):
+  smd-pad(s, false, s)
 
 ; Create an rectangular SMD pad 
 public defn smd-pad (anchor:Anchor, width:Double, height:Double):


### PR DESCRIPTION
Expanded SMD pad and PTH pad to accept arbitrary shapes for copper, solder mask, and paste layer. In the case of pth pad, solder mask layers are mirrored on top and bottom, copper layers are on all layers for pth.