### PR TITLE
Updates to fix checks

### DIFF
--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -17,6 +17,8 @@ defpackage ocdb/utils/checks :
   import ocdb/utils/pin-checks/all
   import ocdb/utils/netlist-checks/all
   import ocdb/utils/netlist-checks/utils
+  import ocdb/utils/propagation
+
 ;<>
 #CHECK(
   condition = p-props is GenericPin,                    ; A boolean check                     (True|False)
@@ -49,6 +51,7 @@ Set of standard checks to run on a top-level-module.
  - Digital I/O pin checks are run, see check-io
 <S>
 
+
 public defn check-design (module:JITXObject):
   erc-check-design(module)
   drc-check-design(module)
@@ -63,7 +66,8 @@ public defn erc-check-design (module:JITXObject):
       check-inductor(i)  when has-property?(i.inductor)    
       check-pins(i)
 
-    check-netlist(module)
+    eval-when PROPAGATION-FINISHED :
+      check-netlist(module)
 
 public defn drc-check-design (module:JITXObject):
   inside pcb-module:

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -15,6 +15,7 @@ defpackage ocdb/utils/generator-utils:
   import ocdb/utils/property-structs
   import ocdb/modules/power-regulators
   import ocdb/utils/bundles
+  import ocdb/utils/propagation
 
 ; =======================================
 ; Ciruit convenience functions
@@ -278,17 +279,21 @@ public defn run-final-passes (module:Instantiable) -> Instantiable :
                            encountered: 5 iterations reached. Check that no eval-when generate other eval-whens in an \
                            infinite loop, or that there is no infinite loop of 2nd order between eval-when execution \
                            and net voltage propagation or pin assignment.")
-
+      
+      
       ;TODO: Review the order and necessity of those algos
       design $> transform-module{propagate-net-voltages, _}
              $> assign-pins
              $> run-eval-loop
-
+  
+  PROPAGATION-FINISHED = true
+  val final-module = run-evals(result-module)
+  
   ; If we did not set the main module, a user forgetting to set it himself on the new module would be exporting
   ; the module before adding operating points (the main module is set in the loop to be able to assign pins).
   ; Such bug would be invisible.
-  set-main-module(result-module)
-  result-module
+  set-main-module(final-module)
+  final-module
 
 ; FIXME: assign-pins was obviously not meant to be used like this, it depends on the flattening
 ; Is run-evals? actually accessing the information resulting from the pin assignment?

--- a/utils/netlist-checks/all.stanza
+++ b/utils/netlist-checks/all.stanza
@@ -5,10 +5,30 @@ defpackage ocdb/utils/netlist-checks/all :
   import ocdb/utils/netlist-checks/utils
   import ocdb/utils/netlist-checks/io-checks
   import ocdb/utils/netlist-checks/power-states
+  import ocdb/utils/netlist-checks/single-pin-nets
 
 public defn check-netlist (root-module:JITXObject) :
   val connections = connections(root-module)
   check-io(root-module, connections)
+  check-single-pin-nets(root-module, connections)
 
   ; Todo: re-add once supported
   ; check-power-states(root-module, connections)
+
+; defn check-no-connects (root-module:JITXObject) :
+;   val all-connected-items = all-connected-items(root-module)
+;   for instance in component-instances(root-module) do :
+;     check-no-connects(instance, all-connected-items)        
+
+; defn check-no-connects (instance:JITXObject, connected-items:ConnectedItems) :
+;   val pins* =
+;     for pin in pins(instance) filter :
+;       needs-connection?(pin)
+;   inside pcb-module :
+;     check no-connects(instance, connected-items, pins*)
+;   do(check-no-connections{instance, connected-items, _}, pins*)
+
+; defn should-be-connected () :
+
+
+; pcb-check no-connects :

--- a/utils/netlist-checks/io-checks.stanza
+++ b/utils/netlist-checks/io-checks.stanza
@@ -13,7 +13,12 @@ defpackage ocdb/utils/netlist-checks/io-checks :
 ;============================ Driver ==========================================
 ;==============================================================================
 val NAME = "IO Checks"
-val DESCRIPTION = "Check Digital I/O Properties"
+
+defn description (p:JITXObject) :
+  "%_ digital I/O Properties"
+
+defn description (p:Seqable<JITXObject>) :
+  "%, digital I/O Properties"
 
 doc: "Check the i/o pin nets."
 public defn check-io (module:JITXObject, connections:Connections) :
@@ -58,17 +63,16 @@ defn cmos-ttl-outputs (pin-categories:DigitalPinCategories) :
 ;==============================================================================
 pcb-check digital-output (output-pins: Tuple<DigitalPin>) :
   val non-tristateable-output-pins = to-tuple $ filter({not tristateable(prop(_))}, output-pins)
-  #CHECK(condition = length(non-tristateable-output-pins) >= 1
+  #CHECK( condition = length(non-tristateable-output-pins) >= 1
           name = NAME
-          description = DESCRIPTION
+          description = description(map(pin, output-pins))
           category = CATEGORY
           subcheck-description = "Check there is at least one non-tristateable output pin",
           pass-message = "Output pins %, are connected together and at most 1 of them is non-tristateable" 
             % [seq(ref{pin(_)}, output-pins)],
           fail-message = "The following non-tristateable output pins are connected together: %," 
             % [seq(ref{pin(_)}, non-tristateable-output-pins)],
