### PR TITLE
Update Interval() to Toleranced() in OCDB - JITX 1538

### DIFF
--- a/components/abracon/ASPI-0530HI.stanza
+++ b/components/abracon/ASPI-0530HI.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/abracon/ASPI-0530HI:
   import ocdb/generator-utils
   import ocdb/generic-components
   import ocdb/property-structs
+  import ocdb/tolerance
 
 
 public pcb-component component (Ind:Double):
@@ -33,7 +34,7 @@ public pcb-component component (Ind:Double):
   symbol = sym(p[1] => sym.p[1], p[2] => sym.p[2])
   reference-prefix = "L"
 
-  property(self.rated-temperature) = RatedTemperature(Interval(-55.0 125.0, false))
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
 
 
 ; public unique pcb-module module :

--- a/components/analog-devices/AD7124-8BBCPZ.stanza
+++ b/components/analog-devices/AD7124-8BBCPZ.stanza
@@ -14,7 +14,8 @@ defpackage ocdb/analog-devices/AD7124-8BBCPZ :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
-
+  import ocdb/tolerance
+  
 pcb-landpattern cp-32-12 :
   pad p[1] : smd-pad(0.2, 0.799999) at loc(-2.45, 1.749999, 90.0)
   pad p[2] : smd-pad(0.2, 0.799999) at loc(-2.45, 1.25, 90.0)
@@ -57,7 +58,7 @@ pcb-landpattern cp-32-12 :
 
 public pcb-component component :
   val pkg = cp-32-12
-  val generic-props = GenericPin(Interval(-0.3, 3.6, false), 1500.0)
+  val generic-props = GenericPin(min-max(-0.3, 3.6), 1500.0)
   port spi:spi-peripheral()
   pin-properties :
     [pin:Ref                   | pads:Int ... | side:Dir| generic-pin:GenericPin]

--- a/components/analog-devices/ADG1408YCPZ-REEL7.stanza
+++ b/components/analog-devices/ADG1408YCPZ-REEL7.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/analog-devices/ADG1408YCPZ-REEL7 :
   import ocdb/box-symbol
   import ocdb/bundles
   import ocdb/property-structs
+  import ocdb/tolerance
 
 pcb-landpattern cp-16-13-adi :
   pad p[1] : smd-pad(0.2548, 0.807999) at loc(-1.8899, 0.974999, 90.0)
@@ -47,7 +48,7 @@ public pcb-component component :
   pin VDD
   pin VSS
   val pkg = cp-16-13-adi
-  val generic-props = GenericPin(Interval(-0.3, 3.6, false), 1500.0)
+  val generic-props = GenericPin(min-max(-0.3, 3.6), 1500.0)
   pin-properties :
     [pin:Ref  | pads:Int ... | side:Dir| generic-pin:GenericPin]
     [VDD      | 13           | Up    | generic-props ]

--- a/components/analog-devices/ADM7150.stanza
+++ b/components/analog-devices/ADM7150.stanza
@@ -13,6 +13,7 @@ defpackage ocdb/analog-devices/ADM7150:
   import ocdb/property-structs
   import ocdb/box-symbol
   import jitx/commands
+  import ocdb/tolerance
 
 doc: \<s>
 800 mA Ultralow Noise, High PSRR, RF Linear Regulator
@@ -46,7 +47,7 @@ public pcb-component component (v-out:Double) :
   make-box-symbol()
 
   assign-landpattern(soic127p-landpattern(8, [2.3 3.0]))
-  property(self.rated-temperature) = RatedTemperature(Interval(-40.0 125.0, false))
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0 125.0))
 
 
 doc: \<s>

--- a/components/analog-devices/ADM7154.stanza
+++ b/components/analog-devices/ADM7154.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/analog-devices/ADM7154:
 
   import ocdb/symbols
   import ocdb/box-symbol
+  import ocdb/tolerance
 
 public pcb-component component (v-out:Double) :
   name = "ADM7154"
@@ -43,8 +44,8 @@ public pcb-component component (v-out:Double) :
   make-box-symbol()
 
   property(self.vout.power-supply-pin) = PowerSupplyPin(v-out, 0.5) 
-  property(self.vin.power-pin) = PowerPin(Interval(2.3, 5.5, false))
-  property(self.rated-temperature) = RatedTemperature(Interval(-40.0 125.0, false))
+  property(self.vin.power-pin) = PowerPin(min-max(2.3, 5.5))
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0 125.0))
 
 public pcb-module module (v-out:Double) :
   pin vin

--- a/components/analog-devices/ADP1720ARMZ-3-3-R7.stanza
+++ b/components/analog-devices/ADP1720ARMZ-3-3-R7.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/analog-devices/ADP1720ARMZ-3-3-R7 :
   import ocdb/box-symbol
   import ocdb/bundles
   import ocdb/property-structs
+  import ocdb/tolerance
 
 pcb-landpattern rm-8-adi :
   pad p[1] : smd-pad(1.512799, 0.431) at loc(-2.1717, 0.974999, 0.0)
@@ -39,7 +40,7 @@ public pcb-component component :
   pin GND
   pin OUT
   val pkg = rm-8-adi
-  val generic-props = GenericPin(Interval(-0.3, 3.6, false), 1500.0)
+  val generic-props = GenericPin(min-max(-0.3, 3.6), 1500.0)
 
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin]

--- a/components/diodes-incorporated/AP2112.stanza
+++ b/components/diodes-incorporated/AP2112.stanza
@@ -13,6 +13,7 @@ defpackage ocdb/diodes-incorporated/AP2112:
   import ocdb/symbols
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
 
 public pcb-component component :
   pin VEN
@@ -27,16 +28,16 @@ public pcb-component component :
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir | generic-pin:GenericPin]
     [GND     | 2            | Down     | -]
-    [VOUT    | 5            | Right    | GenericPin(Interval(0.0, 6.0, false), 4.0e3)]
-    [VIN     | 1            | Left     | GenericPin(Interval(0.0, 6.0, false), 4.0e3)]
-    [VEN     | 3            | Left     | GenericPin(Interval(0.0, 6.0, false), 4.0e3)]
+    [VOUT    | 5            | Right    | GenericPin(min-max(0.0, 6.0), 4.0e3)]
+    [VIN     | 1            | Left     | GenericPin(min-max(0.0, 6.0), 4.0e3)]
+    [VEN     | 3            | Left     | GenericPin(min-max(0.0, 6.0), 4.0e3)]
     [nc      | 4            | Down     | -]
   make-box-symbol()
   assign-landpattern(SOT95P280X145-5N)
 
   property(VOUT.power-supply-pin) = PowerSupplyPin(3.3, 0.6)
-  property(VIN.power-pin) = PowerPin(Interval(3.7, 6.5, false))
-  property(self.rated-temperature) = RatedTemperature(Interval(-40.0, 85.0, false))
+  property(VIN.power-pin) = PowerPin(min-max(3.7, 6.5))
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0, 85.0))
 
 public pcb-module module : 
   port vin : power

--- a/components/espressif/ESP32-PICO-D4.stanza
+++ b/components/espressif/ESP32-PICO-D4.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/espressif/ESP32-PICO-D4 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
 
 
 public pcb-component component :
@@ -39,7 +40,7 @@ public pcb-component component :
   pin SENSOR-CAPP 
   port nc : pin[4]
 
-  val generic-props = GenericPin(Interval(-0.3, 3.6, false), 1500.0)
+  val generic-props = GenericPin(min-max(-0.3, 3.6), 1500.0)
 
   pin-properties :
     [pin:Ref     | pads:Int ... | side:Dir| generic-pin:GenericPin]
@@ -93,13 +94,13 @@ public pcb-component component :
   make-box-symbol()
   assign-landpattern(pqfn50p700x700x104-49n)
 
-  property(VDDA.power-pin)       = PowerPin(Interval(2.3, 3.6, false))
-  property(VDDA3P3.power-pin)    = PowerPin(Interval(2.3, 3.6, false))
-  property(VDD3P3-CPU.power-pin) = PowerPin(Interval(2.3, 3.6, 3.3))
-  property(VDD3P3-RTC.power-pin) = PowerPin(Interval(2.3, 3.6, 3.3))
+  property(VDDA.power-pin)       = PowerPin(min-max(2.3, 3.6))
+  property(VDDA3P3.power-pin)    = PowerPin(min-max(2.3, 3.6))
+  property(VDD3P3-CPU.power-pin) = PowerPin(min-typ-max(2.3, 3.3, 3.6))
+  property(VDD3P3-RTC.power-pin) = PowerPin(min-typ-max(2.3, 3.3, 3.6))
   eval-when has-property?(VDD3P3-CPU.rail-voltage):
     val vdd = property(VDD3P3-CPU.rail-voltage)
-    val drive-props = DigitalOutput(CMOSOutput(Interval(0.0, 0.1 * vdd, false), Interval(0.8 * vdd, vdd, false)), false, VDD3P3-CPU, GND)
+    val drive-props = DigitalOutput(CMOSOutput(min-max(0.0, 0.1 * vdd), min-max(0.8 * vdd, vdd)), false, VDD3P3-CPU, GND)
     val input-props = DigitalInput(0.25 * vdd, 0.75 * vdd, VDD3P3-CPU, GND, 50.0e-9)
     property(U0TXD.digital-output) = drive-props
     property(U0RXD.digital-input) = input-props
@@ -150,25 +151,25 @@ public pcb-module module :
     supports gpio:
       require io:io-pin from mcu
       gpio.gpio => io.p
