### PR TITLE
Bg/skip operating point

### DIFF
--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -63,7 +63,6 @@ public defn erc-check-design (module:JITXObject):
         check generic-pin-check(p) when has-property?(p.generic-pin)
         check power-pin-check(p)   when has-property?(p.power-pin)
         check reset-pin-check(p)   when has-property?(p.reset-pin)
-
     check-io(module)
 
 public defn drc-check-design (module:JITXObject):
@@ -1769,23 +1768,25 @@ public defn propagate-power-states (module:JITXObject) :
   ; DFS walk of the netlist, to update power-states of 
   ; connected power-pins 
   val visited = HashSet<JITXObject>()
-  defn visit (pin:JITXObject, power-states:Tuple<PowerState>) :
+  defn visit-pins (pin:JITXObject, power-states-tuple:Tuple<PowerState>) :
     if not visited[pin] :
       add(visited, pin)
       if not has-property?(pin.power-states) :
-        set-property(pin, `power-states, power-states)
+        set-property(pin, `power-states, power-states-tuple)
         
       if has-property?(pin.power-pin) or
          has-property?(pin.power-supply-pin) :
-        do(visit{_, power-states}, connected-pins(pin))
+        do(visit-pins{_, power-states-tuple}, connected-pins(pin))
 
-      val instance = containing-instance!(pin)
-      if has-property?(instance.power-supply-component) and
-         property(instance.power-supply-component) : 
-        do(visit{_, power-states}, pins(instance))
+  defn visit-power-supply-components (pin:JITXObject, power-states-tuple:Tuple<PowerState>) :
+    val instance = containing-instance!(pin)
+    if has-property?(instance.power-supply-component) and
+        property(instance.power-supply-component) : 
+      do(visit-pins{_, power-states-tuple}, pins(instance))
 
   ; propagate the power-states to connected power-pins
-  do(visit{_0, property(_0.power-states)}, roots)
+  do(visit-pins{_0, property(_0.power-states)}, roots)
+  do(visit-power-supply-components{_0, property(_0.power-states)}, roots)
 
   ; propagate from power pins to io-pins
   for io-pin in filter(is-digital-pin?, all-pins) do :
@@ -1798,18 +1799,17 @@ public defn propagate-power-states (module:JITXObject) :
         vdd-pin(property(io-pin.digital-io))
       else : 
         fatal("Expected a digital io pin.")
