### PR TITLE
extra checks in generic-components that are not needed (diode now included)

### DIFF
--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -50,9 +50,10 @@ public defn check-design (module:JITXObject):
   inside pcb-module:
     for i in populated-components(module) do :
       check rated-temperature(i)
-      check capacitor-component(i) when has-property?(i.capacitance)
-      check resistor-component(i)  when has-property?(i.resistance)
-      check inductor-component(i)  when has-property?(i.inductance)
+      check capacitor-component(i) when has-property?(i.capacitor)
+      check resistor-component(i)  when has-property?(i.resistor)
+      check inductor-component(i)  when has-property?(i.inductor)
+      check diode-component(i)     when has-property?(i.diode)
       
       for p in pins(i) do :
         check generic-pin-check(p) when has-property?(p.generic-pin)
@@ -938,6 +939,27 @@ public pcb-check voltage-levels (p:JITXObject, range:[Double,Double,Double]) :
 ; ====================================
 ; public pcb-check pull-up-check (p:JITXObject) :
 
+public pcb-check diode-component (d:JITXObject) :
+  val name = "Diode checks"
+  val description = "Check diode component properties"
+  val category = "component-check"
+
+  ; should check that pins of the resistor are connected (if they don't have a NC property)
+  for d-pin in pins(d) do :
+    if not no-connect?(d-pin) :
+      val conn-pin = populated-connected-pins(d-pin)
+      #CHECK(
+        condition =            not empty?(conn-pin),
+        name =                 "Diode checks"
+        description =          "Check that the diode pins are connected"
+        category =             "component-check"
+        subcheck-description = "Check diode component is connected property",
+        pass-message =         "Diode %_ pin %_ is connected properly" % [ref(d), ref(d-pin)],
+        fail-message =         "Diode %_ pin %_ is not connected properly" % [ref(d), ref(d-pin)],
+        locators =             [d]
+      )
+
+
 public pcb-check inductor-component (l:JITXObject) :
   val name = "Inductor checks"
   val description = "Check inductor component properties"
@@ -959,13 +981,13 @@ public pcb-check inductor-component (l:JITXObject) :
       )
 
   #CHECK(
-    condition =            has-property?(l.inductor),
+    condition =            has-property?(l.inductance),
     name =                 "Inductor checks"
     description =          "Check inductor component properties"
     category =             "component-check"
-    subcheck-description = "Check inductor component has the correct inductor property",
-    pass-message =         "Inductor %_ has the correct property for an inductor" % [ref(l)],
-    fail-message =         "Inductor %_ does not have the correct property for an inductor" % [ref(l)],
+    subcheck-description = "Check inductor component has the correct inductance property",
+    pass-message =         "Inductor %_ has the correct inductance property for an inductor" % [ref(l)],
+    fail-message =         "Inductor %_ does not have the correct inductance property for an inductor" % [ref(l)],
     locators =             [l]
   )
   #CHECK(
@@ -1037,16 +1059,14 @@ public pcb-check resistor-component (r:JITXObject) :
         locators =             [r]
       )
 
-
-
   #CHECK(
-    condition =            has-property?(r.resistor),
+    condition =            has-property?(r.resistance),
     name =                 "Resistor checks"
     description =          "Check resistor component properties"
     category =             "component-check"
-    subcheck-description = "Check resistor component has the correct resistor property",
-    pass-message =         "Resistor %_ has the correct property for resistor" % [ref(r)],
-    fail-message =         "Resistor %_ does not have the correct property for a resistor" % [ref(r)],
+    subcheck-description = "Check resistor component has the correct resistance property",
+    pass-message =         "Resistor %_ has the correct resistance property for resistor" % [ref(r)],
+    fail-message =         "Resistor %_ does not have the correct resistance property for a resistor" % [ref(r)],
     locators =             [r]
   )
   #CHECK(
@@ -1116,13 +1136,13 @@ public pcb-check capacitor-component (c:JITXObject) :
       )
 
   #CHECK(
-    condition =            has-property?(c.capacitor),
+    condition =            has-property?(c.capacitance),
     name =                 "Capacitor checks"
     description =          "Check capacitor component properties"
     category =             "component-check"
-    subcheck-description = "Check capacitor component has the correct capacitor property",
-    pass-message =         "Capacitor %_ has the correct property for a capacitor" % [ref(c)],
-    fail-message =         "Capacitor %_ does not have the correct property for a capacitor" % [ref(c)],
+    subcheck-description = "Check capacitor component has the correct capacitance property",
+    pass-message =         "Capacitor %_ has the correct capacitance property for a capacitor" % [ref(c)],
+    fail-message =         "Capacitor %_ does not have the correct capacitance property for a capacitor" % [ref(c)],
     locators =             [c]
   )
   #CHECK(

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -296,8 +296,6 @@ public pcb-component gen-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg-name
   property(self.tolerance) = tol
   property(self.rated-voltage) = max-v
   property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
-  check connected(p[1])
-  check connected(p[2])
 
 public defn gen-cap-cmp (cap:Double, tol:Double, max-v:Double) :
   gen-cap-cmp(cap, tol, max-v, "0402")
@@ -341,8 +339,6 @@ public pcb-component gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg
   property(self.rated-current-pk) = 3.7
   property(self.rated-current-rms) = [[25.0 0.298] [85.0 0.268] [125.0 0.119]]
   property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
-  check connected(a)
-  check connected(c)
 
 public defn gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double) :
   gen-tant-cap-cmp(cap, tol, max-v, "0402")
@@ -381,8 +377,6 @@ public pcb-component gen-res-cmp (r-type:ResistorSymbolType, res:Double, tol:Dou
   property(self.resistance) = res
   spice :
     "[R] {p[1]} {p[2]} {res}"
-  check connected(p[1])
-  check connected(p[2])
 
 public defn gen-res-cmp (res:Double, tol:Double, pkg:String) :
   gen-res-cmp(ResistorStd, res, tol, 0.0625, pkg)
@@ -414,8 +408,6 @@ public pcb-component gen-ind-cmp (l-type:InductorSymbolType, ind:Double, tol:Dou
   property(self.inductance) = ind
   property(self.tolerance) = (tol * 0.01)
   property(self.max-current) = max-i
-  check connected(p[1])
-  check connected(p[2])
 
 public defn gen-ind-cmp (ind:Double, tol:Double) :
   gen-ind-cmp(InductorStd, ind, tol, 0.1) ; 100mA default
@@ -442,8 +434,6 @@ public pcb-component gen-led-cmp (vf:Toleranced, itest:Double, color:String, pkg
   property(self.forward-voltage) = vf-center ; Vf
   property(self.test-current) = itest ; If or Itest
   property(self.NamedColor) = color
-  check connected(a)
-  check connected(c)
 
 public defn gen-led-cmp (vf:Toleranced, itest:Double, color:String, pkg-name:String) :
   gen-led-cmp(vf, itest, color, pkg-name, DENSITY-LEVEL)


### PR DESCRIPTION
Removes extra checks that are not part of the check-design() flow. If you run check-design() then the resistor/capacitor/inductor pin connectivity checks are run by default.