### PR TITLE
Update package for JITXValue

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.1-rc.1
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.1-rc.5
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.1-rc.5
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.1-rc.7
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/utils/property-structs.stanza
+++ b/utils/property-structs.stanza
@@ -67,7 +67,7 @@ public pcb-struct ocdb/utils/property-structs/ResetPin :
 
 ; === Logic Property Structs ===
 ; ==============================
-deftype LogicFamily <: jitx/client/JITXValue&Equalable&Hashable
+deftype LogicFamily <: jitx/jitx-value/JITXValue&Equalable&Hashable
 public pcb-struct ocdb/utils/property-structs/CMOSOutput <: LogicFamily :
   vol:Toleranced
   voh:Toleranced

--- a/utils/property-structs.stanza
+++ b/utils/property-structs.stanza
@@ -67,7 +67,7 @@ public pcb-struct ocdb/utils/property-structs/ResetPin :
 
 ; === Logic Property Structs ===
 ; ==============================
-deftype LogicFamily <: jitx/jitx-value/JITXValue&Equalable&Hashable
+deftype LogicFamily <: jitx/value/JITXValue&Equalable&Hashable
 public pcb-struct ocdb/utils/property-structs/CMOSOutput <: LogicFamily :
   vol:Toleranced
   voh:Toleranced


### PR DESCRIPTION
Depends on [#1506](https://github.com/JITx-Inc/jitx-client/pull/1506) in jitx-client.
JITXValue moved from `jitx/client` to `jitx/value`.