-    
     if has-property?(vdd-pin.power-states) and 
        (not has-property?(io-pin.power-states)): 
       set-property(io-pin, `power-states, property(vdd-pin.power-states))
 
-defn check-has-power-states (p:JITXObject) : 
+defn check-has-power-states (p:JITXObject) :
   #CHECK(condition = has-property?(p.power-states)
          name        = "Check Power States"
          description = "Checks that all i/o pins have power states"
          category    = "power-states"
          subcheck-description = "Check that a pin has power states"
-         pass-message = "%_ has a valid .power-states property"    % [ref(p)]
+         pass-message = "%_ has a valid .power-states property" % [ref(p)]
          fail-message = "%_ is missing the .power-states property" % [ref(p)]
          locators = [p])
 
@@ -1820,6 +1820,7 @@ doc: "This check will make sure that components connected to each other \
                                                                         \
       - module: the module to check."
 public pcb-check power-states (module:JITXObject) :
+
   for connected-group in populated-connected-groups(module) do :
     val pin-categories = categorize-digital-pins(connected-group)
     val digital-pins = to-tuple $ cat-all([inputs(pin-categories),
@@ -1838,6 +1839,6 @@ public pcb-check power-states (module:JITXObject) :
             description = "Checks that all components have matching power states."
             category    = "power-states"
             subcheck-description = "Checking power states match on connected pins"
-            pass-message = "Connected pins %, do not have matching power states" % [pin-refs(digital-pins)]
+            pass-message = "Connected pins %, have matching power states" % [pin-refs(digital-pins)]
             fail-message = "Connected pins %_ and %_ do not have matching power states"  % [pin-refs(digital-pins)]
             locators = to-jitx-pins(digital-pins))

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -960,7 +960,7 @@ public pcb-check diode-component (d:JITXObject) :
   val description = "Check diode component properties"
   val category = "component-check"
 
-  ; should check that pins of the resistor are connected (if they don't have a NC property)
+  ; should check that pins of the diode are connected (if they don't have a NC property)
   for d-pin in pins(d) do :
     if not no-connect?(d-pin) :
       val conn-pin = populated-connected-pins(d-pin)

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -54,9 +54,10 @@ public defn erc-check-design (module:JITXObject):
   inside pcb-module:
     for i in populated-components(module) do :
       check rated-temperature(i)
-      check capacitor-component(i) when has-property?(i.capacitance)
-      check resistor-component(i)  when has-property?(i.resistance)
-      check inductor-component(i)  when has-property?(i.inductance)
+      check capacitor-component(i) when has-property?(i.capacitor)
+      check resistor-component(i)  when has-property?(i.resistor)
+      check inductor-component(i)  when has-property?(i.inductor)
+      check diode-component(i)     when has-property?(i.diode)
       
       for p in pins(i) do :
         check generic-pin-check(p) when has-property?(p.generic-pin)
@@ -954,6 +955,27 @@ public pcb-check voltage-levels (p:JITXObject, range:[Double,Double,Double]) :
 ; ====================================
 ; public pcb-check pull-up-check (p:JITXObject) :
 
+public pcb-check diode-component (d:JITXObject) :
+  val name = "Diode checks"
+  val description = "Check diode component properties"
+  val category = "component-check"
+
+  ; should check that pins of the resistor are connected (if they don't have a NC property)
+  for d-pin in pins(d) do :
+    if not no-connect?(d-pin) :
+      val conn-pin = populated-connected-pins(d-pin)
+      #CHECK(
+        condition =            not empty?(conn-pin),
+        name =                 "Diode checks"
+        description =          "Check that the diode pins are connected"
+        category =             "component-check"
+        subcheck-description = "Check diode component is connected property",
+        pass-message =         "Diode %_ pin %_ is connected properly" % [ref(d), ref(d-pin)],
+        fail-message =         "Diode %_ pin %_ is not connected properly" % [ref(d), ref(d-pin)],
+        locators =             [d]
+      )
+
+
 public pcb-check inductor-component (l:JITXObject) :
   val name = "Inductor checks"
   val description = "Check inductor component properties"
@@ -975,13 +997,13 @@ public pcb-check inductor-component (l:JITXObject) :
       )
 
   #CHECK(
-    condition =            has-property?(l.inductor),
+    condition =            has-property?(l.inductance),
     name =                 "Inductor checks"
     description =          "Check inductor component properties"
     category =             "component-check"
-    subcheck-description = "Check inductor component has the correct inductor property",
-    pass-message =         "Inductor %_ has the correct property for an inductor" % [ref(l)],
-    fail-message =         "Inductor %_ does not have the correct property for an inductor" % [ref(l)],
+    subcheck-description = "Check inductor component has the correct inductance property",
+    pass-message =         "Inductor %_ has the correct inductance property for an inductor" % [ref(l)],
+    fail-message =         "Inductor %_ does not have the correct inductance property for an inductor" % [ref(l)],
     locators =             [l]
   )
 
@@ -1055,16 +1077,14 @@ public pcb-check resistor-component (r:JITXObject) :
         locators =             [r]
       )
 
-
-
   #CHECK(
-    condition =            has-property?(r.resistor),
+    condition =            has-property?(r.resistance),
     name =                 "Resistor checks"
     description =          "Check resistor component properties"
     category =             "component-check"
-    subcheck-description = "Check resistor component has the correct resistor property",
-    pass-message =         "Resistor %_ has the correct property for resistor" % [ref(r)],
-    fail-message =         "Resistor %_ does not have the correct property for a resistor" % [ref(r)],
+    subcheck-description = "Check resistor component has the correct resistance property",
+    pass-message =         "Resistor %_ has the correct resistance property for resistor" % [ref(r)],
+    fail-message =         "Resistor %_ does not have the correct resistance property for a resistor" % [ref(r)],
     locators =             [r]
   )
   if has-property?(r.operating-point) :
@@ -1135,13 +1155,13 @@ public pcb-check capacitor-component (c:JITXObject) :
       )
 
   #CHECK(
-    condition =            has-property?(c.capacitor),
+    condition =            has-property?(c.capacitance),
     name =                 "Capacitor checks"
     description =          "Check capacitor component properties"
     category =             "component-check"
-    subcheck-description = "Check capacitor component has the correct capacitor property",
-    pass-message =         "Capacitor %_ has the correct property for a capacitor" % [ref(c)],
-    fail-message =         "Capacitor %_ does not have the correct property for a capacitor" % [ref(c)],
+    subcheck-description = "Check capacitor component has the correct capacitance property",
+    pass-message =         "Capacitor %_ has the correct capacitance property for a capacitor" % [ref(c)],
+    fail-message =         "Capacitor %_ does not have the correct capacitance property for a capacitor" % [ref(c)],
     locators =             [c]
   )
 

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -47,6 +47,10 @@ Set of standard checks to run on a top-level-module.
 <S>
 
 public defn check-design (module:JITXObject):
+  erc-check-design(module)
+  drc-check-design(module)
+
+public defn erc-check-design (module:JITXObject):
   inside pcb-module:
     for i in populated-components(module) do :
       check rated-temperature(i)
@@ -60,7 +64,19 @@ public defn check-design (module:JITXObject):
         check reset-pin-check(p)   when has-property?(p.reset-pin)
 
     check-io(module)
+
+public defn drc-check-design (module:JITXObject):
+  inside pcb-module:
     check-all-landpatterns(module)
+    ; FIXME!: this needs to be added back when we are able to detect whether a board has been set
+    ; if exists?(board) :
+    ;   run-design-verification()
+
+
+    ; if board(design) is False :
+    ;   issue-error(CannotPlaceWithoutBoard(path(design)))
+    ; if rules(design) is False :
+    ;   issue-error(CannotPlaceWithoutRules(path(design)))
 
 ;============================================================
 ;======================== Check IO ==========================
@@ -968,52 +984,54 @@ public pcb-check inductor-component (l:JITXObject) :
     fail-message =         "Inductor %_ does not have the correct property for an inductor" % [ref(l)],
     locators =             [l]
   )
-  #CHECK(
-    condition =            has-property?(l.operating-point),
-    name =                 "Inductor checks"
-    description =          "Check inductor component properties"
-    category =             "component-check"
-    subcheck-description = "Check inductor component has the correct inductor property",
-    pass-message =         "Inductor %_ has the correct property for operating-point" % [ref(l)],
-    fail-message =         "Inductor %_ does not have the correct property for the operating-point" % [ref(l)],
-    locators =             [l]
-  )
 
-  val [vpk, i, temp] = [[min-value(peak-voltage(property(l.operating-point)))
-                         max-value(peak-voltage(property(l.operating-point)))],
-                        max-value(peak-current(property(l.operating-point))),
-                        OPERATING-TEMPERATURE[1]]
-
-  val power = property(l.dc-resistance) * pow(i, 2.0) ; FIXME! just using the DC formula
-  if has-property?(l.derating) and has-property?(l.rated-power):
-    ; Derate the power based on the piecewise linear curve from MFG
-    val derating = PWL(property(l.derating))[temp]
-    val pwr = derating * property(l.rated-power)
+  if has-property?(l.operating-point) :
     #CHECK(
-      condition =            pwr * DERATE-INDUCTOR-POWER > power,
+      condition =            has-property?(l.operating-point),
       name =                 "Inductor checks"
       description =          "Check inductor component properties"
       category =             "component-check"
-      subcheck-description = "Check inductor power derating meets the design requirements",
-      pass-message =         "Inductor %_ power derating %_W meets the design requirements of %_W" % [ref(l), pwr * DERATE-RESISTOR-POWER, power],
-      fail-message =         "Inductor %_ power derating %_W does not meet the design requirements of %_W" % [ref(l), pwr * DERATE-RESISTOR-POWER, power],
+      subcheck-description = "Check inductor component has the correct inductor property",
+      pass-message =         "Inductor %_ has the correct property for operating-point" % [ref(l)],
+      fail-message =         "Inductor %_ does not have the correct property for the operating-point" % [ref(l)],
       locators =             [l]
     )
-  else :
-    ; Derate the power if MFG derating is missing
-    ; adapted from http://www.interfacebus.com/Component_Derating_Guide_line.html but substituting r for l-dc-resistance
-    val derating = PWL([[0.0 1.0] [70.0 1.0] [110.0 0.8] [150.0 0.6] [190.0 0.4] [240.0 0.2] [260.0 0.1]])[temp]
-    val pwr = derating * property(l.rated-power)
-    #CHECK(
-      condition =            pwr * DERATE-INDUCTOR-POWER > power,
-      name =                 "Inductor checks"
-      description =          "Check inductor component properties"
-      category =             "component-check"
-      subcheck-description = "Check inductor default power derating meets the design requirements",
-      pass-message =         "Inductor %_ default power derating %_W meets the design requirements of %_W" % [ref(l), pwr * DERATE-RESISTOR-POWER, power],
-      fail-message =         "Inductor %_ default power derating %_W does not meet the design requirements of %_W" % [ref(l), pwr * DERATE-RESISTOR-POWER, power],
-      locators =             [l]
-    )
+
+    val [vpk, i, temp] = [[min-value(peak-voltage(property(l.operating-point)))
+                          max-value(peak-voltage(property(l.operating-point)))],
+                          max-value(peak-current(property(l.operating-point))),
+                          OPERATING-TEMPERATURE[1]]
+
+    val power = property(l.dc-resistance) * pow(i, 2.0) ; FIXME! just using the DC formula
+    if has-property?(l.derating) and has-property?(l.rated-power):
+      ; Derate the power based on the piecewise linear curve from MFG
+      val derating = PWL(property(l.derating))[temp]
+      val pwr = derating * property(l.rated-power)
+      #CHECK(
+        condition =            pwr * DERATE-INDUCTOR-POWER > power,
+        name =                 "Inductor checks"
+        description =          "Check inductor component properties"
+        category =             "component-check"
+        subcheck-description = "Check inductor power derating meets the design requirements",
+        pass-message =         "Inductor %_ power derating %_W meets the design requirements of %_W" % [ref(l), pwr * DERATE-RESISTOR-POWER, power],
+        fail-message =         "Inductor %_ power derating %_W does not meet the design requirements of %_W" % [ref(l), pwr * DERATE-RESISTOR-POWER, power],
+        locators =             [l]
+      )
+    else :
+      ; Derate the power if MFG derating is missing
+      ; adapted from http://www.interfacebus.com/Component_Derating_Guide_line.html but substituting r for l-dc-resistance
+      val derating = PWL([[0.0 1.0] [70.0 1.0] [110.0 0.8] [150.0 0.6] [190.0 0.4] [240.0 0.2] [260.0 0.1]])[temp]
+      val pwr = derating * property(l.rated-power)
+      #CHECK(
+        condition =            pwr * DERATE-INDUCTOR-POWER > power,
+        name =                 "Inductor checks"
+        description =          "Check inductor component properties"
+        category =             "component-check"
+        subcheck-description = "Check inductor default power derating meets the design requirements",
+        pass-message =         "Inductor %_ default power derating %_W meets the design requirements of %_W" % [ref(l), pwr * DERATE-RESISTOR-POWER, power],
+        fail-message =         "Inductor %_ default power derating %_W does not meet the design requirements of %_W" % [ref(l), pwr * DERATE-RESISTOR-POWER, power],
+        locators =             [l]
+      )
 
 
 ; Checks resistors against operating point and environment
@@ -1049,51 +1067,52 @@ public pcb-check resistor-component (r:JITXObject) :
     fail-message =         "Resistor %_ does not have the correct property for a resistor" % [ref(r)],
     locators =             [r]
   )
-  #CHECK(
-    condition =            has-property?(r.operating-point),
-    name =                 "Resistor checks"
-    description =          "Check resistor component properties"
-    category =             "component-check"
-    subcheck-description = "Check resistor component has the correct operating-point property",
-    pass-message =         "Resistor %_ has the correct property for operating-point" % [ref(r)],
-    fail-message =         "Resistor %_ does not have the correct property for the operating-point" % [ref(r)],
-    locators =             [r]
-  )
-
-  val [vpk, i, temp] = [[min-value(peak-voltage(property(r.operating-point)))
-                         max-value(peak-voltage(property(r.operating-point)))],
-                        max-value(peak-current(property(r.operating-point))),
-                        OPERATING-TEMPERATURE[1]]
-
-  val power = property(r.resistance) * pow(i, 2.0)
-  if has-property?(r.derating) :
-    ; Derate the power based on the piecewise linear curve from MFG
-    val derating = PWL(property(r.derating))[temp]
-    val pwr = derating * property(r.rated-power)
+  if has-property?(r.operating-point) :
     #CHECK(
-      condition =            pwr * DERATE-RESISTOR-POWER > power,
+      condition =            has-property?(r.operating-point),
       name =                 "Resistor checks"
       description =          "Check resistor component properties"
       category =             "component-check"
-      subcheck-description = "Check resistor power derating meets the design requirements",
-      pass-message =         "Resistor %_ power derating %_W meets the design requirements of %_W" % [ref(r), pwr * DERATE-RESISTOR-POWER, power],
-      fail-message =         "Resistor %_ power derating %_W does not meet the design requirements of %_W" % [ref(r), pwr * DERATE-RESISTOR-POWER, power],
+      subcheck-description = "Check resistor component has the correct operating-point property",
+      pass-message =         "Resistor %_ has the correct property for operating-point" % [ref(r)],
+      fail-message =         "Resistor %_ does not have the correct property for the operating-point" % [ref(r)],
       locators =             [r]
     )
-  else :
-    ; Derate the power if MFG derating is missing
-    val derating = PWL([[0.0 1.0] [70.0 1.0] [110.0 0.8] [150.0 0.6] [190.0 0.4] [240.0 0.2] [260.0 0.1]])[temp]
-    val pwr = derating * property(r.rated-power)
-    #CHECK(
-      condition =            pwr * DERATE-RESISTOR-POWER > power,
-      name =                 "Resistor checks"
-      description =          "Check resistor component properties"
-      category =             "component-check"
-      subcheck-description = "Check resistor default power derating meets the design requirements",
-      pass-message =         "Resistor %_ default power derating %_W meets the design requirements of %_W" % [ref(r), pwr * DERATE-RESISTOR-POWER, power],
-      fail-message =         "Resistor %_ default power derating %_W does not meet the design requirements of %_W" % [ref(r), pwr * DERATE-RESISTOR-POWER, power],
-      locators =             [r]
-    )
+
+    val [vpk, i, temp] = [[min-value(peak-voltage(property(r.operating-point)))
+                          max-value(peak-voltage(property(r.operating-point)))],
+                          max-value(peak-current(property(r.operating-point))),
+                          OPERATING-TEMPERATURE[1]]
+
+    val power = property(r.resistance) * pow(i, 2.0)
+    if has-property?(r.derating) :
+      ; Derate the power based on the piecewise linear curve from MFG
+      val derating = PWL(property(r.derating))[temp]
+      val pwr = derating * property(r.rated-power)
+      #CHECK(
+        condition =            pwr * DERATE-RESISTOR-POWER > power,
+        name =                 "Resistor checks"
+        description =          "Check resistor component properties"
+        category =             "component-check"
+        subcheck-description = "Check resistor power derating meets the design requirements",
+        pass-message =         "Resistor %_ power derating %_W meets the design requirements of %_W" % [ref(r), pwr * DERATE-RESISTOR-POWER, power],
+        fail-message =         "Resistor %_ power derating %_W does not meet the design requirements of %_W" % [ref(r), pwr * DERATE-RESISTOR-POWER, power],
+        locators =             [r]
+      )
+    else :
+      ; Derate the power if MFG derating is missing
+      val derating = PWL([[0.0 1.0] [70.0 1.0] [110.0 0.8] [150.0 0.6] [190.0 0.4] [240.0 0.2] [260.0 0.1]])[temp]
+      val pwr = derating * property(r.rated-power)
+      #CHECK(
+        condition =            pwr * DERATE-RESISTOR-POWER > power,
+        name =                 "Resistor checks"
+        description =          "Check resistor component properties"
+        category =             "component-check"
+        subcheck-description = "Check resistor default power derating meets the design requirements",
+        pass-message =         "Resistor %_ default power derating %_W meets the design requirements of %_W" % [ref(r), pwr * DERATE-RESISTOR-POWER, power],
+        fail-message =         "Resistor %_ default power derating %_W does not meet the design requirements of %_W" % [ref(r), pwr * DERATE-RESISTOR-POWER, power],
+        locators =             [r]
+      )
 
 public pcb-check capacitor-component (c:JITXObject) :
   val name = "Capacitor checks"
@@ -1125,302 +1144,304 @@ public pcb-check capacitor-component (c:JITXObject) :
     fail-message =         "Capacitor %_ does not have the correct property for a capacitor" % [ref(c)],
     locators =             [c]
   )
-  #CHECK(
-    condition =            has-property?(c.operating-point),
-    name =                 "Capacitor checks"
-    description =          "Check capacitor component properties"
-    category =             "component-check"
-    subcheck-description = "Check capacitor component has the correct operating-point property",
-    pass-message =         "Capacitor %_ has the correct property for operating-point" % [ref(c)],
-    fail-message =         "Capacitor %_ does not have the correct property for the operating-point" % [ref(c)],
-    locators =             [c]
-  )
-  val [vpk temp] = [[min-value(peak-voltage(property(c.operating-point))) max-value(peak-voltage(property(c.operating-point)))] OPERATING-TEMPERATURE[1]]
-  val max-temp = max-value(operating-temperature(property(c.rated-temperature)))
-  switch(property(c.type)) :
-    "ceramic" :
-      val vpk-derate-wc = PWL(DERATE-CAPACITOR-MLCC-VPK-WC)[temp]
-      #CHECK(
-        condition =            vpk[0] <= (vpk-derate-wc * property(c.rated-voltage)),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check ceramic capacitor voltage derating matches the operating-point voltage",
-        pass-message =         "Capacitor %_ voltage derating %_V is compatible with the wc design constraint %_V" % [ref(c),vpk[0],(vpk-derate-wc * property(c.rated-voltage))],
-        fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the wc design constraint %_V" % [ref(c),vpk[0],(vpk-derate-wc * property(c.rated-voltage))],
-        locators =             [c]
-      )
 
-      #CHECK(
-        condition =            vpk[1] <= (vpk-derate-wc * property(c.rated-voltage)),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check ceramic capacitor voltage derating matches the operating-point voltage",
-        pass-message =         "Capacitor %_ voltage derating %_V is compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
-        fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
-        locators =             [c]
-      )
-
-      val vpk-derate-nom = PWL(DERATE-CAPACITOR-MLCC-VPK-NOM)[temp]
-      #CHECK(
-        condition =            vpk[0] <= (vpk-derate-nom * property(c.rated-voltage)),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check ceramic capacitor voltage derating matches the operating-point voltage",
-        pass-message =         "Capacitor %_ voltage derating %_V is compatible with the nominal design constraint %_V" % [ref(c),vpk[0],(vpk-derate-nom * property(c.rated-voltage))],
-        fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the nominal design constraint %_V" % [ref(c),vpk[0],(vpk-derate-nom * property(c.rated-voltage))],
-        locators =             [c]
-      )
-
-      #CHECK(
-        condition =            vpk[1] <= (vpk-derate-nom * property(c.rated-voltage)),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check ceramic capacitor voltage derating matches the operating-point voltage",
-        pass-message =         "Capacitor %_ voltage derating %_V is compatible with the nominal design constraint %_V" % [ref(c),vpk[1],(vpk-derate-nom * property(c.rated-voltage))],
-        fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the nominal design constraint %_V" % [ref(c),vpk[1],(vpk-derate-nom * property(c.rated-voltage))],
-        locators =             [c]
-      )
-
-      #CHECK(
-        condition =            temp <= min-value(DERATE-CAPACITOR-MLCC-TEMP, max-temp),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check ceramic capacitor de-rated temperature operating point versus design constraints",
-        pass-message =         "Capacitor %_ operating temp %_C satisfies the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-MLCC-TEMP, max-temp)],
-        fail-message =         "Capacitor %_ operating temp %_C does not satisfy the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-MLCC-TEMP, max-temp)],
-        locators =             [c]
-      )
-
-    "electrolytic" :
-      #CHECK(
-        condition =            has-property?(c.anode),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check electrolytic capacitor component has the anode property",
-        pass-message =         "Electrolytic capacitor %_ has the correct anode property" % [ref(c)],
-        fail-message =         "Electrolytic capacitor %_ does not have the correct anode property" % [ref(c)],
-        locators =             [c]
-      )
-
-      #CHECK(
-        condition =            has-property?(c.electrolyte),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check electrolytic capacitor component has the electrolyte property",
-        pass-message =         "Electrolytic capacitor %_ has the correct electrolyte property" % [ref(c)],
-        fail-message =         "Electrolytic capacitor %_ does not have the correct electrolyte property" % [ref(c)],
-        locators =             [c]
-      )
-
-      val [i-pk, i-rms] = [lookup(property(c.operating-point), `current-pk),
-                           lookup(property(c.operating-point), `current-rms)]
-
-      if (property(c.anode) == "tantalum" and property(c.electrolyte) == "polymer") :
+  if has-property?(c.operating-point) :
+    #CHECK(
+      condition =            has-property?(c.operating-point),
+      name =                 "Capacitor checks"
+      description =          "Check capacitor component properties"
+      category =             "component-check"
+      subcheck-description = "Check capacitor component has the correct operating-point property",
+      pass-message =         "Capacitor %_ has the correct property for operating-point" % [ref(c)],
+      fail-message =         "Capacitor %_ does not have the correct property for the operating-point" % [ref(c)],
+      locators =             [c]
+    )
+    val [vpk temp] = [[min-value(peak-voltage(property(c.operating-point))) max-value(peak-voltage(property(c.operating-point)))] OPERATING-TEMPERATURE[1]]
+    val max-temp = max-value(operating-temperature(property(c.rated-temperature)))
+    switch(property(c.type)) :
+      "ceramic" :
+        val vpk-derate-wc = PWL(DERATE-CAPACITOR-MLCC-VPK-WC)[temp]
         #CHECK(
-          condition =            vpk[1]   <= (DERATE-CAPACITOR-ETANTPOLY-VPK * property(c.rated-voltage)),
+          condition =            vpk[0] <= (vpk-derate-wc * property(c.rated-voltage)),
           name =                 "Capacitor checks"
           description =          "Check capacitor component properties"
           category =             "component-check"
-          subcheck-description = "Check polymer tantalum capacitor voltage derating matches the operating-point voltage",
-          pass-message =         "Capacitor %_ voltage operating point %_V is compatible with the constraint %_V" % [ref(c),vpk[1],(DERATE-CAPACITOR-ETANTPOLY-VPK * property(c.rated-voltage))],
-          fail-message =         "Capacitor %_ voltage operating point %_V is not compatible with the constraint %_V" % [ref(c),vpk[1],(DERATE-CAPACITOR-ETANTPOLY-VPK * property(c.rated-voltage))],
+          subcheck-description = "Check ceramic capacitor voltage derating matches the operating-point voltage",
+          pass-message =         "Capacitor %_ voltage derating %_V is compatible with the wc design constraint %_V" % [ref(c),vpk[0],(vpk-derate-wc * property(c.rated-voltage))],
+          fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the wc design constraint %_V" % [ref(c),vpk[0],(vpk-derate-wc * property(c.rated-voltage))],
           locators =             [c]
         )
 
         #CHECK(
-          condition =            temp  <= min-value(DERATE-CAPACITOR-ETANTPOLY-TEMP, max-temp),
+          condition =            vpk[1] <= (vpk-derate-wc * property(c.rated-voltage)),
           name =                 "Capacitor checks"
           description =          "Check capacitor component properties"
           category =             "component-check"
-          subcheck-description = "Check capacitor de-rated temperature operating point versus design constraints",
-          pass-message =         "Capacitor %_ operating temp %_C satisfies the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTPOLY-TEMP, max-temp)],
-          fail-message =         "Capacitor %_ operating temp %_C does not satisfy the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTPOLY-TEMP, max-temp)],
+          subcheck-description = "Check ceramic capacitor voltage derating matches the operating-point voltage",
+          pass-message =         "Capacitor %_ voltage derating %_V is compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
+          fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
+          locators =             [c]
+        )
+
+        val vpk-derate-nom = PWL(DERATE-CAPACITOR-MLCC-VPK-NOM)[temp]
+        #CHECK(
+          condition =            vpk[0] <= (vpk-derate-nom * property(c.rated-voltage)),
+          name =                 "Capacitor checks"
+          description =          "Check capacitor component properties"
+          category =             "component-check"
+          subcheck-description = "Check ceramic capacitor voltage derating matches the operating-point voltage",
+          pass-message =         "Capacitor %_ voltage derating %_V is compatible with the nominal design constraint %_V" % [ref(c),vpk[0],(vpk-derate-nom * property(c.rated-voltage))],
+          fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the nominal design constraint %_V" % [ref(c),vpk[0],(vpk-derate-nom * property(c.rated-voltage))],
           locators =             [c]
         )
 
         #CHECK(
-          condition =            i-pk  <= property(c.rated-current-pk),
+          condition =            vpk[1] <= (vpk-derate-nom * property(c.rated-voltage)),
           name =                 "Capacitor checks"
           description =          "Check capacitor component properties"
           category =             "component-check"
-          subcheck-description = "Check capacitor peak current matches the rated peak current",
-          pass-message =         "Capacitor %_ peak current %_A is compatible with the rated peak current %_A" % [ref(c),i-pk,property(c.rated-current-pk)],
-          fail-message =         "Capacitor %_ peak current %_A is not compatible with the rated peak current %_A" % [ref(c),i-pk,property(c.rated-current-pk)],
+          subcheck-description = "Check ceramic capacitor voltage derating matches the operating-point voltage",
+          pass-message =         "Capacitor %_ voltage derating %_V is compatible with the nominal design constraint %_V" % [ref(c),vpk[1],(vpk-derate-nom * property(c.rated-voltage))],
+          fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the nominal design constraint %_V" % [ref(c),vpk[1],(vpk-derate-nom * property(c.rated-voltage))],
           locators =             [c]
         )
 
         #CHECK(
-          condition =            i-rms <= PWL(property(c.rated-current-rms))[temp],
+          condition =            temp <= min-value(DERATE-CAPACITOR-MLCC-TEMP, max-temp),
           name =                 "Capacitor checks"
           description =          "Check capacitor component properties"
           category =             "component-check"
-          subcheck-description = "Check capacitor rms current matches the rated rms current",
-          pass-message =         "Capacitor %_ rms current %_A is compatible with the rated rms current %_A" % [ref(c),i-rms,PWL(property(c.rated-current-rms))[temp]],
-          fail-message =         "Capacitor %_ rms current %_A is not compatible with the rated rms current %_A" % [ref(c),i-rms,PWL(property(c.rated-current-rms))[temp]],
+          subcheck-description = "Check ceramic capacitor de-rated temperature operating point versus design constraints",
+          pass-message =         "Capacitor %_ operating temp %_C satisfies the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-MLCC-TEMP, max-temp)],
+          fail-message =         "Capacitor %_ operating temp %_C does not satisfy the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-MLCC-TEMP, max-temp)],
+          locators =             [c]
+        )
+
+      "electrolytic" :
+        #CHECK(
+          condition =            has-property?(c.anode),
+          name =                 "Capacitor checks"
+          description =          "Check capacitor component properties"
+          category =             "component-check"
+          subcheck-description = "Check electrolytic capacitor component has the anode property",
+          pass-message =         "Electrolytic capacitor %_ has the correct anode property" % [ref(c)],
+          fail-message =         "Electrolytic capacitor %_ does not have the correct anode property" % [ref(c)],
           locators =             [c]
         )
 
         #CHECK(
-          condition =            vpk[0]  >= 0.0,
+          condition =            has-property?(c.electrolyte),
           name =                 "Capacitor checks"
           description =          "Check capacitor component properties"
           category =             "component-check"
-          subcheck-description = "Check capacitor has min peak voltage greater than 0V",
-          pass-message =         "Capacitor %_ min peak voltage %_V is greater than or equal to 0V" % [ref(c),vpk[0]],
-          fail-message =         "Capacitor %_ min peak voltage %_V is less than 0V" % [ref(c),vpk[0]],
+          subcheck-description = "Check electrolytic capacitor component has the electrolyte property",
+          pass-message =         "Electrolytic capacitor %_ has the correct electrolyte property" % [ref(c)],
+          fail-message =         "Electrolytic capacitor %_ does not have the correct electrolyte property" % [ref(c)],
           locators =             [c]
         )
 
-      else if (property(c.anode) == "tantalum" and property(c.electrolyte) == "manganese-dioxide") :
-        #CHECK(
-          condition =            i-pk <= property(c.rated-current-pk),
-          name =                 "Capacitor checks"
-          description =          "Check capacitor component properties"
-          category =             "component-check"
-          subcheck-description = "Check manganese-dioxide tantalum capacitor peak current matches the rated peak current",
-          pass-message =         "Capacitor %_ peak current %_A is compatible with the rated peak current %_A" % [ref(c),i-pk,property(c.rated-current-pk)],
-          fail-message =         "Capacitor %_ peak current %_A is not compatible with the rated peak current %_A" % [ref(c),i-pk,property(c.rated-current-pk)],
-          locators =             [c]
-        )
+        val [i-pk, i-rms] = [lookup(property(c.operating-point), `current-pk),
+                            lookup(property(c.operating-point), `current-rms)]
 
-        #CHECK(
-          condition =            i-rms <= PWL(property(c.rated-current-rms))[temp],
-          name =                 "Capacitor checks"
-          description =          "Check capacitor component properties"
-          category =             "component-check"
-          subcheck-description = "Check manganese-dioxide tantalum capacitor rms current matches the rated rms current",
-          pass-message =         "Capacitor %_ rms current %_A is compatible with the rated rms current %_A" % [ref(c),i-rms,PWL(property(c.rated-current-rms))[temp]],
-          fail-message =         "Capacitor %_ rms current %_A is not compatible with the rated rms current %_A" % [ref(c),i-rms,PWL(property(c.rated-current-rms))[temp]],
-          locators =             [c]
-        )
-
-        #CHECK(
-          condition =            vpk[0]  >= 0.0,
-          name =                 "Capacitor checks"
-          description =          "Check capacitor component properties"
-          category =             "component-check"
-          subcheck-description = "Check manganese-dioxide tantalum capacitor has min peak voltage greater than 0V",
-          pass-message =         "Capacitor %_ min peak voltage %_V is greater than or equal to 0V" % [ref(c),vpk[0]],
-          fail-message =         "Capacitor %_ min peak voltage %_V is less than 0V" % [ref(c),vpk[0]],
-          locators =             [c]
-        )
-
-        val vpk-derate-wc = PWL(DERATE-CAPACITOR-ETANTMNO2-VPK-WC)[temp]
-        val vpk-derate-nom = PWL(DERATE-CAPACITOR-ETANTMNO2-VPK-NOM)[temp]
-        if i-pk <= 2.0 :
+        if (property(c.anode) == "tantalum" and property(c.electrolyte) == "polymer") :
           #CHECK(
-            condition =            vpk[1]  <= (vpk-derate-wc * property(c.rated-voltage)),
+            condition =            vpk[1]   <= (DERATE-CAPACITOR-ETANTPOLY-VPK * property(c.rated-voltage)),
             name =                 "Capacitor checks"
             description =          "Check capacitor component properties"
             category =             "component-check"
-            subcheck-description = "Check capacitor voltage derating matches the wc operating-point voltage",
-            pass-message =         "Capacitor %_ voltage derating %_V is compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
-            fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
+            subcheck-description = "Check polymer tantalum capacitor voltage derating matches the operating-point voltage",
+            pass-message =         "Capacitor %_ voltage operating point %_V is compatible with the constraint %_V" % [ref(c),vpk[1],(DERATE-CAPACITOR-ETANTPOLY-VPK * property(c.rated-voltage))],
+            fail-message =         "Capacitor %_ voltage operating point %_V is not compatible with the constraint %_V" % [ref(c),vpk[1],(DERATE-CAPACITOR-ETANTPOLY-VPK * property(c.rated-voltage))],
             locators =             [c]
           )
 
           #CHECK(
-            condition =            vpk[1]  <= (vpk-derate-nom * property(c.rated-voltage)),
+            condition =            temp  <= min-value(DERATE-CAPACITOR-ETANTPOLY-TEMP, max-temp),
             name =                 "Capacitor checks"
             description =          "Check capacitor component properties"
             category =             "component-check"
-            subcheck-description = "Check capacitor voltage derating matches the operating-point voltage",
-            pass-message =         "Capacitor %_ voltage derating %_V is compatible with the nominal design constraint %_V" % [ref(c),vpk[1],(vpk-derate-nom * property(c.rated-voltage))],
-            fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the nominal design constraint %_V" % [ref(c),vpk[1],(vpk-derate-nom * property(c.rated-voltage))],
+            subcheck-description = "Check capacitor de-rated temperature operating point versus design constraints",
+            pass-message =         "Capacitor %_ operating temp %_C satisfies the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTPOLY-TEMP, max-temp)],
+            fail-message =         "Capacitor %_ operating temp %_C does not satisfy the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTPOLY-TEMP, max-temp)],
             locators =             [c]
           )
 
           #CHECK(
-            condition =            temp <= min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp),
+            condition =            i-pk  <= property(c.rated-current-pk),
             name =                 "Capacitor checks"
             description =          "Check capacitor component properties"
             category =             "component-check"
-            subcheck-description = "Check capacitor de-rated nominal temperature operating point versus design constraints",
-            pass-message =         "Capacitor %_ operating temp %_C satisfies the nominal temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp)],
-            fail-message =         "Capacitor %_ operating temp %_C does not satisfy the nominal temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp)],
+            subcheck-description = "Check capacitor peak current matches the rated peak current",
+            pass-message =         "Capacitor %_ peak current %_A is compatible with the rated peak current %_A" % [ref(c),i-pk,property(c.rated-current-pk)],
+            fail-message =         "Capacitor %_ peak current %_A is not compatible with the rated peak current %_A" % [ref(c),i-pk,property(c.rated-current-pk)],
             locators =             [c]
           )
 
           #CHECK(
-            condition =            temp <= min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-WC, max-temp),
+            condition =            i-rms <= PWL(property(c.rated-current-rms))[temp],
             name =                 "Capacitor checks"
             description =          "Check capacitor component properties"
             category =             "component-check"
-            subcheck-description = "Check capacitor de-rated wc temperature operating point versus design constraints",
-            pass-message =         "Capacitor %_ operating temp %_C satisfies the wc temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-WC, max-temp)],
-            fail-message =         "Capacitor %_ operating temp %_C does not satisfy the wc temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-WC, max-temp)],
+            subcheck-description = "Check capacitor rms current matches the rated rms current",
+            pass-message =         "Capacitor %_ rms current %_A is compatible with the rated rms current %_A" % [ref(c),i-rms,PWL(property(c.rated-current-rms))[temp]],
+            fail-message =         "Capacitor %_ rms current %_A is not compatible with the rated rms current %_A" % [ref(c),i-rms,PWL(property(c.rated-current-rms))[temp]],
             locators =             [c]
           )
-
-        else if i-pk > 2.0 :
-          #CHECK(
-            condition =            vpk[1]  <= (DERATE-CAPACITOR-ETANTMNO2-VPK * property(c.rated-voltage)),
-            name =                 "Capacitor checks"
-            description =          "Check capacitor component properties"
-            category =             "component-check"
-            subcheck-description = "Check capacitor voltage derating matches the wc operating-point voltage",
-            pass-message =         "Capacitor %_ voltage derating %_V is compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
-            fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
-            locators =             [c]
-          )
-
 
           #CHECK(
-            condition =            temp <= min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp),
+            condition =            vpk[0]  >= 0.0,
             name =                 "Capacitor checks"
             description =          "Check capacitor component properties"
             category =             "component-check"
-            subcheck-description = "Check capacitor de-rated nominal temperature operating point versus design constraints",
-            pass-message =         "Capacitor %_ operating temp %_C satisfies the nominal temperature derating spec of %_C" % [ref(c),temp,min(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp)],
-            fail-message =         "Capacitor %_ operating temp %_C does not satisfy the nominal temperature derating spec of %_C" % [ref(c),temp,min(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp)],
+            subcheck-description = "Check capacitor has min peak voltage greater than 0V",
+            pass-message =         "Capacitor %_ min peak voltage %_V is greater than or equal to 0V" % [ref(c),vpk[0]],
+            fail-message =         "Capacitor %_ min peak voltage %_V is less than 0V" % [ref(c),vpk[0]],
             locators =             [c]
           )
 
-      else :
-        println("Unhandled electrolytic type for capacitor check on %_" % [c])
+        else if (property(c.anode) == "tantalum" and property(c.electrolyte) == "manganese-dioxide") :
+          #CHECK(
+            condition =            i-pk <= property(c.rated-current-pk),
+            name =                 "Capacitor checks"
+            description =          "Check capacitor component properties"
+            category =             "component-check"
+            subcheck-description = "Check manganese-dioxide tantalum capacitor peak current matches the rated peak current",
+            pass-message =         "Capacitor %_ peak current %_A is compatible with the rated peak current %_A" % [ref(c),i-pk,property(c.rated-current-pk)],
+            fail-message =         "Capacitor %_ peak current %_A is not compatible with the rated peak current %_A" % [ref(c),i-pk,property(c.rated-current-pk)],
+            locators =             [c]
+          )
 
-    "mica" :
-      #CHECK(
-        condition =            vpk[0] <= (DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage)),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check mica capacitor voltage derating matches the operating-point voltage",
-        pass-message =         "Capacitor %_ voltage operating point %_V is compatible with the constraint %_V" % [ref(c),vpk[0],(DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage))],
-        fail-message =         "Capacitor %_ voltage operating point %_V is not compatible with the constraint %_V" % [ref(c),vpk[0],(DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage))],
-        locators =             [c]
-      )
+          #CHECK(
+            condition =            i-rms <= PWL(property(c.rated-current-rms))[temp],
+            name =                 "Capacitor checks"
+            description =          "Check capacitor component properties"
+            category =             "component-check"
+            subcheck-description = "Check manganese-dioxide tantalum capacitor rms current matches the rated rms current",
+            pass-message =         "Capacitor %_ rms current %_A is compatible with the rated rms current %_A" % [ref(c),i-rms,PWL(property(c.rated-current-rms))[temp]],
+            fail-message =         "Capacitor %_ rms current %_A is not compatible with the rated rms current %_A" % [ref(c),i-rms,PWL(property(c.rated-current-rms))[temp]],
+            locators =             [c]
+          )
 
-      #CHECK(
-        condition =            vpk[1] <= (DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage)),
-        name =                 "Capacitor checks"
-        description =          "Check capacitor component properties"
-        category =             "component-check"
-        subcheck-description = "Check mica capacitor voltage derating matches the operating-point voltage",
-        pass-message =         "Capacitor %_ voltage operating point %_V is compatible with the constraint %_V" % [ref(c),vpk[1],(DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage))],
-        fail-message =         "Capacitor %_ voltage operating point %_V is not compatible with the constraint %_V" % [ref(c),vpk[1],(DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage))],
-        locators =             [c]
-      )
+          #CHECK(
+            condition =            vpk[0]  >= 0.0,
+            name =                 "Capacitor checks"
+            description =          "Check capacitor component properties"
+            category =             "component-check"
+            subcheck-description = "Check manganese-dioxide tantalum capacitor has min peak voltage greater than 0V",
+            pass-message =         "Capacitor %_ min peak voltage %_V is greater than or equal to 0V" % [ref(c),vpk[0]],
+            fail-message =         "Capacitor %_ min peak voltage %_V is less than 0V" % [ref(c),vpk[0]],
+            locators =             [c]
+          )
 
-      #CHECK(
-          condition =            temp <= min-value(DERATE-CAPACITOR-MICA-TEMP, max-temp),
+          val vpk-derate-wc = PWL(DERATE-CAPACITOR-ETANTMNO2-VPK-WC)[temp]
+          val vpk-derate-nom = PWL(DERATE-CAPACITOR-ETANTMNO2-VPK-NOM)[temp]
+          if i-pk <= 2.0 :
+            #CHECK(
+              condition =            vpk[1]  <= (vpk-derate-wc * property(c.rated-voltage)),
+              name =                 "Capacitor checks"
+              description =          "Check capacitor component properties"
+              category =             "component-check"
+              subcheck-description = "Check capacitor voltage derating matches the wc operating-point voltage",
+              pass-message =         "Capacitor %_ voltage derating %_V is compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
+              fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
+              locators =             [c]
+            )
+
+            #CHECK(
+              condition =            vpk[1]  <= (vpk-derate-nom * property(c.rated-voltage)),
+              name =                 "Capacitor checks"
+              description =          "Check capacitor component properties"
+              category =             "component-check"
+              subcheck-description = "Check capacitor voltage derating matches the operating-point voltage",
+              pass-message =         "Capacitor %_ voltage derating %_V is compatible with the nominal design constraint %_V" % [ref(c),vpk[1],(vpk-derate-nom * property(c.rated-voltage))],
+              fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the nominal design constraint %_V" % [ref(c),vpk[1],(vpk-derate-nom * property(c.rated-voltage))],
+              locators =             [c]
+            )
+
+            #CHECK(
+              condition =            temp <= min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp),
+              name =                 "Capacitor checks"
+              description =          "Check capacitor component properties"
+              category =             "component-check"
+              subcheck-description = "Check capacitor de-rated nominal temperature operating point versus design constraints",
+              pass-message =         "Capacitor %_ operating temp %_C satisfies the nominal temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp)],
+              fail-message =         "Capacitor %_ operating temp %_C does not satisfy the nominal temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp)],
+              locators =             [c]
+            )
+
+            #CHECK(
+              condition =            temp <= min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-WC, max-temp),
+              name =                 "Capacitor checks"
+              description =          "Check capacitor component properties"
+              category =             "component-check"
+              subcheck-description = "Check capacitor de-rated wc temperature operating point versus design constraints",
+              pass-message =         "Capacitor %_ operating temp %_C satisfies the wc temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-WC, max-temp)],
+              fail-message =         "Capacitor %_ operating temp %_C does not satisfy the wc temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-WC, max-temp)],
+              locators =             [c]
+            )
+
+          else if i-pk > 2.0 :
+            #CHECK(
+              condition =            vpk[1]  <= (DERATE-CAPACITOR-ETANTMNO2-VPK * property(c.rated-voltage)),
+              name =                 "Capacitor checks"
+              description =          "Check capacitor component properties"
+              category =             "component-check"
+              subcheck-description = "Check capacitor voltage derating matches the wc operating-point voltage",
+              pass-message =         "Capacitor %_ voltage derating %_V is compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
+              fail-message =         "Capacitor %_ voltage derating %_V is not compatible with the wc design constraint %_V" % [ref(c),vpk[1],(vpk-derate-wc * property(c.rated-voltage))],
+              locators =             [c]
+            )
+
+
+            #CHECK(
+              condition =            temp <= min-value(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp),
+              name =                 "Capacitor checks"
+              description =          "Check capacitor component properties"
+              category =             "component-check"
+              subcheck-description = "Check capacitor de-rated nominal temperature operating point versus design constraints",
+              pass-message =         "Capacitor %_ operating temp %_C satisfies the nominal temperature derating spec of %_C" % [ref(c),temp,min(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp)],
+              fail-message =         "Capacitor %_ operating temp %_C does not satisfy the nominal temperature derating spec of %_C" % [ref(c),temp,min(DERATE-CAPACITOR-ETANTMNO2-TEMP-NOM, max-temp)],
+              locators =             [c]
+            )
+
+        else :
+          println("Unhandled electrolytic type for capacitor check on %_" % [c])
+
+      "mica" :
+        #CHECK(
+          condition =            vpk[0] <= (DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage)),
           name =                 "Capacitor checks"
           description =          "Check capacitor component properties"
           category =             "component-check"
-          subcheck-description = "Check capacitor de-rated temperature operating point versus design constraints",
-          pass-message =         "Capacitor %_ operating temp %_C satisfies the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-MICA-TEMP, max-temp)],
-          fail-message =         "Capacitor %_ operating temp %_C does not satisfy the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-MICA-TEMP, max-temp)],
+          subcheck-description = "Check mica capacitor voltage derating matches the operating-point voltage",
+          pass-message =         "Capacitor %_ voltage operating point %_V is compatible with the constraint %_V" % [ref(c),vpk[0],(DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage))],
+          fail-message =         "Capacitor %_ voltage operating point %_V is not compatible with the constraint %_V" % [ref(c),vpk[0],(DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage))],
           locators =             [c]
         )
 
-    else : println("Unhandled type for capacitor check on %_" % [c])
+        #CHECK(
+          condition =            vpk[1] <= (DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage)),
+          name =                 "Capacitor checks"
+          description =          "Check capacitor component properties"
+          category =             "component-check"
+          subcheck-description = "Check mica capacitor voltage derating matches the operating-point voltage",
+          pass-message =         "Capacitor %_ voltage operating point %_V is compatible with the constraint %_V" % [ref(c),vpk[1],(DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage))],
+          fail-message =         "Capacitor %_ voltage operating point %_V is not compatible with the constraint %_V" % [ref(c),vpk[1],(DERATE-CAPACITOR-MICA-VPK * property(c.rated-voltage))],
+          locators =             [c]
+        )
+
+        #CHECK(
+            condition =            temp <= min-value(DERATE-CAPACITOR-MICA-TEMP, max-temp),
+            name =                 "Capacitor checks"
+            description =          "Check capacitor component properties"
+            category =             "component-check"
+            subcheck-description = "Check capacitor de-rated temperature operating point versus design constraints",
+            pass-message =         "Capacitor %_ operating temp %_C satisfies the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-MICA-TEMP, max-temp)],
+            fail-message =         "Capacitor %_ operating temp %_C does not satisfy the temperature derating spec of %_C" % [ref(c),temp,min-value(DERATE-CAPACITOR-MICA-TEMP, max-temp)],
+            locators =             [c]
+          )
+
+      else : println("Unhandled type for capacitor check on %_" % [c])
 
   #CHECK(
     condition =            OPERATING-TEMPERATURE[0] >= min-value(operating-temperature(property(c.rated-temperature))),

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -296,8 +296,6 @@ public pcb-component gen-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg-name
   property(self.tolerance) = tol
   property(self.rated-voltage) = max-v
   property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
-  check connected(p[1])
-  check connected(p[2])
 
 public defn gen-cap-cmp (cap:Double, tol:Double, max-v:Double) :
   gen-cap-cmp(cap, tol, max-v, "0402")
@@ -341,8 +339,6 @@ public pcb-component gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg
   property(self.rated-current-pk) = 3.7
   property(self.rated-current-rms) = [[25.0 0.298] [85.0 0.268] [125.0 0.119]]
   property(self.rated-temperature) = RatedTemperature(min-max(-55.0 125.0))
-  check connected(a)
-  check connected(c)
 
 public defn gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double) :
   gen-tant-cap-cmp(cap, tol, max-v, "0402")
@@ -381,8 +377,6 @@ public pcb-component gen-res-cmp (r-type:ResistorSymbolType, res:Double, tol:Dou
   property(self.resistance) = res
   spice :
     "[R] {p[1]} {p[2]} {res}"
-  check connected(p[1])
-  check connected(p[2])
 
 public defn gen-res-cmp (res:Double, tol:Double, pkg:String) :
   gen-res-cmp(ResistorStd, res, tol, 0.0625, pkg)
@@ -414,8 +408,6 @@ public pcb-component gen-ind-cmp (l-type:InductorSymbolType, ind:Double, tol:Dou
   property(self.inductance) = ind
   property(self.tolerance) = (tol * 0.01)
   property(self.max-current) = max-i
-  check connected(p[1])
-  check connected(p[2])
 
 public defn gen-ind-cmp (ind:Double, tol:Double) :
   gen-ind-cmp(InductorStd, ind, tol, 0.1) ; 100mA default
@@ -442,8 +434,6 @@ public pcb-component gen-led-cmp (vf:Toleranced, itest:Double, color:String, pkg
   property(self.forward-voltage) = vf-center ; Vf
   property(self.test-current) = itest ; If or Itest
   property(self.NamedColor) = color
-  check connected(a)
-  check connected(c)
 
 public defn gen-led-cmp (vf:Toleranced, itest:Double, color:String, pkg-name:String) :
   gen-led-cmp(vf, itest, color, pkg-name, DENSITY-LEVEL)


### PR DESCRIPTION
@m-hilgendorf So the power states code almost works. The code that actually does the final equality check does not seem to be working:
```
public pcb-check power-states (module:JITXObject) :

  for connected-group in populated-connected-groups(module) do :
    val pin-categories = categorize-digital-pins(connected-group)
    val digital-pins = to-tuple $ cat-all([inputs(pin-categories),
                                           outputs(pin-categories),
                                           ios(pin-categories)])

    for digital-pin in digital-pins do :
      check-has-power-states $ pin(digital-pin)

    val condition? = all-equal? $
      for digital-pin in digital-pins seq :
        property(pin(digital-pin).power-states)

    #CHECK(condition    = condition?
            name        = "Power States"
            description = "Checks that all components have matching power states."
            category    = "power-states"
            subcheck-description = "Checking power states match on connected pins"
            pass-message = "Connected pins %, have matching power states" % [pin-refs(digital-pins)]
            fail-message = "Connected pins %_ and %_ do not have matching power states"  % [pin-refs(digital-pins)]
            locators = to-jitx-pins(digital-pins))
```
The all-equal condition is always true it appears even when the power-states are verifiably different.