### PR TITLE
Use no-connect? introspection

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.14.2-dev.1
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.16.0-rc.2
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/designs/test-component-checks.stanza
+++ b/designs/test-component-checks.stanza
@@ -158,8 +158,8 @@ pcb-module checks :
   property(fmc.v3p3.supply-pin) = true
   property(fmc.v3p3.voltage) = [3.0 3.3 6.0]
 
-  property(r5.p[1].no-connect) = true
-  property(r5.p[2].no-connect) = true
+  no-connect(r5.p[1])
+  no-connect(r5.p[2])
   property(r6.DNP) = true
 
   require out:gpio[10] from fmc

--- a/designs/test-component-checks.stanza
+++ b/designs/test-component-checks.stanza
@@ -150,7 +150,6 @@ pcb-module checks :
 
   net (fmc.v3p3 ldo.in ldo.en)
   net (r4.p[1] ldo.out)
-  net (r5.p[2] gnd)
 
   net (r6.p[1] ldo.in)
   net (r6.p[2] ldo.out)

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -220,12 +220,6 @@ pcb-check rated-temperature (component:JITXObject):
       fail-message =         "%_ does not have an acceptable higher operating temperature versus design target (%_C < %_C)" % [ref(component), temp, OPERATING-TEMPERATURE[1]],
       locators =             [component]  
     )
-  
-; Checks if a pin is marked "no-connect"
-defn no-connect? (p:JITXObject) -> True|False : 
-  has-property?(p.no-connect) or
-  has-property?(p.nc) or 
-  has-property?(p.NC)
 
 ; Returns if a pin is a digital-output pin or capable of being one
 defn is-digital-output? (p:JITXObject) -> True|False : 


### PR DESCRIPTION
This PR unifies `no-connect` properties under the `no-connect` statement.
Two changes:
- Checks uses `no-connect?` introspection instead of a utility that checks properties
- Designs that had `no-connect` properties now use the `no-connect` statement.