-          locators = map(pin, output-pins)
-          )
+          locators = map(pin, output-pins) )
 
 ;==============================================================================
 ;=============================== Open Collector ===============================
@@ -102,12 +106,11 @@ defn open-collector-fail-message (open-collectors:Tuple<DigitalPin>, action:?) :
 ; - check that generic pin/io-pin ratings agree
 defn check-open-collectors (open-collectors:Tuple<DigitalPin>,
                             pin-categories:DigitalPinCategories) :
+  println("Running open collector checks")
   inside pcb-module :
     val [pullup-resistors, net-voltages] = 
       pullup-resistors(open-collectors, pin-categories)
     
-    println("Pullups: %_" % [pullup-resistors])
-
     for p in open-collectors do :
       check no-net-voltage(pin(p))
     
@@ -123,10 +126,11 @@ defn check-open-collectors (open-collectors:Tuple<DigitalPin>,
         check input-and-generic-pin-max-voltage-rating(net-voltage?, pin-categories)
 
 pcb-check net-voltages-equal (ps:Tuple<DigitalPin>, nvs:Tuple<Toleranced>, rs:Tuple<JITXObject>) :
+  val locators = to-tuple(cat(seq(pin, ps), rs))
   #CHECK(
     condition = all-equal?(nvs),
     name = NAME
-    description = DESCRIPTION
+    description = description(locators)
     category = CATEGORY
     subcheck-description = 
       "Check that io pins have pullup resistors connected to the same net voltage",
@@ -136,7 +140,7 @@ pcb-check net-voltages-equal (ps:Tuple<DigitalPin>, nvs:Tuple<Toleranced>, rs:Tu
       open-collector-fail-message(ps, 
         "all pull-up resistors %, with the same net voltage" 
           % [seq(ref, rs)]),
-    locators = to-tuple(cat(seq(pin, ps), rs))
+    locators = locators
   )
 
 ; Check that a pin does not have a net voltage
@@ -144,7 +148,7 @@ pcb-check no-net-voltage (p:Pin) :
   #CHECK(
     condition = not has-property?(p.net-voltage),
     name = NAME
-    description = DESCRIPTION
+    description = description(p)
     category = CATEGORY
     subcheck-description = 
       "Check that open-collector i/o pins are not connected to a net with a `net-voltage` property.",
@@ -161,7 +165,7 @@ pcb-check pullup-resistor-exists (open-collectors:Tuple<DigitalPin>, resistors:T
   #CHECK(
     condition = not empty?(resistors),
     name = NAME
-    description = DESCRIPTION
+    description = description(map(pin, open-collectors))
     category = CATEGORY
     subcheck-description = "Check that open collector pins have at least one pullup resistor",
     pass-message = open-collector-pass-message(open-collectors, "at least one pullup resistor"),
@@ -171,7 +175,7 @@ pcb-check pullup-resistor-exists (open-collectors:Tuple<DigitalPin>, resistors:T
 pcb-check sink-current (open-collector:DigitalPin, net-voltage:Toleranced, resistance?:False|Double) :
   #CHECK(condition = resistance? is Double,
          name = NAME,
-         description = DESCRIPTION,
+         description = description(pin(open-collector)),
          category = CATEGORY, 
          subcheck-description  = "Check that open collector pins have a finite pullup resistance.",
          fail-message = "%_ has an infinite pullup resistance" %
@@ -187,7 +191,7 @@ pcb-check sink-current (open-collector:DigitalPin, net-voltage:Toleranced, resis
   #CHECK(condition =           ipk < iol(driver),
         name =                 NAME
         description =          CATEGORY
-        category =             DESCRIPTION
+        category =             description(pin(open-collector))
         subcheck-description = "Check an open collector pin's peak sink current is in spec",
         pass-message = "%_ current sink specification %_A satisfies the design requirement %_A" 
           % [context(pin(open-collector)), iol(driver), ipk],
@@ -207,7 +211,7 @@ pcb-check input-and-generic-pin-max-voltage-rating (net-voltage:Toleranced, pin-
       val vih-v = vih(input-prop)
       #CHECK(condition = min-value(net-voltage) > min-value(vih-v)
              name = NAME
-             description = DESCRIPTION
+             description = description(pin)
              category = CATEGORY
              subcheck-description = "Check the net with a net-voltage property is higher than the vih pin specification",
              pass-message = "%_'s vih specification (%_V) is lower than the net voltage (%_V)"    
@@ -223,11 +227,7 @@ defn pullup-resistors (open-collectors:Tuple<DigitalPin>,
   val collected-net-voltages = Vector<Toleranced>()
 
   defn is-resistor? (r) :
-    if index-of-chars(to-string(ref(r)), "pullup") is Int :
-      println("Checking if %_ is a resistor" % [ref(r)])
-      println("resistor:%_" % [property?(r.resistor)])
-      println("resistance:%_" % [property?(r.resistance)])
-    has-property?(r.resistor) and
+    has-property?(r.resistor)   and
     has-property?(r.resistance)
 
   defn collect-net-voltages-and-returns-if-any? (instance:Instance) -> True|False :
@@ -295,7 +295,7 @@ defn vhi-vlo (i:Pin, o:Pin, vih:Toleranced, voh:Toleranced, vil:Toleranced, vol:
   #CHECK(condition = min-value(voh) >= max-value(vih)
          name = NAME
          category = CATEGORY
-         description = DESCRIPTION
+         description = description([i, o])
          subcheck-description = "Check that the min voh is greater than max vih"
          pass-message = "%_'s max voh (%_) greater than %_'s min vih (%_)" % [
             context(i), vih
@@ -310,7 +310,7 @@ defn vhi-vlo (i:Pin, o:Pin, vih:Toleranced, voh:Toleranced, vil:Toleranced, vol:
   #CHECK(condition = max-value(vol) <= min-value(vil)
          name = NAME
          category = CATEGORY
-         description = DESCRIPTION
+         description = description([i, o])
          subcheck-description = "Check that the max vol is less than min vil"
          pass-message = "%_'s max vol (%_) is less than %_'s min vil (%_)" % [
             context(o), voh
@@ -327,7 +327,7 @@ defn gnd-pins (i:Pin, o:Pin, ip:DigitalInput|DigitalIO, op:DigitalOutput|Digital
   #CHECK(condition = connected?([gnd-pin(ip), gnd-pin(op)])
          name = NAME
          category = CATEGORY
-         description = DESCRIPTION
+         description = description([i, o])
          locators = locators
          subcheck-description = "Check that digital i/o pins share a ground net"
          pass-message = "%_ and %_ grounds are connected together"
@@ -354,7 +354,7 @@ pcb-check input-push-pull-levels (input:DigitalPin, output:DigitalPin) :
     #CHECK(condition = in-range?(vin-max, voh)
            name = NAME
            category = CATEGORY
-           description = DESCRIPTION
+           description = description([inpt-pin, outp-pin])
            locators = [inpt-pin, outp-pin]
            pass-message = "%_'s voh (%_) is in range of %_'s max input voltage (%_)" % [
              context(outp-pin), voh
@@ -375,7 +375,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
   #CHECK(
     condition = driver? is CMOSOutput|TTLOutput
     name = NAME
-    description = DESCRIPTION
+    description = description(locators)
     category = CATEGORY
     locators = locators    
     subcheck-description = "Check digital output's driver pin is CMOSOutput|TTLOutput"
@@ -385,7 +385,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
   #CHECK(
     condition = driver? is CMOSOutput|TTLOutput
     name = NAME
-    description = DESCRIPTION
+    description = description(outp-pin)
     category = CATEGORY
     locators = [outp-pin]
     subcheck-description = "Check digital output's driver pin is CMOSOutput|TTLOutput"
@@ -395,7 +395,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
   #CHECK(
     condition = io-driver? is CMOSOutput|TTLOutput
     name = NAME
-    description = DESCRIPTION
+    description = description(io-pin)
     category = CATEGORY
     locators = [io-pin]
     subcheck-description = "Check digital i/o's driver pin is CMOSOutput|TTLOutput"
@@ -413,7 +413,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
     #CHECK(
       condition = min-value(voh(io-driver)) >= min-value(vih(outp-prop)),
       name = NAME
-      description = DESCRIPTION
+      description = description(locators)
       category = CATEGORY
       locators = locators
       subcheck-description = "Check min voh of io driver is greater than the vih of the io pin",
@@ -429,7 +429,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
     #CHECK(
       condition = max-value(vol(io-driver)) <= min-value(vil(outp-prop)),
       name = NAME
-      description = DESCRIPTION
+      description = description(locators)
       category = CATEGORY
       locators = locators
       subcheck-description = "Check max vol of io driver is lower than the vil of the io pin",
@@ -448,7 +448,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
     #CHECK(
       condition = in-range?(max-input-voltage, voh(driver)),
       name = NAME
-      description = DESCRIPTION
+      description = description(locators)
       category = CATEGORY
       locators = locators
       subcheck-description = "Check voh of output driver is within its voltage range",
@@ -467,7 +467,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
     #CHECK(
       condition = in-range?(max-input-voltage, voh(io-driver)),
       name = NAME
-      description = DESCRIPTION
+      description = description(locators)
       category = CATEGORY
       locators = locators
       subcheck-description = "Check voh of output driver is within its voltage range",

--- a/utils/netlist-checks/single-pin-nets.stanza
+++ b/utils/netlist-checks/single-pin-nets.stanza
@@ -1,0 +1,23 @@
+defpackage ocdb/utils/netlist-checks/single-pin-nets :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/utils/netlist-checks/utils
+
+val name = "Single Pin Net Checks"
+
+public defn check-single-pin-nets (module:JITXObject, connections:Connections) :
+  inside pcb-module :
+    for group in connected-groups(connections) do :
+      check single-pin-net(group)
+  
+pcb-check single-pin-net (group:Tuple<Pin>) :
+  #CHECK( condition    = length(group) == 1
+          name         = NAME
+          category     = CATEGORY
+          description  = DESCRIPTION
+          subcheck-description = "The net containing %, has more than one pin" % [map(context, group)]
+          fail-message = "%_ is the only pin on a net." % [context(group[0])]
+          pass-message = "%, are on the same net." % [map(context, group)]
+          locators     = group )

--- a/utils/passive-checks/capacitor-checks.stanza
+++ b/utils/passive-checks/capacitor-checks.stanza
@@ -15,7 +15,9 @@ defpackage ocdb/utils/passive-checks/capacitor-checks :
 ;==============================================================================
 ; Some common values re-used in this package
 val NAME        = "Capacitor Checks"
-val DESCRIPTION = "Check capacitor component properties"
+
+defn description (r:JITXObject) :
+  "%_ capacitor properties" % [context(r)]
 
 doc: \<s> 
   Assigns checks to a single capacitor component.
@@ -27,57 +29,20 @@ doc: \<s>
 <s>
 public defn check-capacitor (c:JITXObject) : 
   inside pcb-module :
-    ; First we check if the capacitor has the required
-    ; properties to do any checks.
-    check-capacitor-preconditions(c)
-    ; If this succeeds, we can perform the required checking.
-    if can-run-capacitor-checks?(c) :
-      val type = property(c.type)
-      ; If the cap has a known type, we perform our analysis with
-      ; the known deratings.
-      switch(type) :
-        "ceramic"      : check-ceramic-capacitor(c)
-        "electrolytic" : check-electrolytic-capacitor(c)
-        "mica"         : check-mica-film-capacitor(c)
-        else           : check-unknown-capacitor(c)
+    val type = property(c.type)
+    ; If the cap has a known type, we perform our analysis with
+    ; the known deratings.
+    switch(type) :
+      "ceramic"      : check-ceramic-capacitor(c)
+      "electrolytic" : check-electrolytic-capacitor(c)
+      "mica"         : check-mica-film-capacitor(c)
+      else           : check-unknown-capacitor(c)
 
 ; The basic capacitor check
 defn check-unknown-capacitor (c:JITXObject) :
   inside pcb-module :
     check capacitor-temp(c, false, false)
     check capacitor-voltage(c, false, false)
-
-; TODO: once inside pcb-check lands, reuse logic.
-defn can-run-capacitor-checks? (c:JITXObject) -> True|False :
-  var acc : True|False = true
-  #for prop in [capacitance, operating-point, rated-voltage, rated-temperature, type] :
-    acc = acc and has-property?(c.prop)
-  acc
-
-; Checks a capacitor component to see if it has the approparite properties.
-defn check-capacitor-preconditions (c:JITXObject) :
-  #for prop in [capacitance, operating-point, rated-voltage, rated-temperature, type] :
-    pcb-check prop (c:JITXObject) :
-      val [pass?, sub-dsc, msg] = 
-        within has-prop-msg(c, `prop) :
-          One(has-property?(c.prop))
-      #CHECK(
-        condition = pass?
-        name = NAME
-        description = DESCRIPTION
-        category = CATEGORY
-        subcheck-description = sub-dsc
-        info-message = msg
-        pass-message = msg
-        locators = [c]
-      )
-  inside pcb-module :
-    check capacitance(c)
-    check operating-point(c)
-    check type(c)
-    check rated-temperature(c)
-    check rated-voltage(c)
-
 
 ; Shared check: given a capacitor, an optional case name, and optional
 ; temperature derating, check if OPERATING-TEMPERATURE is within the 
@@ -87,8 +52,11 @@ defn check-capacitor-preconditions (c:JITXObject) :
 ; - case?: an optional case name for the derating value
 ; - derating: an optional derating value. 
 pcb-check capacitor-temp (c:JITXObject, case?:False|String, derating:False|Double) :
+  check-has-properties(NAME, c, [`rated-temperature])
+
   val [min-temp, max-temp] = OPERATING-TEMPERATURE
   val rated-temp = property(c.rated-temperature)
+    $> operating-temperature
   
   val rated-temp* = 
     match(derating:Double) :
@@ -103,7 +71,7 @@ pcb-check capacitor-temp (c:JITXObject, case?:False|String, derating:False|Doubl
     condition = in-range?(rated-temp*, min-temp) and
                 in-range?(rated-temp*, max-temp)
     name = NAME
-    description = DESCRIPTION
+    description = description(c)
     category = CATEGORY
     subcheck-description = "Check rated temperature meets the design requirements."
     pass-message = "%_ rated-temperature %_ meets%_design requirements, min:%_C, max:%_C" 
@@ -121,6 +89,8 @@ pcb-check capacitor-temp (c:JITXObject, case?:False|String, derating:False|Doubl
 ; - derating: an optional double or table of doubles for derating the component
 ;
 pcb-check capacitor-voltage (c:JITXObject, case?:False|String, derating:False|Double|Tuple<[Double, Double]>) :
+  check-has-properties(NAME, c, [`rated-voltage, `operating-point])
+
   val peak-voltage = property(c.operating-point)
     $> peak-voltage
     $> max{ abs(min-value(_0)), abs(max-value(_0)) }
@@ -137,11 +107,11 @@ pcb-check capacitor-voltage (c:JITXObject, case?:False|String, derating:False|Do
     match(case?:String) : " %_ " % [case?]
     else : " "
   
-  val voltage = derating* * max-value(rated-voltage)
+  val voltage = derating* * rated-voltage
   #CHECK(
       condition = peak-voltage < voltage
       name = NAME
-      description = DESCRIPTION
+      description = description(c)
       category = CATEGORY
       subcheck-description = "Check the %_ capacitor voltage derating matches the operating-point voltage" 
         % [property(c.type)]
@@ -188,37 +158,12 @@ val ANODES = [
 ; Checks if the electrolytic capacitor materials
 ; are known to JITX.
 defn check-electrolytic-preconditions (c:JITXObject) :
-  #for prop in [anode, electrolyte] :
-    pcb-check prop (c:JITXObject, supported:Tuple<Equalable>) :
-      val [pass?, sub-dsc, msg] = 
-      within has-prop-msg(c, `prop) :
-        One(has-property?(c.prop))
-      #CHECK(
-        condition   = pass?
-        name        = NAME,
-        description = DESCRIPTION, 
-        category    = CATEGORY,
-        subcheck-description = sub-dsc
-        pass-message = msg,
-        info-message = msg
-      )
-      val value = property(c.prop) as Equalable
-      #CHECK(
-        condition = contains?(supported, value)
-        name        = NAME,
-        description = DESCRIPTION, 
-        category    = CATEGORY,
-        subcheck-description = "Check that the `%_` value is supported" 
-          % [`prop]
-        pass-message = "%_ is a supported value for the `%_` property." 
-          % [value, `prop]
-        fail-message = "%_ is not a supported value for the `%_` property. Derating analysis will not be performed." 
-          % [value, `prop]
-      )
+  pcb-check prop-check (c:JITXObject) :
+    check-has-properties(NAME, c, [`anode, `electrolyte])
+  
   inside pcb-module :
-    check anode(c, ANODES)
-    check electrolyte(c, ELECTROLYTES)
-
+    check prop-check(c)
+  
 defn known-electrolytic-materials? (c:JITXObject) -> True|False :
   has-property?(c.anode) and
   contains?(ANODES, property(c.anode) as Equalable) and
@@ -227,7 +172,7 @@ defn known-electrolytic-materials? (c:JITXObject) -> True|False :
 
 defn check-electrolytic-capacitor (c:JITXObject) :
   inside pcb-module :
-    check-electrolytic-preconditions(c)
+    ; check-electrolytic-preconditions(c)
     check electrolytic-cap-current(c)
     
     ; If we don't recognize the electrolytic cap materials, we 
@@ -239,6 +184,7 @@ defn check-electrolytic-capacitor (c:JITXObject) :
     else :
       val anode       = property(c.anode)
       val electrolyte = property(c.electrolyte)
+
       val [derate-vpk, derate-temp] =
         switch([anode, electrolyte]) :
           ["tantalum", "polymer"] :
@@ -276,15 +222,7 @@ defn check-electrolytic-capacitor (c:JITXObject) :
 ; Checks if the peak current through the cap is above the rated
 ; value.
 pcb-check electrolytic-cap-current (c:JITXObject) :
-  #CHECK(
-    condition = has-property?(c.rated-current-pk)
-    name = NAME
-    description = DESCRIPTION
-    category = CATEGORY
-    subcheck-description = "Check if the capacitor has a peak current rating."
-    info-message = "%_ is missing the `rated-current-pk` property"
-    pass-message = "%_ has the `rated-current-pkg` property"
-  )
+  check-has-properties(NAME, c, [`rated-current-pk, `operating-point])
 
   val rated-current-pk = property(c.rated-current-pk)
   val peak-current     = property(c.operating-point)
@@ -295,7 +233,7 @@ pcb-check electrolytic-cap-current (c:JITXObject) :
   #CHECK(
     condition =  ipk < rated-current-pk,
     name        = NAME
-    description = DESCRIPTION
+    description = description(c)
     category    = CATEGORY
     subcheck-description = "Check the capacitor peak current matches the rated peak current",
     pass-message = "%_ peak current %_A is compatible with the rated peak current %_A" 
@@ -310,5 +248,5 @@ pcb-check electrolytic-cap-current (c:JITXObject) :
 ;==============================================================================
 defn check-mica-film-capacitor (c:JITXObject) :
   inside pcb-module :
-    check capacitor-voltage(c, false, DERATE-CAPACITOR-MICA-VPK)  
     check capacitor-temp(c, false, DERATE-CAPACITOR-MICA-TEMP)
+    check capacitor-voltage(c, false, DERATE-CAPACITOR-MICA-VPK)  

--- a/utils/passive-checks/inductor-checks.stanza
+++ b/utils/passive-checks/inductor-checks.stanza
@@ -11,17 +11,16 @@ defpackage ocdb/utils/passive-checks/inductor-checks :
   import ocdb/utils/generator-utils
 
 val NAME        = "Inductor Checks"
-val DESCRIPTION = "Check inductor component properties"
+defn description (r:JITXObject) :
+  "%_ inductor properties" % [context(r)]
+
 
 doc: \<s> 
   Assigns checks to a single inductor component.
 <s>
 public defn check-inductor (l:JITXObject) :
-  check-inductor-preconditions(l)
-
-  if can-run-inductor-checks?(l) :
-    inside pcb-module :
-      check inductor-power(l)
+  inside pcb-module :
+    check inductor-power(l)
 
 ; TODO: once inside pcb-check lands, reuse/chain logic
 defn can-run-inductor-checks? (l:JITXObject) -> True|False :
@@ -30,33 +29,13 @@ defn can-run-inductor-checks? (l:JITXObject) -> True|False :
     acc = acc and has-property?(l.prop)
   acc
 
-; Checks an inductor component to see if it has the appropriate properties
-defn check-inductor-preconditions (l:JITXObject) :
-  #for prop in [operating-point, rated-power, inductance, dc-resistance] :
-    pcb-check prop (c:JITXObject) :
-      val [pass?, sub-dsc, msg] = 
-        within has-prop-msg(l, `prop) :
-          One(has-property?(l.prop))
-      #CHECK(
-        condition = pass?
-        name = NAME
-        description = DESCRIPTION
-        category = CATEGORY
-        subcheck-description = sub-dsc
-        info-message = msg
-        pass-message = msg
-        locators = [l]
-      )
-
-  inside pcb-module :
-    check operating-point(l)
-    check rated-power(l)
-    check inductance(l)
-    check dc-resistance(l)
-
 ; Check that the power consumed by an inductor is 
 ; below the derated maximum power.
 pcb-check inductor-power (l:JITXObject) :
+  check-has-properties(NAME, l, [`operating-point, 
+                                 `rated-power, 
+                                 `inductance, 
+                                 `dc-resistance])
   val operating-point = property(l.operating-point)
   val rated-power     = property(l.rated-power)
   val inductance      = property(l.inductance)
@@ -71,7 +50,7 @@ pcb-check inductor-power (l:JITXObject) :
   #CHECK(
     condition = power < rated-power*
     name = NAME
-    description = DESCRIPTION
+    description = description(l)
     category = CATEGORY
     subcheck-description = "Check that inductor power derating meets the design requirements"
     pass-message = "Derated power for %_ meets the design requirements: %_W < %_W"

--- a/utils/passive-checks/resistor-checks.stanza
+++ b/utils/passive-checks/resistor-checks.stanza
@@ -16,17 +16,16 @@ defpackage ocdb/utils/passive-checks/resistor-checks :
 ;==============================================================================
 ; Some common values re-used in this package
 val NAME        = "Resistor Checks"
-val DESCRIPTION = "Check resistor component properties"
 
+defn description (r:JITXObject) :
+  "%_ resistor properties" % [context(r)]
 
 doc: \<s> 
   Assigns checks to a single resistor component.
 <s>
 public defn check-resistor (r:JITXObject) :
-  check-resistor-preconditions(r)
-  if can-run-resistor-checks?(r) :
-    inside pcb-module :
-      check resistor-power(r)
+  inside pcb-module :
+    check resistor-power(r)
 
 ; TODO: once inside pcb-check lands, reuse/chain logic
 defn can-run-resistor-checks? (r:JITXObject) -> True|False :
@@ -35,32 +34,11 @@ defn can-run-resistor-checks? (r:JITXObject) -> True|False :
     acc = acc and has-property?(r.prop)
   acc
 
-; Checks a resistor component to see if it has the appropriate properties
-defn check-resistor-preconditions (r:JITXObject) :
-  #for prop in [resistance, operating-point, rated-power] :
-    pcb-check prop (r:JITXObject) :
-      val [pass?, sub-dsc, msg] = 
-        within has-prop-msg(r, `prop) :
-          One(has-property?(r.prop))
-      #CHECK(
-        condition = pass?
-        name = NAME
-        description = DESCRIPTION
-        category = CATEGORY
-        subcheck-description = sub-dsc
-        info-message = msg
-        pass-message = msg
-        locators = [r]
-      )
-    
-  inside pcb-module :
-    check resistance(r)
-    check operating-point(r)
-    check rated-power(r)
-
 ; Check that the power consumed by a resistor is 
 ; below the derated maximum power.
 pcb-check resistor-power (r:JITXObject) :
+  check-has-properties(NAME, r, [`operating-point, `resistance, `rated-power])
+
   val op-point    = property(r.operating-point)
   val resistance  = property(r.resistance)
   val rated-power = property(r.rated-power)
@@ -75,7 +53,7 @@ pcb-check resistor-power (r:JITXObject) :
   #CHECK(
     condition = power < rated-power*
     name = NAME
-    description = DESCRIPTION
+    description = description(r)
     category = CATEGORY
     subcheck-description = "Check that resistor power derating meets the design requirements"
     pass-message = "Derated power for %_  meets the design requirements: %_W < %_W"

--- a/utils/passive-checks/resonator-checks.stanza
+++ b/utils/passive-checks/resonator-checks.stanza
@@ -12,19 +12,19 @@ defpackage ocdb/utils/passive-checks/resonator-checks :
   import ocdb/utils/generator-utils
 
 val NAME        = "Crystal Resonator Checks"
-val DESCRIPTION = "Check crystal resonator component properties"
+
+defn description (r:JITXObject) :
+  "%_ crystal resonator properties" % [context(r)]
 
 doc: \<s> 
   Assigns checks to a single crystal oscillator component.
 <s>
 public defn check-resonator (x:JITXObject, intf:CrystalOscillator, load-cap:JITXObject) :
-  check-resonator-preconditions(x)
-  if can-run-resonator-checks?(x) :
-    inside pcb-module :
-      check resonator-frequency-check(x, intf)
-      check resonator-gain-check(x, intf, load-cap)
-      check resonator-drive-check(x, intf, load-cap)
-      check resonator-pullability-check(x, intf, load-cap)
+  inside pcb-module :
+    check resonator-frequency-check(x, intf)
+    check resonator-gain-check(x, intf, load-cap)
+    check resonator-drive-check(x, intf, load-cap)
+    check resonator-pullability-check(x, intf, load-cap)
 
 ; TODO: once inside pcb-check lands, reuse/chain logic
 defn can-run-resonator-checks? (x:JITXObject) -> True|False :
@@ -40,7 +40,7 @@ defn check-resonator-preconditions (x:JITXObject) :
       #CHECK(
         condition = pass?
         name = NAME
-        description = DESCRIPTION
+        description = description(x)
         category = CATEGORY
         subcheck-description = sub-dsc
         info-message = msg
@@ -53,11 +53,13 @@ defn check-resonator-preconditions (x:JITXObject) :
 
 ; Checks the frequency of an oscillator (o) against an interface on an IC (intf)
 public pcb-check resonator-frequency-check (o:JITXObject, intf:CrystalOscillator) :
+  check-has-properties(NAME, o, [`crystal-resonator])
+
   ; Check critical gain point to ensure oscillation
   #CHECK(
     condition = frequency(property(o.crystal-resonator)) == frequency(intf),
     name = NAME
-    description = DESCRIPTION
+    description = description(x)
     category = CATEGORY
     subcheck-description = "Check the crystal has the correct frequency which meets the design specs",
     pass-message = "Crystal %_ does have the correct frequency %_ to meet design specs %_" 
@@ -69,13 +71,15 @@ public pcb-check resonator-frequency-check (o:JITXObject, intf:CrystalOscillator
 
 ; Checks the critical gain of an oscillator (o) against an interface on an IC (intf)
 public pcb-check resonator-gain-check (o:JITXObject, intf:CrystalOscillator, load-cap:JITXObject) :
+  check-has-properties(NAME, o, [`crystal-resonator])
+
   ; Check critical gain point to ensure oscillation
   val op = property(o.crystal-resonator)
   val gain = 4.0 * ESR(op) * pow(2.0 * PI * frequency(op), 2.0) * pow(shunt-capacitance(op) + load-capacitance(op), 2.0)
   #CHECK(
     condition = gain < max-critical-gain(intf),
     name = NAME
-    description = DESCRIPTION
+    description = description(x)
     category = CATEGORY
     subcheck-description = "Check the crystal circuit gain meets the design criteria for max-critical-gain",
     pass-message = "Crystal %_ gain %_ meets the design criteria for max-critical-gain %_" 
@@ -87,11 +91,13 @@ public pcb-check resonator-gain-check (o:JITXObject, intf:CrystalOscillator, loa
 
 ; Checks the drive level of an oscillator (o) against an interface on an IC (intf)
 public pcb-check resonator-drive-check (o:JITXObject, intf:CrystalOscillator, load-cap:JITXObject) :
+  check-has-properties(NAME, o, [`crystal-resonator])
+
   ; Check drive level against crystal maximum
   #CHECK(
     condition = drive-level(intf) <= max-drive-level(property(o.crystal-resonator)),
     name = NAME
-    description = DESCRIPTION
+    description = description(x)
     category = CATEGORY
     subcheck-description = "Check the crystal resonator circuit has the correct drive-level property to match crystal",
     pass-message = "Crystal circuit %_ has the correct drive-level property %_ that matches the crystal spec %_" 
@@ -103,41 +109,18 @@ public pcb-check resonator-drive-check (o:JITXObject, intf:CrystalOscillator, lo
 
 ; Check pullability of crystal to ensure accuracy
 public pcb-check resonator-pullability-check (o:JITXObject, intf:CrystalOscillator, load-cap:JITXObject) :
+  check-has-properties(NAME, load-cap, [`tolerance, `capacitance])
+  check-has-properties(NAME, o, [`crystal-resonator])
+
   val op = property(o.crystal-resonator)
   val pullability = motional-capacitance(op) / (2.0 * pow(shunt-capacitance(op) + load-capacitance(op), 2.0))
   
-  #CHECK(
-    condition = has-property?(load-cap.tolerance),
-    name = NAME
-    description = DESCRIPTION
-    category = CATEGORY
-    subcheck-description = "Check the crystal-tuning capacitor has the correct tolerance property",
-    pass-message =  "Capacitor %_ has the correct tolerance property for crystal tuning" 
-      % [context(load-cap)],
-    fail-message = "Capacitor %_ does not have the correct tolerance property for crystal tuning"
-       % [context(load-cap)],
-    locators = [load-cap]
-  )
-
-  #CHECK(
-    condition = has-property?(load-cap.capacitance),
-    name = NAME
-    description = DESCRIPTION
-    category = CATEGORY
-    subcheck-description = "Check the crystal-tuning capacitor has the correct capacitance property",
-    pass-message = "Capacitor %_ has the correct capacitance property for crystal tuning" 
-      % [context(load-cap)],
-    fail-message = "Capacitor %_ does not have the correct capacitance property for crystal tuning" 
-      % [context(load-cap)],
-    locators = [load-cap]
-  )
-
   val dC = (property(load-cap.capacitance) as Double) * (property(load-cap.tolerance)[1] as Double)
   val freq-error = (pullability as Double) * (dC as Double) * frequency(op)
   #CHECK(
     condition = frequency-tolerance(op) + freq-error < frequency-tolerance(intf),
     name = NAME
-    description = DESCRIPTION
+    description = description(x)
     category = CATEGORY
     subcheck-description = "Check the crystal frequency tolerance with pullability meets the design specification",
     pass-message = "Crystal %_ has the correct frequency tolerance %_ that meets the design spec %_" 

--- a/utils/passive-checks/utils.stanza
+++ b/utils/passive-checks/utils.stanza
@@ -1,3 +1,4 @@
+#use-added-syntax(jitx)
 defpackage ocdb/utils/passive-checks/utils :
   import core
   import collections
@@ -10,6 +11,30 @@ public defn context (c:JITXObject) :
 
 doc:"Category used by passive component checks."
 public val CATEGORY = "Component Checks"
+
+doc:"Make sure that a component has the correct properties."
+public defn check-has-properties (name:String, 
+                                  thing:JITXObject, 
+                                  properties:Tuple<Symbol>) :
+  val missing = 
+    for prop in properties seq? :
+      match(get-property?(thing, prop)) : 
+        (one:One)   : None()
+        (none:None) : One(prop)
+
+  val condition = not empty?(missing)
+  val pass = "%_ has properties %," % [context(thing), properties]
+  val fail = "%_ is missing a properties %," % [context(thing), missing]
+
+  #CHECK( condition   = condition
+          name        = name
+          locators    = [thing, originating-instantiable(thing)]
+          description = "%_ data consistency" % [context(thing)]
+          category    = "%_ (Data)" % [CATEGORY]
+          subcheck-description = "%_ has properties %," % [context(thing), properties] 
+          info-message = pass
+          pass-message = fail )
+
 
 doc:"Helper to check if a component has a property."
 public defn has-prop-msg (condition: () -> Maybe<True|False>, 

--- a/utils/pin-checks/all.stanza
+++ b/utils/pin-checks/all.stanza
@@ -9,46 +9,12 @@ defpackage ocdb/utils/pin-checks/all :
   import ocdb/utils/pin-checks/power-pin-checks
   import ocdb/utils/pin-checks/reset-pin-checks
 
+
 doc: "Check the pins of an instance."
 public defn check-pins (instance:JITXObject) :
   for pin in pins(instance) do :
-    check-connectivity(pin)
     check-generic-pin(pin)      when has-property?(pin.generic-pin)
     check-power-pin(pin)        when has-property?(pin.power-pin)
     ; check-power-supply-pin(pin) when has-property?(pin.power-supply-pin)
     check-reset-pin(pin)        when has-property?(pin.reset-pin)
 
-defn check-connectivity (p:JITXObject) :
-  inside pcb-module :
-    check connectivity(p)
-
-; Checks that a pin is connected (or not). 
-; if no connect, fail if connected. If not no connect, fail if unconnected.
-pcb-check connectivity (p:JITXObject) :
-  val connected-pins = connected-pins(p)
-  if no-connect?(p) :
-    #CHECK(
-      condition = empty?(connected-pins)
-      name = "Pin Connectivity"
-      category = CATEGORY
-      description = "Check that a no-connect pin is not connected"
-      subcheck-description = "Check that no-connect pins are not connected"
-      pass-message = "%_ is marked no-connect and not connected"
-        % [context(p)]
-      fail-message = "%_ is marked no-connected, but is connected to other pins: %,"
-        % [context(p), seq(context, connected-pins)] 
-      locators = [p]
-    )
-  else :
-    #CHECK(
-      condition = connected?(p)
-      name = "Pin Connectivity"
-      category = CATEGORY
-      description = "Check that a pin is connected"
-      subcheck-description = "Check that pins are connected"
-      pass-message = "%_ is connected to %,"
-        % [context(p), seq(context, connected-pins)]
-      fail-message = "%_ is unconnected but not marked no-connect" 
-        % [context(p)]
-      locators = [p]
-    )

--- a/utils/propagation.stanza
+++ b/utils/propagation.stanza
@@ -1,0 +1,4 @@
+defpackage ocdb/utils/propagation :
+  import core
+
+public var PROPAGATION-FINISHED : True|False = false


### PR DESCRIPTION
- run-design has a final eval-when statement to force i/o checks after propagation of net-voltages
- changed description in checks to contain refs
- removed connectivity check for pins and added single-pin-net check
- removed conditional check generation, moved to info check in passive-checks/utils