### PR TITLE
fix run-final-passes

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.14.0-dev.1
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.14.0-rc.13
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -54,6 +54,7 @@ pcb-module sensor-mote :
 
   ; Define ground net and assign symbol
   public net gnd (usb.usb-2.vbus.gnd)
+  property(self.gnd) = gnd
   symbol(gnd) = ocdb/symbols/ground-sym
 
   ; Create a protected power and data interface for USB-2
@@ -186,4 +187,3 @@ view-schematic()
 
 ; Solve and export Bill of Materials
 ; export-bom()
-

--- a/utils/defaults.stanza
+++ b/utils/defaults.stanza
@@ -78,7 +78,7 @@ public pcb-board default-board (stack:Stackup, outline:Shape) :
   signal-boundary = outline
 
 ; Creates a design using the default board. 
-public defn make-default-board (module:Instantiable, num-layers:Int, outline:Shape) :  
+public defn make-default-board (module:Instantiable, num-layers:Int, outline:Shape) :
   set-main-module(module)
   set-board(default-board(num-layers, outline))
   set-rules(default-rules)

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -126,16 +126,17 @@ public defn propagate-rail-voltage ():
           property(pin.rail-voltage) = max-v
 
 public defn calculate-operating-points ():
+  ; FIXME!: This function is highly suspicious / unoptimal, what do we actually want to do ?
   defn get-other-pin (comp:JITXObject,  p:JITXObject) :
     for ps in pins(comp) find! :
       ps != p
 
   inside pcb-module :
-    for i in component-instances(self) do :
-      if has-property?(i.resistance) or has-property?(i.capacitance) :
-        for p in pins(i) do :
-          if has-property?(p.rail-voltage) : ;and connected?([get-other-pin(i,p), property(self.gnd)])
-            if has-property?(self.gnd) :
+    if has-property?(self.gnd) :
+      for i in component-instances(self) do :
+        if has-property?(i.resistance) or has-property?(i.capacitance) :
+          for p in pins(i) do :
+            if has-property?(p.rail-voltage) and connected?([get-other-pin(i,p), property(self.gnd)])
               if connected?([get-other-pin(i,p), property(self.gnd)]):
                 val voltage = property(p.rail-voltage)
                 if has-property?(i.resistance) :
@@ -184,15 +185,18 @@ public defn set-power-source (pos:JITXObject, neg:JITXObject, v-in:Double):
 ; =======================================
 ; Run transformations to propagate voltages from sources, and run delayed evaluations
 ; =======================================
