### PR TITLE
Speed up DRC landpattern checks

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.14.0-rc.14
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.14.2-dev.1
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -1734,16 +1734,17 @@ public pcb-check check-min-solder-mask-sliver (lp:LandPattern, shapes:Seqable<Sh
       locators =             [lp]
     )
 
-; Runs all the land pattern checks on either an instance or definition. 
-public defn check-landpattern (component:JITXObject|JITXDef) :
+; Runs all the land pattern checks on either an instance or definition.
+; Not currently used in the design checks
+public defn check-landpattern (obj:JITXObject|JITXDef) :
   ; extract the land pattern
-  val lp = 
-    match(component) :
+  val lp =
+    match(obj) :
       (landpattern:LandPattern) :
         landpattern
       (d:JITXDef) :
         landpattern(d)
-      (i:JITXObject) : 
+      (i:JITXObject) :
         landpattern(instance-definition(i))
 
   ; perform the checks
@@ -1753,16 +1754,47 @@ public defn check-landpattern (component:JITXObject|JITXDef) :
       check check-min-copper-width(lp, side)
       check check-min-solder-mask-sliver(lp, layer(lp, SolderMask(side)))
 
-    if has-property?(component.bga) and property(component.bga):
+    if property?(obj.bga, false):
       check check-bga-pitch(lp)
 
-    if has-property?(component.leaded) and property(component.leaded):
+    if property?(obj.leaded, false):
+      check check-leaded-pitch(lp)
+
+defstruct LandpatternCheckInfo <: Equalable&Hashable :
+  landpattern: LandPattern
+  bga: True|False
+  leaded: True|False
+with :
+  equalable => true
+  hashable => true
+
+defn check-landpattern (info:LandpatternCheckInfo) :
+  val lp = landpattern(info)
+
+  ; perform the checks
+  inside pcb-module :
+    for side in [Top, Bottom] do :
+      check check-min-copper-copper-space(lp, side)
+      check check-min-copper-width(lp, side)
+      check check-min-solder-mask-sliver(lp, layer(lp, SolderMask(side)))
+
+    if bga(info) :
+      check check-bga-pitch(lp)
+
+    if leaded(info) :
       check check-leaded-pitch(lp)
 
 ; Runs landpattern checks recursively on all the lands in a module
-public defn check-all-landpatterns (module:JITXObject) : 
+public defn check-all-landpatterns (module:JITXObject) :
+  defn info (inst: JITXObject) :
+    LandpatternCheckInfo(landpattern $ instance-definition(inst),
+                         property?(inst.bga, false),
+                         property?(inst.leaded, false))
+
   inside pcb-module :
-    do(check-landpattern, component-instances(module))
+    val instance-infos = unique $ seq(info, component-instances(module))
+
+    do(check-landpattern, instance-infos)
     
 ; Runs landpattern checks recursively starting from self.
 public defn check-all-landpatterns () : 

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -1734,6 +1734,14 @@ public pcb-check check-min-solder-mask-sliver (lp:LandPattern, shapes:Seqable<Sh
       locators =             [lp]
     )
 
+defstruct LandpatternCheckInfo <: Equalable&Hashable :
+  landpattern: LandPattern
+  bga: True|False
+  leaded: True|False
+with :
+  equalable => true
+  hashable => true
+
 ; Runs all the land pattern checks on either an instance or definition.
 ; Not currently used in the design checks
 public defn check-landpattern (obj:JITXObject|JITXDef) :
@@ -1747,26 +1755,7 @@ public defn check-landpattern (obj:JITXObject|JITXDef) :
       (i:JITXObject) :
         landpattern(instance-definition(i))
 
-  ; perform the checks
-  inside pcb-module :
-    for side in [Top, Bottom] do :
-      check check-min-copper-copper-space(lp, side)
-      check check-min-copper-width(lp, side)
-      check check-min-solder-mask-sliver(lp, layer(lp, SolderMask(side)))
-
-    if property?(obj.bga, false):
-      check check-bga-pitch(lp)
-
-    if property?(obj.leaded, false):
-      check check-leaded-pitch(lp)
-
-defstruct LandpatternCheckInfo <: Equalable&Hashable :
-  landpattern: LandPattern
-  bga: True|False
-  leaded: True|False
-with :
-  equalable => true
-  hashable => true
+  check-landpattern $ LandpatternCheckInfo(lp, property?(lp.bga, false), property?(lp.leaded, false))
 
 defn check-landpattern (info:LandpatternCheckInfo) :
   val lp = landpattern(info)

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -48,9 +48,7 @@ Set of standard checks to run on a top-level-module.
 
 public defn check-design (module:JITXObject):
   erc-check-design(module)
-  ; commenting out the land pattern checks from the default check run
-  ; can be added back when they are optimized
-  ; drc-check-design(module)
+  drc-check-design(module)
 
 public defn erc-check-design (module:JITXObject):
   inside pcb-module:
@@ -1764,18 +1762,12 @@ public defn check-landpattern (component:JITXObject|JITXDef) :
 ; Runs landpattern checks recursively on all the lands in a module
 public defn check-all-landpatterns (module:JITXObject) : 
   inside pcb-module :
-    val components = to-tuple(component-instances(module))
-    val modules    = filter({not contains?(components, _)}, instances(module))
-    for component in components do :
-      check-landpattern(component)
-    for module in modules do :
-      check-all-landpatterns(module)
+    do(check-landpattern, component-instances(module))
     
 ; Runs landpattern checks recursively starting from self.
 public defn check-all-landpatterns () : 
   inside pcb-module: 
     check-all-landpatterns(self)
-
 
 
 doc: "Helper to force power-states property to propagate through \

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -1755,7 +1755,7 @@ public defn check-landpattern (obj:JITXObject|JITXDef) :
       (i:JITXObject) :
         landpattern(instance-definition(i))
 
-  check-landpattern $ LandpatternCheckInfo(lp, property?(lp.bga, false), property?(lp.leaded, false))
+  check-landpattern $ LandpatternCheckInfo(lp, property?(obj.bga, false), property?(obj.leaded, false))
 
 defn check-landpattern (info:LandpatternCheckInfo) :
   val lp = landpattern(info)


### PR DESCRIPTION
`component-instances(module)` is already a recursive function that returns all components under module, whether direct or indirect children.

PR goes with https://github.com/JITx-Inc/jitx-client/pull/1293.

I need to benchmark the speed up tomorrow to confirm uncommenting the check is acceptable.