### PR TITLE
Add REF and VALUE to spst

### DIFF
--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -814,6 +814,9 @@ public pcb-symbol spst (n-pside:Int, n-tside:Int) :
       name-size = 0.762
   unit-line([[( - xpoff), (- 1.0)], [xpoff, (- 1.0)]])
 
+  unit-ref([1.0, 2.0])
+  unit-val([1.0, 1.0])
+
 ; TODO: Relay symbol parametric in connections
 
 ; ====== RF ====================================================================


### PR DESCRIPTION
This PR adds a REF text and VALUE text to `pcb-symbol spst` in `utils/symbols.stanza`.

I'd like to learn more about the situational usage of such text, so I have some questions for reviewers:
- `altium-gost-gnd-...` earth and power symbols have neither REF nor VALUE. I see other Altium net symbols have a VALUE -- should a VALUE be added to these two symbols?
- The testpoint and hole symbols do not have VALUEs. That makes because of how generic those concepts are.
- And lastly, should `spst` have a REF and VALUE? I'm effectively asking if this PR should go through, and if the symbol was designed to intentionally not have the texts.