-public defn run-final-passes (module:Instantiable) :
-  var intermediate-design = transform-module(propagate-rail-voltage, module)
-  set-main-module(intermediate-design)
-  intermediate-design = run-evals(intermediate-design)
-  intermediate-design = transform-module(propagate-rail-voltage, intermediate-design)
-  intermediate-design = run-evals(intermediate-design)
-  intermediate-design = transform-module(propagate-rail-voltage, intermediate-design)
-  intermediate-design = run-evals(intermediate-design)
-  val assigned-pins = assign-pins()
-  var final = run-evals(assigned-pins)
-  final = transform-module(calculate-operating-points, final)
-  final
+public defn run-final-passes (module:Instantiable) -> Instantiable :
+  transform-module{calculate-operating-points, _} $
+    let loop (design: Instantiable = module, i: Int = 0) :
+      if i == 5 :
+        throw(Exception("A loop executing eval-whens and propagating rail voltages has been encountered: 5 iterations \
+                         reached. Check that no eval-when generate other eval-whens in an infinite loop, or that there \
+                         is no infinite loop of 2nd order between eval-when execution and rail voltage propagation.")
+      val propagated-design = transform-module(propagate-rail-voltage, design)
+      set-main-module(propagated-design)
+      val assigned-design = assign-pins()
+      val evaluated-design = run-evals?(assigned-design)
+      match(evaluated-design: DefID) :
+        loop(evaluated-design, i + 1)
+      else :
+        assigned-design

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -225,7 +225,7 @@ public defn set-power-source (pos:JITXObject, neg:JITXObject, v-in:Double):
 ; Run transformations to propagate voltages from sources, and run delayed evaluations
 ; =======================================
 public defn run-final-passes (module:Instantiable) -> Instantiable :
-  val module = transform-module{calculate-operating-points, _} $
+  val result-module = transform-module{calculate-operating-points, _} $
     let loop (design: Instantiable = module, i: Int = 0) :
       defn run-eval-loop (design: Instantiable) :
         val design* = run-evals?(design)
@@ -246,8 +246,8 @@ public defn run-final-passes (module:Instantiable) -> Instantiable :
   ; If we did not set the main module, a user forgetting to set it himself on the new module would be exporting
   ; the module before adding operating points (the main module is set in the loop to be able to assign pins).
   ; Such bug would be invisible.
-  set-main-module(module)
-  module
+  set-main-module(result-module)
+  result-module
 
 ; FIXME: assign-pins was obviously not meant to be used like this, it depends on the flattening
 ; Is run-evals? actually accessing the information resulting from the pin assignment?

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -225,7 +225,7 @@ public defn set-power-source (pos:JITXObject, neg:JITXObject, v-in:Double):
 ; Run transformations to propagate voltages from sources, and run delayed evaluations
 ; =======================================
 public defn run-final-passes (module:Instantiable) -> Instantiable :
-  transform-module{calculate-operating-points, _} $
+  val module = transform-module{calculate-operating-points, _} $
     let loop (design: Instantiable = module, i: Int = 0) :
       defn run-eval-loop (design: Instantiable) :
         val design* = run-evals?(design)
@@ -242,6 +242,12 @@ public defn run-final-passes (module:Instantiable) -> Instantiable :
       design $> transform-module{propagate-rail-voltage, _}
              $> assign-pins
              $> run-eval-loop
+
+  ; If we did not set the main module, a user forgetting to set it himself on the new module would be exporting
+  ; the module before adding operating points (the main module is set in the loop to be able to assign pins).
+  ; Such bug would be invisible.
+  set-main-module(module)
+  module
 
 ; FIXME: assign-pins was obviously not meant to be used like this, it depends on the flattening
 ; Is run-evals? actually accessing the information resulting from the pin assignment?

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -136,13 +136,12 @@ public defn calculate-operating-points ():
       for i in component-instances(self) do :
         if has-property?(i.resistance) or has-property?(i.capacitance) :
           for p in pins(i) do :
-            if has-property?(p.rail-voltage) and connected?([get-other-pin(i,p), property(self.gnd)])
-              if connected?([get-other-pin(i,p), property(self.gnd)]):
-                val voltage = property(p.rail-voltage)
-                if has-property?(i.resistance) :
-                  property(i.operating-point) = OperatingPoint(min-max(0.0, voltage), min-max(0.0, voltage / property(i.resistance)))
-                else if has-property?(i.capacitance) :
-                  property(i.operating-point) = OperatingPoint(min-max(0.0, voltage), min-max(0.0, 0.0))
+            if has-property?(p.rail-voltage) and connected?([get-other-pin(i,p), property(self.gnd)]) :
+              val voltage = property(p.rail-voltage)
+              if has-property?(i.resistance) :
+                property(i.operating-point) = OperatingPoint(min-max(0.0, voltage), min-max(0.0, voltage / property(i.resistance)))
+              else if has-property?(i.capacitance) :
+                property(i.operating-point) = OperatingPoint(min-max(0.0, voltage), min-max(0.0, 0.0))
 
 
 ; =======================================
@@ -189,14 +188,14 @@ public defn run-final-passes (module:Instantiable) -> Instantiable :
   transform-module{calculate-operating-points, _} $
     let loop (design: Instantiable = module, i: Int = 0) :
       if i == 5 :
-        throw(Exception("A loop executing eval-whens and propagating rail voltages has been encountered: 5 iterations \
-                         reached. Check that no eval-when generate other eval-whens in an infinite loop, or that there \
-                         is no infinite loop of 2nd order between eval-when execution and rail voltage propagation.")
+        throw $ Exception("A loop executing eval-whens and propagating rail voltages has been encountered: 5 iterations \
+                           reached. Check that no eval-when generate other eval-whens in an infinite loop, or that there \
+                           is no infinite loop of 2nd order between eval-when execution and rail voltage propagation.")
       val propagated-design = transform-module(propagate-rail-voltage, design)
       set-main-module(propagated-design)
       val assigned-design = assign-pins()
       val evaluated-design = run-evals?(assigned-design)
-      match(evaluated-design: DefID) :
+      match(evaluated-design: Instantiable) :
         loop(evaluated-design, i + 1)
       else :
         assigned-design

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -111,7 +111,8 @@ public defn connect-gnd-pins ():
 
 
 ; Replace this once nets introspection is back
-public defn propagate-rail-voltage ():
+public defn propagate-rail-voltage () :
+  ; println("Propagating rail voltages...")
   inside pcb-module :
     for connected-group in populated-connected-groups(self) do :
       val power-supply-voltages = to-tuple $
@@ -125,23 +126,62 @@ public defn propagate-rail-voltage ():
         for pin in connected-group do:
           property(pin.rail-voltage) = max-v
 
-public defn calculate-operating-points ():
-  ; FIXME!: This function is highly suspicious / unoptimal, what do we actually want to do ?
+public defn calculate-operating-points ()  :
   defn get-other-pin (comp:JITXObject,  p:JITXObject) :
+    ; Used on 2-pin components to get the single other pin
     for ps in pins(comp) find! :
       ps != p
 
+  defn gnd-type-error! (inst, gnd) :
+    throw $ Exception("The gnd property of module %_ must be of type Pin or Net, got: '%_'." % [ref(inst), gnd])
+
+  defn resistor-operating-point (v: Double, r: Double) :
+    OperatingPoint(min-max(0.0, v), min-max(0.0, v / r))
+
+  defn capacitor-operating-point (v: Double) :
+    OperatingPoint(min-max(0.0, v), min-max(0.0, 0.0))
+
+  defn is-resistor? (i: Instance) :
+    has-property?(i.resistance)
+
+  defn is-capacitor? (i: Instance) :
+    has-property?(i.capacitance)
+
+  defn resistance! (i: Instance) :
+    property(i.resistance)
+
   inside pcb-module :
-    if has-property?(self.gnd) :
-      for i in component-instances(self) do :
-        if has-property?(i.resistance) or has-property?(i.capacitance) :
-          for p in pins(i) do :
-            if has-property?(p.rail-voltage) and connected?([get-other-pin(i,p), property(self.gnd)]) :
-              val voltage = property(p.rail-voltage)
-              if has-property?(i.resistance) :
-                property(i.operating-point) = OperatingPoint(min-max(0.0, voltage), min-max(0.0, voltage / property(i.resistance)))
-              else if has-property?(i.capacitance) :
-                property(i.operating-point) = OperatingPoint(min-max(0.0, voltage), min-max(0.0, 0.0))
+    val gnd = value? $ property?(self.gnd)
+
+    match(gnd: Pin|Net) :
+      ; println("Calculating operating points...")
+      val gnd-pins = connected-group(gnd)
+      for gnd-pin in gnd-pins do :
+        val inst = containing-instance!(gnd-pin)
+        if is-resistor?(inst) or is-capacitor?(inst) :
+          val other-pin = get-other-pin(inst, gnd-pin)
+          val voltage = value? $ property?(other-pin.rail-voltage)
+          match(voltage: Double) :
+            if is-resistor?(inst) :
+              property(inst.operating-point) = resistor-operating-point(voltage, resistance!(inst))
+            if is-capacitor?(inst) :
+              property(inst.operating-point) = capacitor-operating-point(voltage)
+    else :
+      gnd-type-error!(self, gnd) when gnd is-not False
+
+
+; - jitx/commands/connected-pins(p) result does not contain p.
+; - connected-group(p) contains p if it is a component pin (not net or module pin)
+defn connected-group (obj: Pin|Net) :
+  defn is-component-pin? (pin: Pin) :
+    containing-instance(pin) is Instance
+
+  val extra-pins =
+    match(obj) :
+      (pin: Pin) : [pin] when is-component-pin?(pin) else []
+      (net: Net) : []
+
+  to-tuple $ cat(extra-pins, connected-pins(obj))
 
 
 ; =======================================
@@ -187,15 +227,24 @@ public defn set-power-source (pos:JITXObject, neg:JITXObject, v-in:Double):
 public defn run-final-passes (module:Instantiable) -> Instantiable :
   transform-module{calculate-operating-points, _} $
     let loop (design: Instantiable = module, i: Int = 0) :
+      defn run-eval-loop (design: Instantiable) :
+        val design* = run-evals?(design)
+        match(design*: Instantiable) : loop(design*, i + 1)
+        else : design
+
       if i == 5 :
-        throw $ Exception("A loop executing eval-whens and propagating rail voltages has been encountered: 5 iterations \
-                           reached. Check that no eval-when generate other eval-whens in an infinite loop, or that there \
-                           is no infinite loop of 2nd order between eval-when execution and rail voltage propagation.")
-      val propagated-design = transform-module(propagate-rail-voltage, design)
-      set-main-module(propagated-design)
-      val assigned-design = assign-pins()
-      val evaluated-design = run-evals?(assigned-design)
-      match(evaluated-design: Instantiable) :
-        loop(evaluated-design, i + 1)
-      else :
-        assigned-design
+        throw $ Exception("A loop executing eval-whens, propagating rail voltages and assigning pins has been \
+                           encountered: 5 iterations reached. Check that no eval-when generate other eval-whens in an \
+                           infinite loop, or that there is no infinite loop of 2nd order between eval-when execution \
+                           and rail voltage propagation or pin assignment.")
+
+      ;TODO: Review the order and necessity of those algos
+      design $> transform-module{propagate-rail-voltage, _}
+             $> assign-pins
+             $> run-eval-loop
+
+; FIXME: assign-pins was obviously not meant to be used like this, it depends on the flattening
+; Is run-evals? actually accessing the information resulting from the pin assignment?
+defn assign-pins (design: Instantiable) -> Instantiable :
+  set-main-module(design)
+  assign-pins()


### PR DESCRIPTION
- `run-final-passes` was incorrect, `assign-pins()` was reusing the `intermediate-design` from the start instead of the result of the 3 iteration of `propagate-rail-voltage` and `run-evals`
- `calculate-operating-point` was suboptimal
- add gnd prop to ble-mote to run the logic in CI

Goes with https://github.com/JITx-Inc/jitx-client/pull/1180

Tested with prints:
![Screenshot from 2022-07-01 13-11-39](https://user-images.githubusercontent.com/17492851/176968912-38407db0-599c-4b93-a074-af5ec4414e10.png)

Using a net as gnd property:
![Screenshot from 2022-07-01 14-18-56](https://user-images.githubusercontent.com/17492851/176969149-efad5ed1-aa87-4ceb-a185-9a57d12aed38.png)

![Screenshot from 2022-07-01 13-10-22](https://user-images.githubusercontent.com/17492851/176969062-e710fcf4-fad3-4e8a-9504-f32446e44be2.png)

With component pin:
![Screenshot from 2022-07-01 13-12-51](https://user-images.githubusercontent.com/17492851/176969207-86f69852-12e8-45c5-9f18-91341c6e78e6.png)
![Screenshot from 2022-07-01 13-15-53](https://user-images.githubusercontent.com/17492851/176968960-31bb0ec4-bdb3-4108-a9d7-454468f56de5.png)

With module pin:
![Screenshot from 2022-07-01 13-16-43](https://user-images.githubusercontent.com/17492851/176968981-1c73d957-a131-4f01-8ec4-df2fdf942048.png)
![Screenshot from 2022-07-01 13-17-43](https://user-images.githubusercontent.com/17492851/176968993-6ff253f4-7469-416f-b178-1c1ad8de67f3.png)