-      property(io.p.digital-io) = DigitalIO(CMOSOutput(Interval(0.0, 0.1 * 3.3, false), Interval(0.8 * 3.3, 3.3, false)), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
+      property(io.p.digital-io) = DigitalIO(CMOSOutput(min-max(0.0, 0.1 * 3.3), min-max(0.8 * 3.3, 3.3)), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
   for i in 0 to 16 do:
     supports timer:
       require io:io-pin from mcu
       timer.timer => io.p
-      property(io.p.digital-io) = DigitalIO(CMOSOutput(Interval(0.0, 0.1 * 3.3, false), Interval(0.8 * 3.3, 3.3, false)), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
+      property(io.p.digital-io) = DigitalIO(CMOSOutput(min-max(0.0, 0.1 * 3.3, false), min-max(0.8 * 3.3, 3.3, false)), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
   for i in 0 to 2 do:
     supports i2c:
       require io:io-pin[2] from mcu
       i2c.sda => io[0].p
       i2c.scl => io[1].p
-      property(io[0].p.digital-io) = DigitalIO(OpenCollector(Interval(0.0, 0.1 * 3.3, false), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
-      property(io[1].p.digital-io) = DigitalIO(OpenCollector(Interval(0.0, 0.1 * 3.3, false), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
+      property(io[0].p.digital-io) = DigitalIO(OpenCollector(min-max(0.0, 0.1 * 3.3), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
+      property(io[1].p.digital-io) = DigitalIO(OpenCollector(min-max(0.0, 0.1 * 3.3), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)
   for i in 0 to 2 do:
     val ocdb-uart = /uart()
     supports ocdb-uart:
       require io:io-pin[2] from mcu
       ocdb-uart.tx => io[0].p
-      property(io[0].p.digital-output) = DigitalOutput(CMOSOutput(Interval(0.0, 0.1 * 3.3, false), Interval(0.8 * 3.3, 3.3, false)), false, mcu.VDD3P3-CPU, mcu.GND)
+      property(io[0].p.digital-output) = DigitalOutput(CMOSOutput(min-max(0.0, 0.1 * 3.3), min-max(0.8 * 3.3, 3.3)), false, mcu.VDD3P3-CPU, mcu.GND)
       ocdb-uart.rx => io[1].p
       property(io[1].p.digital-input) = DigitalInput(0.25 * 3.3, 0.75 * 3.3, mcu.VDD3P3-CPU, mcu.GND, 50.0e-9)  
 

--- a/components/future-designs/FT232RL.stanza
+++ b/components/future-designs/FT232RL.stanza
@@ -17,6 +17,7 @@ defpackage ocdb/future-designs/FT232RL :
   import ocdb/property-structs
   import ocdb/generator-utils
   import ocdb/checks
+  import ocdb/tolerance
 
 public pcb-component component:
   pin VCC
@@ -40,35 +41,35 @@ public pcb-component component:
     [pin:Ref | pads:Int ... | side:Dir | generic-pin:GenericPin]
     [GND     | 7 18 21      | Down     | -]
     [AGND    | 25           | Down     | -]
-    [TEST    | 26           | Down     | GenericPin(Interval(-0.5, 6.0, false), 0.0)]
-    [USBDM   | 16           | Left     | GenericPin(Interval(-0.5, 3.8, false), 0.0)]
-    [USBDP   | 15           | Left     | GenericPin(Interval(-0.5, 3.8, false), 0.0)]
-    [RXD     | 5            | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [TXD     | 1            | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [VCC     | 20           | Up       | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [nRI     | 6            | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [OSCI    | 27           | Left     | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [OSCO    | 28           | Left     | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [nCTS    | 11           | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [nDCD    | 10           | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [nDSR    | 9            | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [nDTR    | 2            | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [nRTS    | 3            | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [CBUS[0] | 23           | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [CBUS[1] | 22           | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [CBUS[2] | 13           | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [CBUS[3] | 14           | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [CBUS[4] | 12           | Right    | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [VCCIO   | 4            | Up       | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
+    [TEST    | 26           | Down     | GenericPin(min-max(-0.5, 6.0), 0.0)]
+    [USBDM   | 16           | Left     | GenericPin(min-max(-0.5, 3.8), 0.0)]
+    [USBDP   | 15           | Left     | GenericPin(min-max(-0.5, 3.8), 0.0)]
+    [RXD     | 5            | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [TXD     | 1            | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [VCC     | 20           | Up       | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [nRI     | 6            | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [OSCI    | 27           | Left     | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [OSCO    | 28           | Left     | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [nCTS    | 11           | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [nDCD    | 10           | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [nDSR    | 9            | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [nDTR    | 2            | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [nRTS    | 3            | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [CBUS[0] | 23           | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [CBUS[1] | 22           | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [CBUS[2] | 13           | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [CBUS[3] | 14           | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [CBUS[4] | 12           | Right    | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [VCCIO   | 4            | Up       | GenericPin(min-max(-0.5, 5.5), 0.0)]
     [nc[0]   | 8            | Down     | -]
     [nc[1]   | 24           | Down     | -]
-    [nRESET  | 19           | Left     | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
-    [p3V3OUT | 17           | Left     | GenericPin(Interval(-0.5, 5.5, false), 0.0)]
+    [nRESET  | 19           | Left     | GenericPin(min-max(-0.5, 5.5), 0.0)]
+    [p3V3OUT | 17           | Left     | GenericPin(min-max(-0.5, 5.5), 0.0)]
 
   make-box-symbol()
   assign-landpattern(sop65-landpattern(28, 7.8))
-  property(VCC.power-pin) = PowerPin(Interval(4.0, 5.25, false))
-  property(VCCIO.power-pin) = PowerPin(Interval(1.8, 5.25, false))
+  property(VCC.power-pin) = PowerPin(min-max(4.0, 5.25))
+  property(VCCIO.power-pin) = PowerPin(min-max(1.8, 5.25))
   property(p3V3OUT.power-supply-pin) = PowerSupplyPin(3.3, 0.05)
 
   eval-when has-property?(VCCIO.rail-voltage) :
@@ -80,7 +81,7 @@ public pcb-component component:
     val vol-min = PWL([[1.8 0.06] [2.8 0.3] [3.3 0.3] [5.0 0.3]])[vdd]
     val vih = 1.5
     val vil = vdd * 0.3 ;guess
-    val drive-props = DigitalOutput(CMOSOutput(Interval(vol-min, vol-max, false), Interval(voh-min, voh-max, false)), false, VCCIO, GND)
+    val drive-props = DigitalOutput(CMOSOutput(min-max(vol-min, vol-max), min-max(voh-min, voh-max)), false, VCCIO, GND)
     val input-props = DigitalInput(vil, vih, VCCIO, GND, 1.0e-6) ; TODO: Leakage current is a guess
     property(TXD.digital-output) = drive-props
     property(nDTR.digital-output) = drive-props
@@ -91,7 +92,7 @@ public pcb-component component:
     property(nDCD.digital-input) = input-props
     property(nCTS.digital-input) = input-props
     for p in pins(CBUS) do :
-      property(p.digital-io) = DigitalIO(CMOSOutput(Interval(vol-min, vol-max, false), Interval(voh-min, voh-max, false)), vil, vih, VCCIO, GND, 1.0e-6)
+      property(p.digital-io) = DigitalIO(CMOSOutput(min-max(vol-min, vol-max), min-max(voh-min, voh-max)), vil, vih, VCCIO, GND, 1.0e-6)
 
   ; Test pin must be connected to GND for device operation
   check connected([TEST GND])

--- a/components/idt/5PB11xx.stanza
+++ b/components/idt/5PB11xx.stanza
@@ -12,6 +12,7 @@ defpackage ocdb/idt/5PB11xx:
   import ocdb/bundles
   import ocdb/symbols
   import ocdb/box-symbol
+  import ocdb/tolerance
 
 public pcb-component component (n:Int) :
   description = "1.8V to 3.3V LVCMOS High Performance Clock Buffer Family"
@@ -37,9 +38,9 @@ public pcb-component component (n:Int) :
   make-box-symbol()
   assign-landpattern(pkg)
 
-  property(self.rated-temperature) = [-40.0 105.0]
-  property(self.vdd.power-pin) = true
-  property(self.vdd.rated-voltage) = [1.71, 3.465]
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0 105.0))
+  property(self.vdd.power-pin) = PowerPin(min-max(1.8, 3.3))
+  property(self.vdd.rated-voltage) = min-max(1.71, 3.465)
   
   ; eval when has-property?(vdd.voltage) :
   ;   val vdd-v = property(vdd.voltage)

--- a/components/idt/5PB11xx.stanza
+++ b/components/idt/5PB11xx.stanza
@@ -40,7 +40,8 @@ public pcb-component component (n:Int) :
 
   property(self.rated-temperature) = RatedTemperature(min-max(-40.0 105.0))
   property(self.vdd.power-pin) = PowerPin(min-max(1.8, 3.3))
-  property(self.vdd.rated-voltage) = min-max(1.71, 3.465)
+  ; property(self.vdd.rated-voltage) = min-max(1.71, 3.465)
+  property(self.vdd.rated-voltage) = 3.465
   
   ; eval when has-property?(vdd.voltage) :
   ;   val vdd-v = property(vdd.voltage)

--- a/components/maxim/MAX1606x.stanza
+++ b/components/maxim/MAX1606x.stanza
@@ -21,7 +21,7 @@ public pcb-component component :
   manufacturer = "Maxim Integrated"
   mpn = "MAX16061ETP+"
   description = "1% Accurate, Quad-/Hex-/Octal-Voltage µP Supervisors"
-  val generic-props = GenericPin(Interval(-0.3, 6.0, false), 100.0)
+  val generic-props = GenericPin(min-max(-0.3, 6.0), 100.0)
   pin-properties :
     [pin:Ref     | pads:Int ...   | side:Dir | generic-pin:GenericPin]
     [in[1]       | 17             | Left     | generic-props ]
@@ -49,13 +49,13 @@ public pcb-component component :
   make-box-symbol()
   assign-landpattern(qfn-landpattern(0.5, 4.0, 20, 0.25, 0.55, [2.1, 2.1]))
 
-  property(self.rated-temperature) = RatedTemperature(Interval(-40.0, 125.0, false))
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0, 125.0))
 
-  property(self.VCC.power-pin) = PowerPin(Interval(1.0, 5.5, false))
+  property(self.VCC.power-pin) = PowerPin(min-max(1.0, 5.5))
   eval-when has-property?(self.VCC.rail-voltage):
     val vdd = property(self.VCC.rail-voltage)
     for p in [self.TOL self.SRT self.nMR self.WDI self.nMARGIN] do :
-      property(p.generic-pin) = GenericPin(Interval(-0.3, vdd + 0.3, false), 100.0)
+      property(p.generic-pin) = GenericPin(min-max(-0.3, vdd + 0.3), 100.0)
 
 public pcb-module module (rails:Tuple<PowerRail>):
   port power:power

--- a/components/maxim/MAX300x.stanza
+++ b/components/maxim/MAX300x.stanza
@@ -14,13 +14,14 @@ defpackage ocdb/maxim/MAX300x:
   import ocdb/box-symbol
   import ocdb/property-structs
   import ocdb/checks
+  import ocdb/tolerance
 
 public pcb-component component :
   name = "MAX3001EEUP+T"
   manufacturer = "Maxim Integrated"
   mpn = "MAX3001EEUP+T"
   description = "Voltage Level Translator Bidirectional 1 Circuit 8 Channel 4Mbps 20-TSSOP"
-  val generic-props = GenericPin(Interval(-0.3, 6.0, false), 15000.0)
+  val generic-props = GenericPin(min-max(-0.3, 6.0), 15000.0)
   pin-properties :
     [pin:Ref     | pads:Int ...   | side:Dir | generic-pin:GenericPin]
     [GND       | 11 | Down  | generic-props ]      
@@ -47,9 +48,9 @@ public pcb-component component :
   make-box-symbol()
   assign-landpattern(sop65-landpattern(20))
 
-  property(self.VCC.power-pin) = PowerPin(Interval(1.2, 5.5, false))
+  property(self.VCC.power-pin) = PowerPin(min-max(1.2, 5.5))
   eval-when has-property?(self.VCC.rail-voltage):
-    property(self.VCC.power-pin) = PowerPin(Interval(1.65, property(self.VCC.rail-voltage), false))
+    property(self.VCC.power-pin) = PowerPin(min-max(1.65, property(self.VCC.rail-voltage)))
 
   check connected(self.EN)
 

--- a/components/microsemi/A2F200M3F-FGG256I.stanza
+++ b/components/microsemi/A2F200M3F-FGG256I.stanza
@@ -13,6 +13,7 @@ defpackage ocdb/microsemi/A2F200M3F-FGG256I:
   import ocdb/symbols
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
 
 pcb-bundle fpga-io :
   pin io
@@ -270,14 +271,14 @@ public pcb-component component :
       assign-se(apin)
 
   for p in [self.VCC self.VCC15A self.VCC15ADC0 self.VCC15ADC1] do :
-    property(p.power-pin) = PowerPin(Interval(1.425, 1.575, 1.5))
+    property(p.power-pin) = PowerPin(min-typ-max(1.425, 1.5, 1.575))
   for p in [self.VPP self.VCC33A self.VCC33ADC0 self.VCC33ADC1 self.VCC33AP self.VCC33SDD0 self.VCC33SDD1 self.VCCMAINXTAL self.VCCLPXTAL] do :
-    property(p.power-pin) = PowerPin(Interval(3.15, 3.45, 3.3))
+    property(p.power-pin) = PowerPin(min-typ-max(3.15, 3.3, 3.45))
   for p in [self.VCCFPGAIOB[1] self.VCCFPGAIOB[0] self.VCCMSSIOB[4] self.VCCFPGAIOB[5] self.VCCMSSIOB[2]] do :
-    property(p.power-pin) = PowerPin(Interval(1.425, 3.6, false))
+    property(p.power-pin) = PowerPin(min-max(1.425, 3.6))
 
   
-  property(self.rated-temperature) = RatedTemperature(Interval(-40.0 100.0, false))
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0 100.0))
 
 defn replace-at (s:String, p:Int, c:Char) :
   String $ for i in 0 to length(s) seq :

--- a/components/qorvo/QPL9065SR.stanza
+++ b/components/qorvo/QPL9065SR.stanza
@@ -12,6 +12,7 @@ defpackage ocdb/qorvo/QPL9065SR :
   import ocdb/bundles
   import ocdb/symbols
   import ocdb/box-symbol
+  import ocdb/tolerance
 
 public pcb-component component :
   name = "QPL9065SR"
@@ -34,18 +35,18 @@ public pcb-component component :
 
   property(self.vpd.digital-in) = true
   property(self.vpd.vi) = [0.63 1.17]
-  property(self.vpd.rated-voltage) = [0.0 3.0]
+  property(self.vpd.rated-voltage) = 3.0
   property(self.vbyp.digital-in) = true
   property(self.vbyp.vi) = [0.63 1.17]
-  property(self.vbyp.rated-voltage) = [0.0 3.0]
-  property(self.vdd1.power-pin) = true
+  property(self.vbyp.rated-voltage) = 3.0
+  property(self.vdd1.power-pin) = PowerPin(min-max(3.3, 5.25))
   property(self.vdd1.vdd) = 5.0
-  property(self.vdd1.rated-voltage) = [3.3 5.25]
-  property(self.vdd2.power-pin) = true
+  property(self.vdd1.rated-voltage) = 5.25
+  property(self.vdd2.power-pin) = PowerPin(min-max(3.3, 5.25))
   property(self.vdd2.vdd) = 5.0
-  property(self.vdd2.rated-voltage) = [3.3 5.25]
+  property(self.vdd2.rated-voltage) = 5.25
 
-  property(self.rated-temperature) = [-40.0 105.0]
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0 105.0))
 
 public pcb-module module :
   pin gnd

--- a/components/samtec/ASP-134488-01.stanza
+++ b/components/samtec/ASP-134488-01.stanza
@@ -13,6 +13,7 @@ defpackage ocdb/samtec/ASP-134488-01 :
   import ocdb/symbols
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
 
 ; Land Patterns
 public defn samtec-bga-pkg (pitch:Double, pad-diam:Double, n-pads:[Int Int], courtyard:[Double Double], omit-pads:Tuple<Ref>) :
@@ -150,7 +151,7 @@ public pcb-component component :
     i2c.sda => self.sda
     i2c.scl => self.scl
 
-  property(self.rated-temperature) = RatedTemperature(Interval(-55.0 125.0, false))
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
   
 
 public pcb-module module :

--- a/components/si-labs/CP2105.stanza
+++ b/components/si-labs/CP2105.stanza
@@ -13,6 +13,7 @@ defpackage ocdb/si-labs/CP2105 :
   import ocdb/generator-utils
   import ocdb/generic-components
   import ocdb/property-structs
+  import ocdb/tolerance
 
 public pcb-component component :
   manufacturer = "Silicon Labs"
@@ -76,13 +77,13 @@ public pcb-component component :
   make-box-symbol()
   assign-landpattern(qfn-landpattern(0.5, 4.0, 24, 0.25, 0.4, [2.7 2.7]))
 
-  property(REGIN.power-pin) = PowerPin(Interval(3.0, 5.25, false))
-  property(VDD.power-pin) = PowerPin(Interval(3.0, 3.6, false))
+  property(REGIN.power-pin) = PowerPin(min-max(3.0, 5.25))
+  property(VDD.power-pin) = PowerPin(min-max(3.0, 3.6))
   eval-when has-property?(VDD.rail-voltage) :
-    property(VIO.power-pin) = PowerPin(Interval(1.8, property(VDD.rail-voltage), false))
+    property(VIO.power-pin) = PowerPin(min-max(1.8, property(VDD.rail-voltage)))
   eval-when has-property?(VIO.rail-voltage) :
     val vdd  = property(VIO.rail-voltage)
-    val drive-props = DigitalOutput(CMOSOutput(Interval(0.0, 0.4, false), Interval(vdd - 0.2, vdd, false)), false, VIO, GND)
+    val drive-props = DigitalOutput(CMOSOutput(min-max(0.0, 0.4), min-max(vdd - 0.2, vdd)), false, VIO, GND)
     val input-props = DigitalInput(0.6, 0.7 * vdd, VIO, GND, 50.0e-6)
     for o in [TXD_ECI DTR_ECI RTS_ECI TXD_SCI DTR_SCI RTS_SCI] do :
       property(o.digital-output) = drive-props

--- a/components/st-microelectronics/LIS3DH.stanza
+++ b/components/st-microelectronics/LIS3DH.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/st-microelectronics/LIS3DH :
   import ocdb/box-symbol
   import ocdb/property-structs
   import ocdb/checks
+  import ocdb/tolerance
 
 pcb-landpattern xdcr-lis3dhtr :
   pad p[1] : smd-pad(0.45, 0.35) at loc(-1.225, 1.0, 0.0)
@@ -67,7 +68,7 @@ public pcb-component component :
   check connected([self.RES self.GND])
   check connected(self.VDD-IO)
 
-  property(self.VDD.power-pin) = PowerPin(Interval(1.71, 3.6, 2.5))
+  property(self.VDD.power-pin) = PowerPin(min-typ-max(1.71, 2.5, 3.6))
 
 
 public pcb-module module :

--- a/components/st-microelectronics/STM32F031F4P6.stanza
+++ b/components/st-microelectronics/STM32F031F4P6.stanza
@@ -16,12 +16,13 @@ defpackage ocdb/st-microelectronics/STM32F031F4P6 :
   import ocdb/property-structs
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F031F_4-6_Px/supports
+  import ocdb/tolerance
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F031F4P6"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [BOOT[0]   | 1 | Left | generic-props | - ]
@@ -49,7 +50,7 @@ public pcb-component component :
   make-box-symbol()
 
   for p in pins(self.PA) do :
-    property(p.digital-io) = DigitalIO(CMOSOutput(Interval(0.0, 0.4, false), Interval(3.3 - 0.4, 3.3, false)), 0.3 * 3.3, 0.7 * 3.3, self.VDD, self.VSS, 50.0e-9)
+    property(p.digital-io) = DigitalIO(CMOSOutput(min-max(0.0, 0.4), min-max(3.3 - 0.4, 3.3)), 0.3 * 3.3, 0.7 * 3.3, self.VDD, self.VSS, 50.0e-9)
   
   ocdb/components/STM32F031F_4-6_Px/supports/make-supports()
 

--- a/components/st-microelectronics/STM32F031F6P6.stanza
+++ b/components/st-microelectronics/STM32F031F6P6.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F031F6P6 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+  
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F031F_4-6_Px/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F031F6P6"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [BOOT[0]   | 1 | Left | generic-props | - ]

--- a/components/st-microelectronics/STM32F038G6U6.stanza
+++ b/components/st-microelectronics/STM32F038G6U6.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F038G6U6 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+  
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F038G6Ux/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F038G6U6"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(1.65, 1.95, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(1.65, 1.95))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [BOOT[0]   | 1 | Left | generic-props | - ]

--- a/components/st-microelectronics/STM32F102C4T6A.stanza
+++ b/components/st-microelectronics/STM32F102C4T6A.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F102C4T6A :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+  
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F102C_4-6_Tx/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F102C4T6A"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [VBAT   | 1 | Up | generic-props | power-props ]

--- a/components/st-microelectronics/STM32F102C6T6A.stanza
+++ b/components/st-microelectronics/STM32F102C6T6A.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F102C6T6A :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F102C_4-6_Tx/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F102C6T6A"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [VBAT   | 1 | Up | generic-props | power-props ]

--- a/components/st-microelectronics/STM32F102R4T6A.stanza
+++ b/components/st-microelectronics/STM32F102R4T6A.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F102R4T6A :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+  
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F102R_4-6_Tx/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F102R4T6A"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(,min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [VBAT   | 1 | Up | generic-props | power-props ]

--- a/components/st-microelectronics/STM32F102R6T6A.stanza
+++ b/components/st-microelectronics/STM32F102R6T6A.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F102R6T6A :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F102R_4-6_Tx/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F102R6T6A"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [VBAT   | 1 | Up | generic-props | power-props ]

--- a/components/st-microelectronics/STM32F103RBH6.stanza
+++ b/components/st-microelectronics/STM32F103RBH6.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F103RBH6 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F103R_8-B_Hx/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F103RBH6"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Ref ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [PC[14]   | A[1] | Right | generic-props | - ]

--- a/components/st-microelectronics/STM32F103T4U6A.stanza
+++ b/components/st-microelectronics/STM32F103T4U6A.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F103T4U6A :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F103T_4-6_Ux/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F103T4U6A"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [VDD[0]   | 1 | Up | generic-props | power-props ]

--- a/components/st-microelectronics/STM32F103T6U6A.stanza
+++ b/components/st-microelectronics/STM32F103T6U6A.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F103T6U6A :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F103T_4-6_Ux/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F103T6U6A"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [VDD[0]   | 1 | Up | generic-props | power-props ]

--- a/components/st-microelectronics/STM32F105V8H6.stanza
+++ b/components/st-microelectronics/STM32F105V8H6.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F105V8H6 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F105V_8-B_Hx/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F105V8H6"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Ref ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [PC[14]   | A[1] | Right | generic-props | - ]

--- a/components/st-microelectronics/STM32F105VBH6.stanza
+++ b/components/st-microelectronics/STM32F105VBH6.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F105VBH6 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F105V_8-B_Hx/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F105VBH6"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Ref ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [PC[14]   | A[1] | Right | generic-props | - ]

--- a/components/st-microelectronics/STM32F107VCH6.stanza
+++ b/components/st-microelectronics/STM32F107VCH6.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32F107VCH6 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32F107VCHx/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32F107VCH6"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(2.0, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(2.0, 3.6))
   pin-properties :
     [pin:Ref | pads:Ref ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [PC[14]   | A[1] | Right | generic-props | - ]

--- a/components/st-microelectronics/STM32F407ZET6.stanza
+++ b/components/st-microelectronics/STM32F407ZET6.stanza
@@ -38,14 +38,14 @@ public pcb-component component :
   ; val VDD-PINS = [144 17 30 39 131 121 108 95 62 52 72 84]
   ; val VSS-PINS = [16 38 130 120 107 94 61 51 83]
 
-  val FT-props = GenericPin(Interval(-0.3, 5.5, false), 8.0)
-  val TT-props = GenericPin(Interval(-0.3, 3.6, false), 8.0)
-  val FT-I-props = GenericPin(Interval(-0.3, 5.5, false), 3.0)
-  val reset-props = GenericPin(Interval(-0.3, 5.5, false), 8.0)
-  val boot-props = GenericPin(Interval(-0.3, 5.5, false), 8.0)
-  ; val generic-props = GenericPin(Interval(-0.3, 5.5, false), 20.0)
-  val power-props = PowerPin(Interval(1.8, 3.6, false))
-  val battery-props = PowerPin(Interval(1.65 3.6, false))
+  val FT-props = GenericPin(min-max(-0.3, 5.5), 8.0)
+  val TT-props = GenericPin(min-max(-0.3, 3.6), 8.0)
+  val FT-I-props = GenericPin(min-max(-0.3, 5.5), 3.0)
+  val reset-props = GenericPin(min-max(-0.3, 5.5), 8.0)
+  val boot-props = GenericPin(min-max(-0.3, 5.5), 8.0)
+  ; val generic-props = GenericPin(min-max(-0.3, 5.5), 20.0)
+  val power-props = PowerPin(min-max(1.8, 3.6))
+  val battery-props = PowerPin(min-max(1.65 3.6))
 
   ; [pin:Ref | pads : (Ref|Int) ... | side:Dir | generic-pin:GenericPin | power-pin:PowerPin]
   pin-properties :

--- a/components/st-microelectronics/STM32L031F6P6.stanza
+++ b/components/st-microelectronics/STM32L031F6P6.stanza
@@ -14,14 +14,16 @@ defpackage ocdb/st-microelectronics/STM32L031F6P6 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
+
   import ocdb/st-microelectronics/stm-api
   import ocdb/components/STM32L031F_4-6_Px/supports
 
 public pcb-component component :
   manufacturer = "STMicroelectronics"
   mpn = "STM32L031F6P6"
-  val generic-props = GenericPin(Interval(-0.3, 4.0, false), 2000.0)
-  val power-props = PowerPin(Interval(1.65, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.3, 4.0), 2000.0)
+  val power-props = PowerPin(min-max(1.65, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [BOOT[0]   | 1 | Left | generic-props | - ]

--- a/components/st-microelectronics/VL53L1X.stanza
+++ b/components/st-microelectronics/VL53L1X.stanza
@@ -16,6 +16,7 @@ defpackage ocdb/st-microelectronics/VL53L1X :
   import ocdb/property-structs
   import ocdb/checks
   import ocdb/generator-utils
+  import ocdb/tolerance
 
 pcb-landpattern vl53l1cxv0fyslash-1 :
   pad p[1]  : smd-pad(0.508, 0.508) at loc(0.8, 1.6, 90.0)
@@ -38,8 +39,8 @@ pcb-landpattern vl53l1cxv0fyslash-1 :
   ref-label()
 
 public pcb-component component :
-  val generic-props = GenericPin(Interval(-0.5, 3.6, false), 2000.0)
-  val power-props = PowerPin(Interval(2.6, 3.6, false))
+  val generic-props = GenericPin(min-max(-0.5, 3.6), 2000.0)
+  val power-props = PowerPin(min-max(2.6, 3.6))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [DNC | 8 | Right      | - | - ]
@@ -60,8 +61,8 @@ public pcb-component component :
   reference-prefix = "U"
   mpn = "VL53L1CBV0FY/1"
 
-  property(self.SCL.digital-io) = DigitalIO(OpenCollector(Interval(0.0, 0.4, false), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, self.AVDD, self.GND, 50.0e-9)
-  property(self.SDA.digital-io) = DigitalIO(OpenCollector(Interval(0.0, 0.4, false), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, self.AVDD, self.GND, 50.0e-9)
+  property(self.SCL.digital-io) = DigitalIO(OpenCollector(min-max(0.0, 0.4), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, self.AVDD, self.GND, 50.0e-9)
+  property(self.SDA.digital-io) = DigitalIO(OpenCollector(min-max(0.0, 0.4), 28.0e-3), 0.25 * 3.3, 0.75 * 3.3, self.AVDD, self.GND, 50.0e-9)
 
 
 public pcb-module module :

--- a/components/st-microelectronics/stm-api.stanza
+++ b/components/st-microelectronics/stm-api.stanza
@@ -16,6 +16,7 @@ defpackage ocdb/st-microelectronics/stm-api :
   import ocdb/box-symbol
   import ocdb/property-structs
   import ocdb/checks
+  import ocdb/tolerance
 
 public deftype STMPinNames
 
@@ -223,13 +224,13 @@ public defn connect-power (stm:JITXObject, power-port-name:String, vdd-net:PwrPi
           make-net(to-symbol(gnd-net), [self.(power-port-symbol).gnd, p])
         property(vdd-pin-list[0].gnd-ref) = gnd-pin-list[0] 
         val v-range = recommended-voltage(property(vdd-pin-list[0].power-pin))
-        if contains?(v-range, 3.3) :
+        if in-range?(v-range, 3.3) :
           property(vdd-pin-list[0].power-request) = [3.3, 0.1, 3.3 * 0.03]
-        else if contains?(v-range, 2.5) :
+        else if in-range?(v-range, 2.5) :
           property(vdd-pin-list[0].power-request) = [2.5, 0.1, 2.5 * 0.03]
-        else if contains?(v-range, 1.8) :
+        else if in-range?(v-range, 1.8) :
           property(vdd-pin-list[0].power-request) = [1.8, 0.1, 1.8 * 0.03]
-        else if contains?(v-range, 1.2) :
+        else if in-range?(v-range, 1.2) :
           property(vdd-pin-list[0].power-request) = [1.2, 0.1, 1.2 * 0.03]
         true ; need this in order to check for missing pins in the outer if statements
 
@@ -307,7 +308,7 @@ public defn connect-por (stm:JITXObject, por-net:ResetPinNames, vdd-net:PwrPinNa
       val gnd-pins = gnd-pins-list(stm, gnd-net)
       if not empty?(power-pins) and not empty?(gnd-pins) :
         val v-range = recommended-voltage(property(power-pins[0].power-pin))
-        if contains?(v-range, 1.8) :
+        if in-range?(v-range, 1.8) :
           inst mon : ocdb/on-semiconductor/NCP30x/component(1.8)
           bypass-cap-strap(por-pin[0], gnd-pins[0], 0.1e-6) ; hardcoded value for now (eek)
           net (mon.gnd, gnd-pins[0])

--- a/components/texas-instruments/HDC1080.stanza
+++ b/components/texas-instruments/HDC1080.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/texas-instruments/HDC1080 :
   import ocdb/bundles
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
 
 pcb-landpattern son100p300x300x80-7n :
   pad p[1] : smd-pad(0.86, 0.42) at loc(-1.435, 1.0, 0.0)
@@ -34,9 +35,9 @@ public pcb-component component :
   pin-properties :
     [pin:Ref | pads:Int ...  | side:Dir | generic-pin:GenericPin ]
     [GND     | 2             | Down     |  -]
-    [SCL     | 6             | Left     |  GenericPin(Interval(-0.3, 6.0, false), 2.0e3)]
-    [SDA     | 1             | Left     |  GenericPin(Interval(-0.3, 6.0, false), 2.0e3)]
-    [VDD     | 5             | Up       |  GenericPin(Interval(-0.3, 6.0, false), 2.0e3)]
+    [SCL     | 6             | Left     |  GenericPin(min-max(-0.3, 6.0), 2.0e3)]
+    [SDA     | 1             | Left     |  GenericPin(min-max(-0.3, 6.0), 2.0e3)]
+    [VDD     | 5             | Up       |  GenericPin(min-max(-0.3, 6.0), 2.0e3)]
     [NC[0]   | 3             | Right    | -]
     [NC[1]   | 4             | Right    | -]
     [NC[2]   | 7             | Right    | -]
@@ -44,7 +45,7 @@ public pcb-component component :
   make-box-symbol()
   assign-landpattern(son100p300x300x80-7n)
 
-  property(VDD.power-pin) = PowerPin(Interval(2.7, 5.5, 3.0))
+  property(VDD.power-pin) = PowerPin(min-typ-max(2.7, 3.0, 5.5))
   mpn = "HDC1080DMBR"
   manufacturer = "Texas Instruments"
   description = "I2C humidity sensor"

--- a/components/texas-instruments/SN65HVD1781.stanza
+++ b/components/texas-instruments/SN65HVD1781.stanza
@@ -17,6 +17,7 @@ defpackage ocdb/texas-instruments/SN65HVD1781 :
   import ocdb/property-structs
   import ocdb/checks
   import ocdb/generator-utils
+  import ocdb/tolerance
 
 pcb-landpattern sn65hvd1786d-lp :
   val pad-shape = smd-pad(1.55, 0.6)
@@ -34,9 +35,9 @@ pcb-landpattern sn65hvd1786d-lp :
   ref-label()
 
 public pcb-component component :
-  val generic-props = GenericPin(Interval(-0.3, 7.0, false), 4000.0)
-  val ab-props = GenericPin(Interval(-70.0, 70.0, false), 16000.0)
-  val power-props = PowerPin(Interval(3.15, 5.5, false))
+  val generic-props = GenericPin(min-max(-0.3, 7.0), 4000.0)
+  val ab-props = GenericPin(min-max(-70.0, 70.0), 16000.0)
+  val power-props = PowerPin(min-max(3.15, 5.5))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [R   | 1 | Left     | generic-props | - ]
@@ -55,7 +56,7 @@ public pcb-component component :
 
   eval-when has-property?(self.VDD.rail-voltage) :
     val vdd  = property(self.VDD.rail-voltage)
-    val drive-props = DigitalOutput(CMOSOutput(Interval(0.0, 0.8, false), Interval(2.4, vdd - 0.3, false)), false, self.VDD, self.GND)
+    val drive-props = DigitalOutput(CMOSOutput(min-max(0.0, 0.8), min-max(2.4, vdd - 0.3)), false, self.VDD, self.GND)
     val input-props = DigitalInput(0.8, 2.0, self.VDD, self.GND, 50.0e-6)
     for o in [self.R] do :
       property(o.digital-output) = drive-props

--- a/components/texas-instruments/SN65HVD1786.stanza
+++ b/components/texas-instruments/SN65HVD1786.stanza
@@ -16,6 +16,7 @@ defpackage ocdb/texas-instruments/SN65HVD1786 :
   import ocdb/property-structs
   import ocdb/checks
   import ocdb/generator-utils
+  import ocdb/tolerance
 
 pcb-landpattern sn65hvd1786d-lp :
   val pad-shape = smd-pad(1.55, 0.6)
@@ -33,9 +34,9 @@ pcb-landpattern sn65hvd1786d-lp :
   ref-label()
 
 public pcb-component component :
-  val generic-props = GenericPin(Interval(-0.3, 5.5, false), 4000.0)
-  val ab-props = GenericPin(Interval(-25.0, 25.0, false), 16000.0)
-  val power-props = PowerPin(Interval(4.5, 5.5, false))
+  val generic-props = GenericPin(min-max(-0.3, 5.5), 4000.0)
+  val ab-props = GenericPin(min-max(-25.0, 25.0), 16000.0)
+  val power-props = PowerPin(min-max(4.5, 5.5))
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir| generic-pin:GenericPin | power-pin:PowerPin ]
     [R   | 1 | Left     | generic-props | - ]
@@ -56,7 +57,7 @@ public pcb-component component :
 
   eval-when has-property?(self.VDD.rail-voltage) :
     val vdd  = property(self.VDD.rail-voltage)
-    val drive-props = DigitalOutput(CMOSOutput(Interval(0.0, 0.8, false), Interval(2.4, vdd - 0.3, false)), false, self.VDD, self.GND)
+    val drive-props = DigitalOutput(CMOSOutput(min-max(0.0, 0.8), min-max(2.4, vdd - 0.3)), false, self.VDD, self.GND)
     val input-props = DigitalInput(0.8, 2.0, self.VDD, self.GND, 50.0e-6)
     for o in [self.R] do :
       property(o.digital-output) = drive-props

--- a/components/texas-instruments/TCAN1051.stanza
+++ b/components/texas-instruments/TCAN1051.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/texas-instruments/TCAN1051 :
   import ocdb/generator-utils
   import ocdb/generic-components
   import ocdb/property-structs
+  import ocdb/tolerance
 
 public pcb-component component :
   manufacturer = "Texas Instruments"
@@ -34,13 +35,13 @@ public pcb-component component :
   make-box-symbol()
   assign-landpattern(soic127p-landpattern(8))
 
-  property(self.VIO.power-pin) = PowerPin(Interval(2.8, 5.5, false))
-  property(self.VCC.power-pin) = PowerPin(Interval(4.5, 5.5, false))
+  property(self.VIO.power-pin) = PowerPin(min-max(2.8, 5.5))
+  property(self.VCC.power-pin) = PowerPin(min-max(4.5, 5.5))
 
   ; Figure out what the io voltage level is in the design.
   eval-when has-property?(self.VIO.rail-voltage):
     val vdd = property(self.VIO.rail-voltage)
-    val drive-props = DigitalOutput(CMOSOutput(Interval(0.0, 0.2 * vdd, false), Interval(0.8 * vdd, vdd, false)), false, self.VCC, self.GND)
+    val drive-props = DigitalOutput(CMOSOutput(min-max(0.0, 0.2 * vdd), min-max(0.8 * vdd, vdd)), false, self.VCC, self.GND)
     val input-props = DigitalInput(0.3 * vdd, 0.7 * vdd, self.VCC, self.GND, 30.0e-6)
     property(self.TXD.digital-output) = drive-props
     property(self.RXD.digital-input) = input-props

--- a/components/texas-instruments/TLV62130.stanza
+++ b/components/texas-instruments/TLV62130.stanza
@@ -40,21 +40,21 @@ public pcb-component component :
   assign-landpattern(qfn-landpattern(0.5, 3.0, 16, 0.24, 0.5, [1.68, 1.68]))
   make-box-symbol()
 
-  property(self.PVIN.power-pin) = PowerPin(Interval(3.0, 17.0, false))
-  property(self.rated-temperature) = RatedTemperature(Interval(-40.0 85.0, false))
+  property(self.PVIN.power-pin) = PowerPin(min-max(3.0, 17.0))
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0 85.0))
   
   eval-when has-property?(self.PVIN.rail-voltage) :
     val vin = property(self.PVIN.rail-voltage)
-    property(self.PVIN.generic-pin) = GenericPin(Interval(-0.3, 20.0, false), 2000.0)
-    property(self.AVIN.generic-pin) = GenericPin(Interval(-0.3, 20.0, false), 2000.0)
-    property(self.EN.generic-pin) = GenericPin(Interval(-0.3, vin + 0.3, false), 2000.0)
-    property(self.SS.generic-pin) = GenericPin(Interval(-0.3, vin + 0.3, false), 2000.0)
-    property(self.DEF.generic-pin) = GenericPin(Interval(-0.3, 7.0, false), 2000.0)
-    property(self.FSW.generic-pin) = GenericPin(Interval(-0.3, 7.0, false), 2000.0)
-    property(self.SW.generic-pin) = GenericPin(Interval(-0.3, vin + 0.3, false), 2000.0)
-    property(self.VOS.generic-pin) = GenericPin(Interval(-0.3, 7.0, false), 2000.0)
-    property(self.PG.generic-pin) = GenericPin(Interval(-0.3, 7.0, false), 2000.0)
-    property(self.FB.generic-pin) = GenericPin(Interval(-0.3, 7.0, false), 2000.0)
+    property(self.PVIN.generic-pin) = GenericPin(min-max(-0.3, 20.0), 2000.0)
+    property(self.AVIN.generic-pin) = GenericPin(min-max(-0.3, 20.0), 2000.0)
+    property(self.EN.generic-pin)   = GenericPin(min-max(-0.3, vin + 0.3), 2000.0)
+    property(self.SS.generic-pin)   = GenericPin(min-max(-0.3, vin + 0.3), 2000.0)
+    property(self.DEF.generic-pin)  = GenericPin(min-max(-0.3, 7.0), 2000.0)
+    property(self.FSW.generic-pin)  = GenericPin(min-max(-0.3, 7.0), 2000.0)
+    property(self.SW.generic-pin)   = GenericPin(min-max(-0.3, vin + 0.3), 2000.0)
+    property(self.VOS.generic-pin)  = GenericPin(min-max(-0.3, 7.0), 2000.0)
+    property(self.PG.generic-pin)   = GenericPin(min-max(-0.3, 7.0), 2000.0)
+    property(self.FB.generic-pin)   = GenericPin(min-max(-0.3, 7.0), 2000.0)
 
 
 public pcb-module module (v-out:Double) :

--- a/components/texas-instruments/TLV743P.stanza
+++ b/components/texas-instruments/TLV743P.stanza
@@ -13,6 +13,7 @@ defpackage ocdb/texas-instruments/TLV743P :
   import ocdb/symbols
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
 
 public pcb-component component (v-out:Double) :
   pin en
@@ -40,7 +41,7 @@ public pcb-component component (v-out:Double) :
   assign-landpattern(SOT95P280X145-5N)
 
   property(out.power-supply-pin) = PowerSupplyPin(v-out, 0.3) 
-  property(in.power-pin) = PowerPin(Interval(1.4, 5.5, false))
+  property(in.power-pin) = PowerPin(min-max(1.4, 5.5))
 
   spice:
     "[X] {en} {gnd} {in} {out} {nc} {spice-code}"

--- a/components/texas-instruments/TPD3S0x4.stanza
+++ b/components/texas-instruments/TPD3S0x4.stanza
@@ -14,6 +14,7 @@ defpackage ocdb/texas-instruments/TPD3S0x4 :
   import ocdb/generic-components
   import ocdb/box-symbol
   import ocdb/property-structs
+  import ocdb/tolerance
 
 public pcb-component component :
   manufacturer = "Texas Instruments"
@@ -22,14 +23,14 @@ public pcb-component component :
   pin-properties :
     [pin:Ref | pads:Int ... | side:Dir | generic-pin:GenericPin]
     [GND     | 2            | Down     | -]
-    [IN      | 3            | Left     | GenericPin(Interval(-0.3, 6.0, false), 2.0e3)]
-    [OUT     | 4            | Right    | GenericPin(Interval(-0.3, 6.0, false), 2.0e3)]
-    [EN      | 1            | Left     | GenericPin(Interval(-0.3, 6.0, false), 2.0e3)]
-    [D1      | 5            | Right    | GenericPin(Interval(-0.3, 6.0, false), 12.0e3)]
-    [D2      | 6            | Right    | GenericPin(Interval(-0.3, 6.0, false), 12.0e3)]
+    [IN      | 3            | Left     | GenericPin(min-max(-0.3, 6.0), 2.0e3)]
+    [OUT     | 4            | Right    | GenericPin(min-max(-0.3, 6.0), 2.0e3)]
+    [EN      | 1            | Left     | GenericPin(min-max(-0.3, 6.0), 2.0e3)]
+    [D1      | 5            | Right    | GenericPin(min-max(-0.3, 6.0), 12.0e3)]
+    [D2      | 6            | Right    | GenericPin(min-max(-0.3, 6.0), 12.0e3)]
   assign-landpattern(SOT95P280X145-6N)
   make-box-symbol()
-  property(self.IN.power-pin) = PowerPin(Interval(4.5, 5.5, false))
+  property(self.IN.power-pin) = PowerPin(min-max(4.5, 5.5))
 
 
 public pcb-module module :

--- a/components/unisonic/lm317a.stanza
+++ b/components/unisonic/lm317a.stanza
@@ -40,7 +40,7 @@ public pcb-component component :
   assign-landpattern(c75510-lp)
   make-box-symbol()
 
-  property(self.rated-temperature) = RatedTemperature(Interval(-40.0 85.0, false))
+  property(self.rated-temperature) = RatedTemperature(min-max(-40.0 85.0))
   property(self.reference-voltage) = min-typ-max(1.20, 1.25, 1.3)
   property(self.minimum-load) = 4.5e-3
   property(self.adj-current) = 50.0e-6

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -15,6 +15,7 @@ defpackage ocdb/designs/ble-mote :
   import ocdb/property-structs
   import ocdb/checks
   import ocdb/rules
+  import ocdb/tolerance
 
 
 OPERATING-TEMPERATURE = [-20.0 50.0]
@@ -40,8 +41,8 @@ pcb-module pms7003 :
   net (set, header.p[9])
   res-strap(vin-mcu.vdd, set, 10.0e3)
   res-strap(vin-mcu.vdd, reset, 10.0e3)
-  property(header.p[1].power-pin) = PowerPin(Interval(4.5, 5.5, 5.0))
-  property(header.p[10].digital-output) = DigitalOutput(CMOSOutput(Interval(0.3, 0.5, false), Interval(2.6, 3.3, false)), false, header.p[1], header.p[3])
+  property(header.p[1].power-pin) = PowerPin(min-typ-max(4.5, 5.0, 5.5))
+  property(header.p[10].digital-output) = DigitalOutput(CMOSOutput(min-max(0.3, 0.5), min-max(2.6, 3.3)), false, header.p[1], header.p[3])
   property(header.p[8].digital-input) = DigitalInput(0.8, 2.6, header.p[1], header.p[3], 1.0e-6)
   property(header.p[6].digital-input) = DigitalInput(0.8, 2.6, header.p[1], header.p[3], 1.0e-6)
   property(header.p[9].digital-input) = DigitalInput(0.8, 2.6, header.p[1], header.p[3], 1.0e-6)

--- a/designs/test-component-checks.stanza
+++ b/designs/test-component-checks.stanza
@@ -15,6 +15,7 @@ defpackage ocdb/designs/demo :
   import ocdb/rules
   import ocdb/symbols
   import ocdb/box-symbol
+  import ocdb/tolerance
 
 pcb-component test-res :
   mpn = "ERJ-2RKF10R0X"
@@ -31,7 +32,7 @@ pcb-component test-res :
   property(self.rated-power) = 0.063
   property(self.derating) = [[-60.0 1.0] [70.0 1.0] [155.0 0.0]]
   property(self.TCR) = 100.0
-  property(self.rated-temperature) = [-55.0 155.0]
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 155.0))
   property(self.resistance) = 10.0
   property(self.tolerance) = 0.01
 
@@ -53,7 +54,7 @@ pcb-component test-cap-ceramic :
   property(self.capacitance) = 1.0e-6
   property(self.tolerance) = 10.0
   property(self.rated-voltage) = 6.3
-  property(self.rated-temperature) = [-55.0 125.0]
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 155.0))
 
   spice:
     "[C] {p[1]} 1 100u"
@@ -79,7 +80,7 @@ pcb-component test-cap-tantalum-mno2 :
   property(self.rated-voltage) = 20.0
   property(self.rated-current-pk) = 0.147
   property(self.rated-current-rms) = [[25.0 0.091] [85.0 0.082] [125.0 0.036]]
-  property(self.rated-temperature) = [-55.0 125.0]
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 155.0))
 
   spice :
     "[C] {a} 1 100u"
@@ -106,7 +107,7 @@ pcb-component test-cap-tantalum-polymer :
   property(self.tolerance) = 20.0
   property(self.rated-current-pk) = 3.7
   property(self.rated-current-rms) = [[25.0 0.298] [85.0 0.268] [125.0 0.119]]
-  property(self.rated-temperature) = [-55.0 125.0]
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 155.0))
 
   spice:
    "[C] {a} 1 100u"

--- a/designs/usb-light.stanza
+++ b/designs/usb-light.stanza
@@ -13,6 +13,7 @@ defpackage ocdb/designs/usb-light :
   import ocdb/symbols
   import ocdb/property-structs
   import ocdb/checks
+  import ocdb/tolerance
 
 val BOARD-SHAPE = RoundedRectangle(25.0, 25.0, 0.25)
 
@@ -22,13 +23,13 @@ defn led-circuit-resistance (vbus:Double, forward-voltage:Double, current:Double
 pcb-module main-board:
   inst conn : ocdb/amphenol/10103594-0001LF/component
   port vbus : power
-  property(conn.VCC.power-pin) = PowerPin(Interval(4.75, 5.5, 5.0))
+  property(conn.VCC.power-pin) = PowerPin(min-typ-max(4.75, 5.0, 5.5))
   inst led : gen-led-cmp(tol(2.1,0.1), 0.02, "YELLOW", "0805")[8]
   net p5v (vbus.vdd conn.VCC)
   net gnd (vbus.gnd conn.GND conn.SHIELD)
   symbol(p5v) = ocdb/symbols/supply-sym
   symbol(gnd) = ocdb/symbols/ground-sym
-  val vbus-voltage = (nominal(recommended-voltage(property(conn.VCC.power-pin)))) as Double
+  val vbus-voltage = (nom-value(recommended-voltage(property(conn.VCC.power-pin)))) as Double
   val exact-resistance = led-circuit-resistance(vbus-voltage, property(led[0].forward-voltage), property(led[0].test-current), 2)
   inst res : gen-res-cmp(closest-std-val(exact-resistance,5.0), "0603")[4]
   for i in 0 to 4 do :

--- a/doc/annotations.md
+++ b/doc/annotations.md
@@ -36,7 +36,7 @@ temperature:Double
 - Temperature of the component (degC)
 theta-ja:Double
 - Thermal resistance from junction to ambient
-rated-temperature:[Double,Double] [min max] (degC) 
+rated-temperature:[Toleranced] (degC) 
 - Manufacturer rated temperature of component
 model-trust:String
 - How much do we trust this model?

--- a/modules/passive-circuits.stanza
+++ b/modules/passive-circuits.stanza
@@ -144,8 +144,8 @@ defn make-voltage-divider-module (in: JITXObject, out: JITXObject, lo: JITXObjec
     net (r-lo.p[2] lo)
 
     val vin = typ-value(vo) * (property(r-lo.resistance) + property(r-hi.resistance)) / property(r-lo.resistance)
-    property(r-lo.operating-point) = OperatingPoint(Interval(0.0, typ-value(vo), false),       Interval(0.0, typ-value(vo) / property(r-lo.resistance), false))
-    property(r-hi.operating-point) = OperatingPoint(Interval(0.0, vin - typ-value(vo), false), Interval(0.0, (vin - typ-value(vo))/ property(r-hi.resistance), false))
+    property(r-lo.operating-point) = OperatingPoint(min-max(0.0, typ-value(vo)),       min-max(0.0, typ-value(vo) / property(r-lo.resistance)))
+    property(r-hi.operating-point) = OperatingPoint(min-max(0.0, vin - typ-value(vo)), min-max(0.0, (vin - typ-value(vo))/ property(r-hi.resistance)))
 
     ; [TODO] check. voltage-levels and other check.stanza functions already adapted for JITXObjects.
     ; Check true output against requirement

--- a/tests/test-part-query.stanza
+++ b/tests/test-part-query.stanza
@@ -4,6 +4,8 @@ defpackage ocdb/test/part-query :
   import collections
   import ocdb/db-parts
   import json
+  import ocdb/generic-components
+  import jitx/commands
 
 
 deftest resistors :

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -47,8 +47,8 @@ public pcb-check rated-temperature (component:JITXObject):
   #CHECK(has-property?(component.rated-temperature))
   val temp = operating-temperature(property(component.rated-temperature))
   ; println("Rating %_" % [temp])
-  #CHECK(contains?(temp, OPERATING-TEMPERATURE[0]))
-  #CHECK(contains?(temp, OPERATING-TEMPERATURE[1]))
+  #CHECK(in-range?(temp, OPERATING-TEMPERATURE[0]))
+  #CHECK(in-range?(temp, OPERATING-TEMPERATURE[1]))
 
 public pcb-check io (module:JITXObject) :
   val pins = to-tuple(seq-cat(pins, component-instances(module)))
@@ -114,25 +114,25 @@ public defn check-single-push-pull-levels (out-p:JITXObject, in-p:JITXObject) :
   if has-property?(in-p.digital-input) :
     val [vih vil] = [vih(property(in-p.digital-input)) vil(property(in-p.digital-input))]
     #CHECK(connected?([gnd-pin(o) gnd-pin(property(in-p.digital-input))]))
-    #CHECK(min(voh(driver(o))) > vih)
-    #CHECK(max(vol(driver(o))) < vil)
+    #CHECK(min-value(voh(driver(o))) > vih)
+    #CHECK(max-value(vol(driver(o))) < vil)
     if has-property?(in-p.generic-pin):
-      #CHECK(contains?(max-voltage(property(in-p.generic-pin)), voh(driver(o))))
+      #CHECK(in-range?(max-voltage(property(in-p.generic-pin)), voh(driver(o))))
   else if has-property?(in-p.digital-io):
     #CHECK(connected?([gnd-pin(o) gnd-pin(property(in-p.digital-io))]))
     val i = driver(property(in-p.digital-io))
     #CHECK((i is CMOSOutput) or (i is TTLOutput))
     val [vih-v vil-v] = [vih(property(in-p.digital-io)) vil(property(in-p.digital-io))]
-    #CHECK(min(voh(driver(o))) > vih-v)
-    #CHECK(max(vol(driver(o))) < vil-v)
+    #CHECK(min-value(voh(driver(o))) > vih-v)
+    #CHECK(max-value(vol(driver(o))) < vil-v)
     if has-property?(out-p.digital-io):
-      #CHECK(min(voh(i)) > vih(o))
-      #CHECK(min(voh(i)) > vih(o))
-      #CHECK(max(vol(i)) < vil(o))
+      #CHECK(min-value(voh(i)) > vih(o))
+      #CHECK(min-value(voh(i)) > vih(o))
+      #CHECK(max-value(vol(i)) < vil(o))
     if has-property?(in-p.generic-pin):
-      #CHECK(contains?(max-voltage(property(in-p.generic-pin)), voh(driver(o))))
+      #CHECK(in-range?(max-voltage(property(in-p.generic-pin)), voh(driver(o))))
     if has-property?(out-p.generic-pin):
-      #CHECK(contains?(max-voltage(property(out-p.generic-pin)), voh(i)))
+      #CHECK(in-range?(max-voltage(property(out-p.generic-pin)), voh(i)))
   else if has-property?(in-p.digital-output) and o is DigitalOutput:
     
     #CHECK(tristateable(o))
@@ -158,7 +158,7 @@ public pcb-check power-pin (p:JITXObject) :
   ; println("%_ has power" % [ref(p)])
   #CHECK(has-property?(p.rail-voltage))
   ; println("%_ has %_" % [ref(p) property(p.rail-voltage)])
-  #CHECK(contains?(recommended-voltage(p-props), property(p.rail-voltage)))
+  #CHECK(in-range?(recommended-voltage(p-props), property(p.rail-voltage)))
 
 public pcb-check reset-pin (p:JITXObject) :
   #CHECK(has-property?(p.reset-pin))
@@ -193,7 +193,7 @@ public pcb-check voltage-levels (p:JITXObject, range:[Double,Double,Double]) :
 public pcb-check resistor-component (r:JITXObject) :
   #CHECK(has-property?(r.resistor))
   #CHECK(has-property?(r.operating-point))
-  val [vpk i temp] = [[min(peak-voltage(property(r.operating-point))) max(peak-voltage(property(r.operating-point)))] max(peak-current(property(r.operating-point))) OPERATING-TEMPERATURE[1]]
+  val [vpk i temp] = [[min-value(peak-voltage(property(r.operating-point))) max-value(peak-voltage(property(r.operating-point)))] max-value(peak-current(property(r.operating-point))) OPERATING-TEMPERATURE[1]]
 
   val power = property(r.resistance) * pow(i, 2.0)
   if has-property?(r.derating) :
@@ -211,8 +211,8 @@ public pcb-check capacitor-component (c:JITXObject) :
   #CHECK(has-property?(c.capacitor))
   #CHECK(has-property?(c.operating-point))
 
-  val [vpk temp] = [[min(peak-voltage(property(c.operating-point))) max(peak-voltage(property(c.operating-point)))] OPERATING-TEMPERATURE[1]]
-  val max-temp = max(operating-temperature(property(c.rated-temperature)))
+  val [vpk temp] = [[min-value(peak-voltage(property(c.operating-point))) max-value(peak-voltage(property(c.operating-point)))] OPERATING-TEMPERATURE[1]]
+  val max-temp = max-value(operating-temperature(property(c.rated-temperature)))
   switch(property(c.type)) :
 
     "ceramic" :
@@ -261,7 +261,7 @@ public pcb-check capacitor-component (c:JITXObject) :
 
     else : println("Unhandled type for capacitor check on %_" % [c])
 
-  #CHECK(OPERATING-TEMPERATURE[0] >= min(operating-temperature(property(c.rated-temperature))))
+  #CHECK(OPERATING-TEMPERATURE[0] >= min-value(operating-temperature(property(c.rated-temperature))))
 
 ; Checks the frequency of an oscillator (o) against an interface on an IC (intf)
 public pcb-check oscillator-check-frequency (o:JITXObject, intf:CrystalOscillator) :

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -4,7 +4,8 @@ defpackage ocdb/db-parts :
   import collections
   import json
   import math
-  import lang-utils
+  import lang-utils with:
+    prefix(min-max) => lang-
 
   import jitx with :
     prefix(Resistor) => EModel-
@@ -18,6 +19,7 @@ defpackage ocdb/db-parts :
   import ocdb/property-structs
   import ocdb/symbols
   import ocdb/design-vars
+  import ocdb/tolerance
 
 public deftype Component
 public defmulti x (component: Component) -> Double
@@ -843,7 +845,7 @@ public pcb-struct ocdb/db-parts/MinMaxRange :
 public defn parse-rated-temperature (json: JObject) -> RatedTemperature|False :
   val rated-temperature-json = get?(json, "rated-temperature")
   match(rated-temperature-json: JObject) :
-    RatedTemperature(Interval(rated-temperature-json["min"] as Double, rated-temperature-json["max"] as Double, false))
+    RatedTemperature(min-max(rated-temperature-json["min"] as Double, rated-temperature-json["max"] as Double) as Toleranced)
 
 defn parse-tolerance (json: JObject) -> MinMaxRange|False :
   val tolerance-json = get?(json, "tolerance")

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -14,7 +14,7 @@ defpackage ocdb/generator-utils:
   import ocdb/property-structs
   import ocdb/power-regulators
   import ocdb/bundles
-
+  import ocdb/tolerance
 
 ; =======================================
 ; Ciruit convenience functions
@@ -121,7 +121,7 @@ public defn propagate-rail-voltage ():
             if p1 != p2 and connected?([p1, p2]) :
               if has-property?(p2.rail-voltage) :
                 ; Override with higher voltage
-                if supply-voltage(property(p1.power-supply-pin)) > property(p2.rail-voltage):
+                if supply-voltage(property(p1.power-supply-pin)) as Double > property(p2.rail-voltage) as Double:
                   property(p2.rail-voltage) = supply-voltage(property(p1.power-supply-pin))
               else:
                 property(p2.rail-voltage) = supply-voltage(property(p1.power-supply-pin))
@@ -142,9 +142,9 @@ public defn calculate-operating-points ():
               if connected?([get-other-pin(i,p), property(self.gnd)]):
                 val voltage = property(p.rail-voltage)
                 if has-property?(i.resistance) :
-                  property(i.operating-point) = OperatingPoint(Interval(0.0, voltage, false), Interval(0.0, voltage / property(i.resistance), false))
+                  property(i.operating-point) = OperatingPoint(min-max(0.0, voltage), min-max(0.0, voltage / property(i.resistance)))
                 else if has-property?(i.capacitance) :
-                  property(i.operating-point) = OperatingPoint(Interval(0.0, voltage, false), Interval(0.0, 0.0, false))
+                  property(i.operating-point) = OperatingPoint(min-max(0.0, voltage), min-max(0.0, 0.0))
 
 ; =======================================
 ; Attach the power generator to designs and loads.

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -295,7 +295,7 @@ public pcb-component gen-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg-name
   property(self.capacitance) = cap
   property(self.tolerance) = tol
   property(self.rated-voltage) = max-v
-  property(self.rated-temperature) = [-55.0 125.0]
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
   check connected(self.p[1])
   check connected(self.p[2])
 
@@ -340,7 +340,7 @@ public pcb-component gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg
   property(self.tolerance) = (tol * 0.01)
   property(self.rated-current-pk) = 3.7
   property(self.rated-current-rms) = [[25.0 0.298] [85.0 0.268] [125.0 0.119]]
-  property(self.rated-temperature) = [-55.0 125.0]
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
   check connected(self.a)
   check connected(self.c)
 
@@ -376,7 +376,7 @@ public pcb-component gen-res-cmp (r-type:ResistorSymbolType, res:Double, tol:Dou
   property(self.rated-power) = pwr
   property(self.derating) = [[-60.0 1.0] [70.0 1.0] [155.0 0.0]]
   property(self.TCR) = 100.0e-6
-  property(self.rated-temperature) = [-55.0 155.0]
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
   property(self.tolerance) = (tol * 0.01)
   property(self.resistance) = res
   spice :

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -16,8 +16,8 @@ defpackage ocdb/generic-components:
   import ocdb/box-symbol
   import ocdb/property-structs
   import ocdb/symbol-utils
-  import ocdb/tolerance
   import ocdb/checks
+  import ocdb/tolerance
 
 ; ========================================================
 ; ====== Standard packages for the passive solver ========
@@ -769,7 +769,7 @@ public pcb-component mounting-hole (drill-r:Double, pad-r:Double, mask-r:Double)
   description      = to-string("%~mm mounting hole" % [2. * drill-r])
   landpattern      = (non-plated-hole-landpattern(drill-r, mask-r))()
   symbol           = unplated-hole-sym()
-  property(self.rated-temperature) = RatedTemperature(Interval(-100.0 180.0, false))
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0 180.0))
 
 
 ; A mounting hole component with drill and pad radius. 

--- a/utils/property-structs.stanza
+++ b/utils/property-structs.stanza
@@ -9,24 +9,24 @@ defpackage ocdb/property-structs:
   import ocdb/generator-utils
   import ocdb/tolerance
 
-public pcb-struct ocdb/property-structs/Interval :
-  ; Maximum and minimum values for all operation modes
-  min:Double
-  max:Double
-  ; Nominal operating value
-  nominal:Double|False
+; public pcb-struct ocdb/property-structs/Interval :
+;   ; Maximum and minimum values for all operation modes
+;   min:Double
+;   max:Double
+;   ; Nominal operating value
+;   nominal:Double|False
 
-public defn contains? (a:Interval, b:Interval) -> True|False :
-  min(a) <= min(b) and
-  max(a) >= max(b)
+; public defn contains? (a:Interval, b:Interval) -> True|False :
+;   min(a) <= min(b) and
+;   max(a) >= max(b)
 
-public defn contains? (a:Interval, b:Double) -> True|False :
-  min(a) <= b and
-  max(a) >= b
+; public defn contains? (a:Interval, b:Double) -> True|False :
+;   min(a) <= b and
+;   max(a) >= b
 
 public pcb-struct ocdb/property-structs/OperatingPoint :
-  peak-voltage:Interval
-  peak-current:Interval
+  peak-voltage:Toleranced
+  peak-current:Toleranced
 
 public pcb-struct ocdb/property-structs/PowerRail :
   rail:JITXObject
@@ -37,17 +37,17 @@ public pcb-struct ocdb/property-structs/PowerRail :
 
 ; Library property name: generic-pin
 public pcb-struct ocdb/property-structs/GenericPin :
-  max-voltage:Interval
+  max-voltage:Toleranced
   rated-esd:Double
 
 ; Library property name: power-supply-pin
 public pcb-struct ocdb/property-structs/PowerSupplyPin :
-  supply-voltage:Double
+  supply-voltage:Toleranced|Double
   max-current:Double
 
 ; Library property name: power-pin
 public pcb-struct ocdb/property-structs/PowerPin :
-  recommended-voltage:Interval
+  recommended-voltage:Toleranced
   
 ; Library property name: digital-input
 public pcb-struct ocdb/property-structs/DigitalInput :
@@ -81,15 +81,15 @@ public pcb-struct ocdb/property-structs/ResetPin :
 ; ==============================
 deftype LogicFamily <: jitx/client/JITXValue
 public pcb-struct ocdb/property-structs/CMOSOutput <: LogicFamily :
-  vol:Interval
-  voh:Interval
+  vol:Toleranced
+  voh:Toleranced
 
 public pcb-struct ocdb/property-structs/TTLOutput <: LogicFamily :
-  vol:Interval
-  voh:Interval
+  vol:Toleranced
+  voh:Toleranced
 
 public pcb-struct ocdb/property-structs/OpenCollector <: LogicFamily :
-  vol:Interval
+  vol:Toleranced
   iol:Double
 
 ; === Oscillator Property Structs ===
@@ -108,7 +108,7 @@ public pcb-struct ocdb/property-structs/CrystalOscillator :
 
 ; Library property name: rated-temperature
 public pcb-struct ocdb/property-structs/RatedTemperature :
-  operating-temperature : Interval
+  operating-temperature : Toleranced
 
 ; Library property name: crystal-resonator
 public pcb-struct ocdb/property-structs/CrystalResonator :

--- a/utils/stm-to-jitx.stanza
+++ b/utils/stm-to-jitx.stanza
@@ -8,6 +8,7 @@ defpackage ocdb/stm-to-jitx:
 
   import ocdb/bundles
   import ocdb/property-structs
+  import ocdb/tolerance
 
   import ocdb/stm
   import ocdb/scripts/cubemx-importer-utils
@@ -23,8 +24,8 @@ defn stm-to-jitx (generic-pin:STMGenericPin) -> GenericPin :
 defn stm-to-jitx (power-pin:STMPowerPin) -> PowerPin :
   PowerPin(stm-to-jitx(recommended-voltage(power-pin)))
 
-defn stm-to-jitx (voltage-limits:STMVoltageLimits) -> Interval :
-  Interval(min-val(voltage-limits), max-val(voltage-limits), false)
+defn stm-to-jitx (voltage-limits:STMVoltageLimits) -> Toleranced :
+  min-max(min-val(voltage-limits), max-val(voltage-limits))
 
 ;Generate pin-properties inside of a component.
 public defn to-jitx-pin-properties (pin-properties:STMPinProperties) -> HashTable<Ref, Ref> :


### PR DESCRIPTION
Touches the following parameters/objects:
RatedTemperature
rated-temperature
operating-temperature
rated-voltage
recommended-voltage
power-pin
PowerPin
GenericPin
PowerSupplyPin
CMOSOutput
DigitalOutput
OperatingPoint
nominal

Note that all of the above are not toleranced-enabled objects just some of them.