### PR TITLE
Updates to fix checks

### DIFF
--- a/designs/checks/capacitors.stanza
+++ b/designs/checks/capacitors.stanza
@@ -70,6 +70,121 @@ pcb-component ceramic-cap-info :
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
+;==============================================================================
+;================================ Electrolytics ===============================
+;==============================================================================
+
+pcb-component electrolytic-cap-pass :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.capacitor)         = true
+  property(self.type)              = "electrolytic"
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0, 100.0))
+  property(self.capacitance)       = 1.0e-6
+  property(self.rated-voltage)     = 24.0
+  property(self.anode)             = "tantalum"
+  property(self.electrolyte)       = "manganese-dioxide"
+  property(self.rated-current-pk)  = 1.0e-6
+
+pcb-component electrolytic-cap-fail :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.capacitor)         = true
+  property(self.type)              = "electrolytic"
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0, 100.0))
+  property(self.capacitance)       = 1.0e-6
+  property(self.rated-voltage)     = 1.0
+  property(self.anode)             = "tantalum"
+  property(self.electrolyte)       = "manganese-dioxide"
+  property(self.rated-current-pk)  = 1.0e-6
+
+pcb-component electrolytic-cap-info :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+;==============================================================================
+;==================================== Mica ====================================
+;==============================================================================
+pcb-component mica-cap-pass :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.capacitor)         = true
+  property(self.type)              = "mica"
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0, 100.0))
+  property(self.capacitance)       = 1.0e-6
+  property(self.rated-voltage)     = 24.0
+
+pcb-component mica-cap-fail :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.capacitor)         = true
+  property(self.type)              = "mica"
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0, 100.0))
+  property(self.capacitance)       = 1.0e-6
+  property(self.rated-voltage)     = 5.0
+
+pcb-component mica-cap-info :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
 
 public pcb-module capacitors :
   port power : ocdb/utils/bundles/power
@@ -79,17 +194,38 @@ public pcb-module capacitors :
   inst C-cer-fail: ceramic-cap-fail
   inst C-cer-info: ceramic-cap-info
   
+  inst C-elec-pass: electrolytic-cap-pass
+  inst C-elec-fail: electrolytic-cap-fail
+  inst C-elec-info: electrolytic-cap-info
+  
+  inst C-mica-pass: mica-cap-pass
+  inst C-mica-fail: mica-cap-fail
+  inst C-mica-info: mica-cap-info
   
 
-  net VDD (power.vdd, 
-           Creal.p[1], 
-           C-cer-pass.p[1],
-           C-cer-fail.p[1],
-           C-cer-info.p[1] )
+  
 
-  net GND (power.gnd, 
-           Creal.p[2], 
-           C-cer-pass.p[2],
-           C-cer-fail.p[2],
-           C-cer-info.p[2] )
+  net VDD ( power.vdd, 
+            Creal.p[1], 
+            C-cer-pass.p[1],
+            C-cer-fail.p[1],
+            C-cer-info.p[1],
+            C-elec-pass.p[1],
+            C-elec-fail.p[1],
+            C-elec-info.p[1],
+            C-mica-pass.p[1],
+            C-mica-fail.p[1],
+            C-mica-info.p[1] )
+
+  net GND ( power.gnd, 
+            Creal.p[2], 
+            C-cer-pass.p[2],
+            C-cer-fail.p[2],
+            C-cer-info.p[2],
+            C-elec-pass.p[2],
+            C-elec-fail.p[2],
+            C-elec-info.p[2],
+            C-mica-pass.p[2],
+            C-mica-fail.p[2],
+            C-mica-info.p[2] )
   

--- a/designs/checks/capacitors.stanza
+++ b/designs/checks/capacitors.stanza
@@ -1,0 +1,23 @@
+#use-added-syntax(jitx)
+defpackage ocdb/designs/checks/capacitors :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/utils/checks
+  import ocdb/utils/defaults
+  import ocdb/utils/landpatterns
+  import ocdb/utils/symbols
+  import ocdb/utils/property-structs
+  import ocdb/utils/box-symbol
+  import ocdb/utils/passive-checks/resonator-checks
+  import ocdb/utils/generator-utils
+  import ocdb/utils/micro-controllers
+  import ocdb/utils/design-vars
+  import ocdb/utils/generic-components
+
+public pcb-module capacitors :
+  port power : ocdb/utils/bundles/power
+  inst Creal : ceramic-cap(1.0e-9)
+  net VDD (power.vdd, Creal.p[1])
+  net GND (power.vdd, Creal.p[2])

--- a/designs/checks/capacitors.stanza
+++ b/designs/checks/capacitors.stanza
@@ -185,6 +185,60 @@ pcb-component mica-cap-info :
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
+;==============================================================================
+;==================================== Mylar ===================================
+;==============================================================================
+pcb-component mylar-cap-pass :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.capacitor)         = true
+  property(self.type)              = "mylar"
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0, 100.0))
+  property(self.capacitance)       = 1.0e-6
+  property(self.rated-voltage)     = 24.0
+
+pcb-component mylar-cap-fail:
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.capacitor)         = true
+  property(self.type)              = "mylar"
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0, 100.0))
+  property(self.capacitance)       = 1.0e-6
+  property(self.rated-voltage)     = 1.0
+
+pcb-component mylar-cap-info :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = capacitor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
 
 public pcb-module capacitors :
   port power : ocdb/utils/bundles/power
@@ -202,8 +256,9 @@ public pcb-module capacitors :
   inst C-mica-fail: mica-cap-fail
   inst C-mica-info: mica-cap-info
   
-
-  
+  inst C-mylar-pass: mylar-cap-pass
+  inst C-mylar-fail: mylar-cap-fail
+  inst C-mylar-info: mylar-cap-info
 
   net VDD ( power.vdd, 
             Creal.p[1], 
@@ -215,7 +270,10 @@ public pcb-module capacitors :
             C-elec-info.p[1],
             C-mica-pass.p[1],
             C-mica-fail.p[1],
-            C-mica-info.p[1] )
+            C-mica-info.p[1],
+            C-mylar-pass.p[1],
+            C-mylar-fail.p[1],
+            C-mylar-info.p[1] )
 
   net GND ( power.gnd, 
             Creal.p[2], 
@@ -227,5 +285,8 @@ public pcb-module capacitors :
             C-elec-info.p[2],
             C-mica-pass.p[2],
             C-mica-fail.p[2],
-            C-mica-info.p[2] )
+            C-mica-info.p[2],
+            C-mylar-pass.p[2],
+            C-mylar-fail.p[2],
+            C-mylar-info.p[2] )
   

--- a/designs/checks/capacitors.stanza
+++ b/designs/checks/capacitors.stanza
@@ -16,8 +16,80 @@ defpackage ocdb/designs/checks/capacitors :
   import ocdb/utils/design-vars
   import ocdb/utils/generic-components
 
+;==============================================================================
+;============================== Ceramics ======================================
+;==============================================================================
+pcb-component ceramic-cap-pass :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = resistor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.capacitor)         = true
+  property(self.type)              = "ceramic"
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0, 100.0))
+  property(self.capacitance)       = 1.0e-9
+  property(self.rated-voltage)     = 24.0
+
+pcb-component ceramic-cap-fail :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = resistor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.capacitor)         = true
+  property(self.type)              = "ceramic"
+  property(self.rated-temperature) = RatedTemperature(min-max(-100.0, 100.0))
+  property(self.capacitance)       = 1.0e-9
+  property(self.rated-voltage)     = 1.0
+
+pcb-component ceramic-cap-info :
+  reference-prefix = "C"
+
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = resistor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+
 public pcb-module capacitors :
   port power : ocdb/utils/bundles/power
   inst Creal : ceramic-cap(1.0e-9)
-  net VDD (power.vdd, Creal.p[1])
-  net GND (power.vdd, Creal.p[2])
+
+  inst C-cer-pass: ceramic-cap-pass
+  inst C-cer-fail: ceramic-cap-fail
+  inst C-cer-info: ceramic-cap-info
+  
+  
+
+  net VDD (power.vdd, 
+           Creal.p[1], 
+           C-cer-pass.p[1],
+           C-cer-fail.p[1],
+           C-cer-info.p[1] )
+
+  net GND (power.gnd, 
+           Creal.p[2], 
+           C-cer-pass.p[2],
+           C-cer-fail.p[2],
+           C-cer-info.p[2] )
+  

--- a/designs/checks/checked-design.stanza
+++ b/designs/checks/checked-design.stanza
@@ -4,20 +4,22 @@ defpackage ocdb/designs/checks/checked-design :
   import collections
   import jitx
   import jitx/commands
+  import ocdb/utils/checks
   import ocdb/utils/defaults
   import ocdb/utils/generator-utils
-  import ocdb/utils/checks
-  import ocdb/designs/checks/resistors 
   import ocdb/designs/checks/capacitors
+  import ocdb/designs/checks/digital-io
   import ocdb/designs/checks/inductors
+  import ocdb/designs/checks/resistors
 
 pcb-module main-module :
   inst rs: resistors
   inst cs: capacitors
   inst ls: inductors
-  
-  net VDD (rs.power.vdd, ls.power.vdd, cs.power.vdd)
-  net GND (rs.power.gnd, ls.power.gnd, cs.power.gnd)
+  inst io: digital-io
+
+  net VDD (rs.power.vdd, ls.power.vdd, cs.power.vdd, io.power.vdd)
+  net GND (rs.power.gnd, ls.power.gnd, cs.power.gnd, io.power.gnd)
 
   property(VDD.net-voltage) = typ(5.0)
   property(GND.net-voltage) = typ(0.0)

--- a/designs/checks/checked-design.stanza
+++ b/designs/checks/checked-design.stanza
@@ -1,0 +1,18 @@
+#use-added-syntax(jitx)
+defpackage ocdb/designs/checks/checked-design :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/utils/defaults
+  import ocdb/utils/generator-utils
+  import ocdb/utils/checks
+  import ocdb/designs/checks/resistors 
+
+pcb-module main-module :
+  inst rs: resistors
+  check-design(self)
+
+set-design-directory("checked-design")
+run-final-passes(main-module)
+run-checks("checks.txt")

--- a/designs/checks/checked-design.stanza
+++ b/designs/checks/checked-design.stanza
@@ -8,11 +8,24 @@ defpackage ocdb/designs/checks/checked-design :
   import ocdb/utils/generator-utils
   import ocdb/utils/checks
   import ocdb/designs/checks/resistors 
+  import ocdb/designs/checks/capacitors
+  import ocdb/designs/checks/inductors
 
 pcb-module main-module :
   inst rs: resistors
+  inst cs: capacitors
+  inst ls: capacitors
+  
+  net VDD (rs.power.vdd, ls.power.vdd, cs.power.vdd)
+  net GND (rs.power.gnd, ls.power.gnd, cs.power.gnd)
+
+  property(VDD.net-voltage) = typ(5.0)
+  property(GND.net-voltage) = typ(0.0)
   check-design(self)
 
-set-design-directory("checked-design")
-run-final-passes(main-module)
-run-checks("checks.txt")
+defn main () :
+  set-design-directory("checked-design")
+  run-final-passes(main-module)
+  run-checks("checks.txt")
+
+main()

--- a/designs/checks/checked-design.stanza
+++ b/designs/checks/checked-design.stanza
@@ -14,7 +14,7 @@ defpackage ocdb/designs/checks/checked-design :
 pcb-module main-module :
   inst rs: resistors
   inst cs: capacitors
-  inst ls: capacitors
+  inst ls: inductors
   
   net VDD (rs.power.vdd, ls.power.vdd, cs.power.vdd)
   net GND (rs.power.gnd, ls.power.gnd, cs.power.gnd)

--- a/designs/checks/digital-io.stanza
+++ b/designs/checks/digital-io.stanza
@@ -28,7 +28,7 @@ pcb-component peripheral-pass :
       DigitalIO(OpenCollector(vol, iol), vil, vih, self.vdd, self.gnd, leakage-current)
     where :
       val vol = min-max(0.0, 0.2 * vdd) ; min 0.0V, max 20% of vdd
-      val iol = 1.0e-6
+      val iol = 30.0e-6
       val vil = typ(0.3 * vdd) ; 30% of vdd
       val vih = typ(0.7 * vdd) ; 70% of vdd
       val leakage-current = 30.0e-6 ; 30uA
@@ -52,9 +52,9 @@ pcb-component peripheral-fail :
       DigitalIO(OpenCollector(vol, iol), vil, vih, self.vdd, self.gnd, leakage-current)
     where :
       val vol = min-max(0.0, 0.3 * vdd) ; min 0.0V, max 30% of vdd (way high!)
-      val iol = 1.0e-6
-      val vil = typ(0.25 * vdd) ; 30% of vdd
-      val vih = typ(0.5 * vdd) ; 70% of vdd
+      val iol = 30.0e-6
+      val vil = typ(vdd) ; 30% of vdd
+      val vih = typ(vdd) ; 70% of vdd
       val leakage-current = 30.0e-6 ; 30uA
 
 ; Example module showing a single i/o bus with a pullup resistor, 
@@ -65,24 +65,42 @@ pcb-module io-pass :
   inst U2 : peripheral-pass    ; digital input or output
 
   ; Increase R1 to pass
-  inst R1 : chip-resistor(1000.0) ; pullup resistor
+  inst R1 : chip-resistor(510.0e3) ; pullup resistor
 
   net (U1.io, U2.io, R1.p[2])
-  net (power.vdd U1.vdd U2.vdd, R1.p[1])
-  net (power.gnd U1.gnd U2.gnd)
+  net (power.vdd U1.vdd, U2.vdd, R1.p[1])
+  net (power.gnd U1.gnd, U2.gnd)
   
 ; Example showing a single i/o bus without a pullup resistor, 
 ; showing that the checks fail (vi/vo levels and missing 
 ; pullup on an open-collector )
 pcb-module io-fail :
+  ; Things of note: 
+  ;   - The bus between U1 and U2 is missing a pullup resistor. Check failure.
+  ;   - The bus between U3 and U4 has two pullup resistors and the equivalent
+  ;     reistance is too low. Check failure.
+  ;   - The bus between U4 and U6 has a correct pullup, but the vi/vo high/low
+  ;     levels are mismatched. Check failure. 
   port power : ocdb/utils/bundles/power
   
   inst U1 : peripheral-pass    ; digital input or output
   inst U2 : peripheral-fail    ; digital input or output
-
-  net (U1.io, U2.io)
-  net (power.vdd, U1.vdd, U2.vdd)
-  net (power.gnd, U1.gnd, U2.gnd)
+  inst U3 : peripheral-pass
+  inst U4 : peripheral-fail
+  inst U5 : peripheral-pass
+  inst U6 : peripheral-fail
+  
+  inst R : chip-resistor(250.0e3)[3]
+  net IO-1 (U1.io, U2.io)
+  net IO-2 (U3.io, U4.io, R[0].p[1], R[1].p[1])
+  net IO-3 (U5.io, U6.io, R[2].p[1])
+  
+  net (power.vdd, U1.vdd, U2.vdd, 
+       U3.vdd, U4.vdd, U5.vdd, U6.vdd
+       R[0].p[2], R[1].p[2], R[2].p[2])
+  
+  net (power.gnd, U1.gnd, U2.gnd, 
+       U3.gnd, U4.gnd, U5.gnd, U6.gnd)
   
 public pcb-module digital-io :
   port power : ocdb/utils/bundles/power

--- a/designs/checks/digital-io.stanza
+++ b/designs/checks/digital-io.stanza
@@ -1,0 +1,91 @@
+#use-added-syntax(jitx)
+defpackage ocdb/designs/checks/digital-io :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/utils/box-symbol
+  import ocdb/utils/landpatterns
+  import ocdb/utils/property-structs
+  import ocdb/utils/generic-components
+
+pcb-component peripheral-pass :
+  pin-properties :
+    [ pin : Ref | pads : Int ... | side : Dir ]
+    [ vdd       | 1         | Up         ]
+    [ io        | 2         | Right      ]
+    [ gnd       | 3         | Down       ]
+  
+  make-box-symbol()
+  assign-landpattern(SOT23())
+
+  ; Set the Vi high/low and Vo high/low contraints 
+  ; based on the net voltage of Vdd.
+  eval-when has-property?(self.vdd.net-voltage) :
+    val vdd = max-value(property(self.vdd.net-voltage))
+
+    property(self.io.digital-io) = 
+      DigitalIO(OpenCollector(vol, iol), vil, vih, self.vdd, self.gnd, leakage-current)
+    where :
+      val vol = min-max(0.0, 0.2 * vdd) ; min 0.0V, max 20% of vdd
+      val iol = 1.0e-6
+      val vil = typ(0.3 * vdd) ; 30% of vdd
+      val vih = typ(0.7 * vdd) ; 70% of vdd
+      val leakage-current = 30.0e-6 ; 30uA
+
+pcb-component peripheral-fail :
+  pin-properties :
+    [ pin : Ref | pads : Int ... | side : Dir ]
+    [ vdd       | 1         | Up         ]
+    [ io        | 2         | Right      ]
+    [ gnd       | 3         | Down       ]
+  
+  make-box-symbol()
+  assign-landpattern(SOT23())
+
+  ; Set the Vi high/low and Vo high/low contraints 
+  ; based on the net voltage of Vdd.
+  eval-when has-property?(self.vdd.net-voltage) :
+    val vdd = max-value(property(self.vdd.net-voltage))
+
+    property(self.io.digital-io) = 
+      DigitalIO(OpenCollector(vol, iol), vil, vih, self.vdd, self.gnd, leakage-current)
+    where :
+      val vol = min-max(0.0, 0.3 * vdd) ; min 0.0V, max 30% of vdd (way high!)
+      val iol = 1.0e-6
+      val vil = typ(0.25 * vdd) ; 30% of vdd
+      val vih = typ(0.5 * vdd) ; 70% of vdd
+      val leakage-current = 30.0e-6 ; 30uA
+
+; Example module showing a single i/o bus with a pullup resistor, 
+; showing that the checks pass as expected.
+pcb-module io-pass :
+  port power : ocdb/utils/bundles/power
+  inst U1 : peripheral-pass    ; digital input or output
+  inst U2 : peripheral-pass    ; digital input or output
+
+  ; Increase R1 to pass
+  inst R1 : chip-resistor(1000.0) ; pullup resistor
+
+  net (U1.io, U2.io, R1.p[2])
+  net (power.vdd U1.vdd U2.vdd, R1.p[1])
+  net (power.gnd U1.gnd U2.gnd)
+  
+; Example showing a single i/o bus without a pullup resistor, 
+; showing that the checks fail (vi/vo levels and missing 
+; pullup on an open-collector )
+pcb-module io-fail :
+  port power : ocdb/utils/bundles/power
+  
+  inst U1 : peripheral-pass    ; digital input or output
+  inst U2 : peripheral-fail    ; digital input or output
+
+  net (U1.io, U2.io)
+  net (power.vdd, U1.vdd, U2.vdd)
+  net (power.gnd, U1.gnd, U2.gnd)
+  
+public pcb-module digital-io :
+  port power : ocdb/utils/bundles/power
+  inst pass : io-pass
+  inst fail : io-fail
+  net (power, pass.power, fail.power)

--- a/designs/checks/inductors.stanza
+++ b/designs/checks/inductors.stanza
@@ -69,13 +69,12 @@ pcb-component inductor-info :
 
   property(self.inductor)       = true
 
-
 public pcb-module inductors :
   port power : ocdb/utils/bundles/power
-  inst Lreal : smd-inductor(1.0e-3)
+  val answer = dbquery(["category" => "inductor", "inductance" => 1.0e-6], 1)
+  inst Lreal : smd-inductor(1.0e-6)
   inst Lpass : inductor-pass
   inst Lfail : inductor-fail
   inst Linfo : inductor-info
   net VDD (power.vdd, Lreal.p[1], Lpass.p[1], Lfail.p[1], Linfo.p[1])
   net GND (power.gnd, Lreal.p[2], Lpass.p[2], Lfail.p[2], Linfo.p[2])
-  

--- a/designs/checks/inductors.stanza
+++ b/designs/checks/inductors.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx)
-defpackage ocdb/designs/checks/resistors :
+defpackage ocdb/designs/checks/inductors :
   import core
   import collections
   import jitx
@@ -16,61 +16,66 @@ defpackage ocdb/designs/checks/resistors :
   import ocdb/utils/design-vars
   import ocdb/utils/generic-components
 
-pcb-component resistor-pass :
-  reference-prefix = "R"
+pcb-component inductor-pass :
+  reference-prefix = "L"
+
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = resistor-sym()
+  val sym = inductor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.resistor)    = true
-  property(self.resistance)  = 1.0e3
-  property(self.rated-power) = 1.0
+  property(self.inductor)       = true
+  property(self.dc-resistance)  = 16.0
+  property(self.rated-power)    = 5.0
+  property(self.inductance)     = 1.0e-6
   property(self.rated-temperature) = RatedTemperature(min-max(-55.0, 100.0))
 
-pcb-component resistor-fail :
-  reference-prefix = "R"
+pcb-component inductor-fail :
+  reference-prefix = "L"
+
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = resistor-sym()
+  val sym = inductor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.resistor)    = true
-  property(self.resistance)  = 1.0  ; 1 ohm
-  property(self.rated-power) = 0.25 ; .25 W
+  property(self.inductor)       = true
+  property(self.dc-resistance)  = 16.0
+  property(self.rated-power)    = 0.25
+  property(self.inductance)     = 1.0e-6
   property(self.rated-temperature) = RatedTemperature(min-max(-55.0, 100.0))
 
-pcb-component resistor-info :
-  reference-prefix = "R"
+pcb-component inductor-info :
+  reference-prefix = "L"
+
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = resistor-sym()
+  val sym = inductor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.resistor) = true
+  property(self.inductor)       = true
 
-public pcb-module resistors :
+
+public pcb-module inductors :
   port power : ocdb/utils/bundles/power
-
-  inst Rreal : chip-resistor(1.0e3)
-  inst Rfail : resistor-fail
-  inst Rpass : resistor-pass
-  inst Rinfo : resistor-info
+  inst Lreal : smd-inductor(1.0e-3)
+  inst Lpass : inductor-pass
+  inst Lfail : inductor-fail
+  inst Linfo : inductor-info
+  net VDD (power.vdd, Lreal.p[1], Lpass.p[1], Lfail.p[1], Linfo.p[1])
+  net GND (power.gnd, Lreal.p[2], Lpass.p[2], Lfail.p[2], Linfo.p[2])
   
-  net (power.vdd, Rreal.p[1], Rfail.p[1], Rpass.p[1], Rinfo.p[1])
-  net (power.gnd, Rreal.p[2], Rfail.p[2], Rpass.p[2], Rinfo.p[2])

--- a/designs/checks/resistors.stanza
+++ b/designs/checks/resistors.stanza
@@ -1,0 +1,79 @@
+#use-added-syntax(jitx)
+defpackage ocdb/designs/checks/resistors :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/utils/checks
+  import ocdb/utils/defaults
+  import ocdb/utils/landpatterns
+  import ocdb/utils/symbols
+  import ocdb/utils/property-structs
+  import ocdb/utils/box-symbol
+  import ocdb/utils/passive-checks/resonator-checks
+  import ocdb/utils/generator-utils
+  import ocdb/utils/micro-controllers
+  import ocdb/utils/design-vars
+  import ocdb/utils/generic-components
+
+pcb-component resistor-pass :
+  reference-prefix = "R"
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = resistor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.resistor)    = true
+  property(self.resistance)  = 1.0e3
+  property(self.rated-power) = 1.0
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0, 100.0))
+
+pcb-component resistor-fail :
+  reference-prefix = "R"
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = resistor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.resistor)    = true
+  property(self.resistance)  = 1.0  ; 1 ohm
+  property(self.rated-power) = 0.25 ; .25 W
+  property(self.rated-temperature) = RatedTemperature(min-max(-55.0, 100.0))
+
+pcb-component resistor-info :
+  reference-prefix = "R"
+  pin-properties :
+    [ pin : Ref | pads : Int ... ]
+    [ p[1]      | 1              ]
+    [ p[2]      | 2              ]
+  
+  assign-landpattern(ipc-two-pin-landpattern("0603"))
+  val sym = resistor-sym()
+  symbol =
+    sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
+
+  property(self.resistor) = true
+
+public pcb-module resistors :
+  port power : ocdb/utils/bundles/power
+
+  inst Rreal : chip-resistor(1.0e3)
+  inst Rfail : resistor-fail
+  inst Rpass : resistor-pass
+  inst Rinfo : resistor-info
+
+  net VDD (power.vdd, Rreal.p[1], Rfail.p[1], Rpass.p[1], Rinfo.p[1])
+  net GND (power.gnd, Rreal.p[2], Rfail.p[2], Rpass.p[2], Rinfo.p[2])
+
+  property(VDD.net-voltage) = typ(5.0)
+  property(GND.net-voltage) = typ(0.0)

--- a/stanza.proj
+++ b/stanza.proj
@@ -28,6 +28,7 @@ package ocdb/space-derating defined-in "derating/space-derating.stanza"
 
 package ocdb defined-in "ocdb.stanza"
 packages ocdb/tests/* defined-in "tests"
+packages ocdb/designs/* defined-in "designs"
 
 build ocdb :
   inputs: ocdb

--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -17,6 +17,8 @@ defpackage ocdb/utils/checks :
   import ocdb/utils/pin-checks/all
   import ocdb/utils/netlist-checks/all
   import ocdb/utils/netlist-checks/utils
+  import ocdb/utils/propagation
+
 ;<>
 #CHECK(
   condition = p-props is GenericPin,                    ; A boolean check                     (True|False)
@@ -49,6 +51,7 @@ Set of standard checks to run on a top-level-module.
  - Digital I/O pin checks are run, see check-io
 <S>
 
+
 public defn check-design (module:JITXObject):
   erc-check-design(module)
   drc-check-design(module)
@@ -63,7 +66,8 @@ public defn erc-check-design (module:JITXObject):
       check-inductor(i)  when has-property?(i.inductor)    
       check-pins(i)
 
-    check-netlist(module)
+    eval-when PROPAGATION-FINISHED :
+      check-netlist(module)
 
 public defn drc-check-design (module:JITXObject):
   inside pcb-module:

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -16,6 +16,7 @@ defpackage ocdb/utils/generator-utils:
   import ocdb/modules/power-regulators
   import ocdb/utils/bundles
   import ocdb/utils/relative-voltages
+  import ocdb/utils/propagation
 
 ; =======================================
 ; Ciruit convenience functions
@@ -287,18 +288,22 @@ public defn run-final-passes (module:Instantiable) -> Instantiable :
                            encountered: 5 iterations reached. Check that no eval-when generate other eval-whens in an \
                            infinite loop, or that there is no infinite loop of 2nd order between eval-when execution \
                            and net voltage propagation or pin assignment.")
-
+      
+      
       ;TODO: Review the order and necessity of those algos
       design $> transform-module{propagate-net-voltages, _}
              $> transform-module{propagate-relative-voltages, _}
              $> assign-pins
              $> run-eval-loop
-
+  
+  PROPAGATION-FINISHED = true
+  val final-module = run-evals(result-module)
+  
   ; If we did not set the main module, a user forgetting to set it himself on the new module would be exporting
   ; the module before adding operating points (the main module is set in the loop to be able to assign pins).
   ; Such bug would be invisible.
-  set-main-module(result-module)
-  result-module
+  set-main-module(final-module)
+  final-module
 
 ; FIXME: assign-pins was obviously not meant to be used like this, it depends on the flattening
 ; Is run-evals? actually accessing the information resulting from the pin assignment?

--- a/utils/netlist-checks/all.stanza
+++ b/utils/netlist-checks/all.stanza
@@ -6,6 +6,7 @@ defpackage ocdb/utils/netlist-checks/all :
   import ocdb/utils/netlist-checks/utils
   import ocdb/utils/netlist-checks/io-checks
   import ocdb/utils/netlist-checks/power-states
+  import ocdb/utils/netlist-checks/single-pin-nets
 
 public defn check-netlist (root-module:JITXObject) :
   val netlist = GlobalNetList(root-module)

--- a/utils/netlist-checks/io-checks.stanza
+++ b/utils/netlist-checks/io-checks.stanza
@@ -14,7 +14,12 @@ defpackage ocdb/utils/netlist-checks/io-checks :
 ;============================ Driver ==========================================
 ;==============================================================================
 val NAME = "IO Checks"
-val DESCRIPTION = "Check Digital I/O Properties"
+
+defn description (p:JITXObject) :
+  "%_ digital I/O Properties"
+
+defn description (p:Seqable<JITXObject>) :
+  "%, digital I/O Properties"
 
 doc: "Check the i/o pin nets."
 public defn check-io (module:JITXObject, netlist:GlobalNetList) :
@@ -59,17 +64,16 @@ defn cmos-ttl-outputs (pin-categories:DigitalPinCategories) :
 ;==============================================================================
 pcb-check digital-output (output-pins: Tuple<DigitalPin>) :
   val non-tristateable-output-pins = to-tuple $ filter({not tristateable(prop(_))}, output-pins)
-  #CHECK(condition = length(non-tristateable-output-pins) >= 1
+  #CHECK( condition = length(non-tristateable-output-pins) >= 1
           name = NAME
-          description = DESCRIPTION
+          description = description(map(pin, output-pins))
           category = CATEGORY
           subcheck-description = "Check there is at least one non-tristateable output pin",
           pass-message = "Output pins %, are connected together and at most 1 of them is non-tristateable"
             % [seq(ref{pin(_)}, output-pins)],
           fail-message = "The following non-tristateable output pins are connected together: %,"
             % [seq(ref{pin(_)}, non-tristateable-output-pins)],
-          locators = map(pin, output-pins)
-          )
+          locators = map(pin, output-pins) )
 
 ;==============================================================================
 ;=============================== Open Collector ===============================
@@ -103,10 +107,11 @@ defn open-collector-fail-message (open-collectors:Tuple<DigitalPin>, action:?) :
 ; - check that generic pin/io-pin ratings agree
 defn check-open-collectors (open-collectors:Tuple<DigitalPin>,
                             pin-categories:DigitalPinCategories) :
+  println("Running open collector checks")
   inside pcb-module :
     val [pullup-resistors, net-voltages] =
       pullup-resistors(open-collectors, pin-categories)
-
+    
     for p in open-collectors do :
       check no-net-voltage(pin(p))
 
@@ -122,10 +127,11 @@ defn check-open-collectors (open-collectors:Tuple<DigitalPin>,
         check input-and-generic-pin-max-voltage-rating(net-voltage?, pin-categories)
 
 pcb-check net-voltages-equal (ps:Tuple<DigitalPin>, nvs:Tuple<Toleranced>, rs:Tuple<JITXObject>) :
+  val locators = to-tuple(cat(seq(pin, ps), rs))
   #CHECK(
     condition = all-equal?(nvs),
     name = NAME
-    description = DESCRIPTION
+    description = description(locators)
     category = CATEGORY
     subcheck-description =
       "Check that io pins have pullup resistors connected to the same net voltage",
@@ -135,7 +141,7 @@ pcb-check net-voltages-equal (ps:Tuple<DigitalPin>, nvs:Tuple<Toleranced>, rs:Tu
       open-collector-fail-message(ps,
         "all pull-up resistors %, with the same net voltage"
           % [seq(ref, rs)]),
-    locators = to-tuple(cat(seq(pin, ps), rs))
+    locators = locators
   )
 
 ; Check that a pin does not have a net voltage
@@ -143,7 +149,7 @@ pcb-check no-net-voltage (p:Pin) :
   #CHECK(
     condition = not has-property?(p.net-voltage),
     name = NAME
-    description = DESCRIPTION
+    description = description(p)
     category = CATEGORY
     subcheck-description =
       "Check that open-collector i/o pins are not connected to a net with a `net-voltage` property.",
@@ -160,7 +166,7 @@ pcb-check pullup-resistor-exists (open-collectors:Tuple<DigitalPin>, resistors:T
   #CHECK(
     condition = not empty?(resistors),
     name = NAME
-    description = DESCRIPTION
+    description = description(map(pin, open-collectors))
     category = CATEGORY
     subcheck-description = "Check that open collector pins have at least one pullup resistor",
     pass-message = open-collector-pass-message(open-collectors, "at least one pullup resistor"),
@@ -170,8 +176,8 @@ pcb-check pullup-resistor-exists (open-collectors:Tuple<DigitalPin>, resistors:T
 pcb-check sink-current (open-collector:DigitalPin, net-voltage:Toleranced, resistance?:False|Double) :
   #CHECK(condition = resistance? is Double,
          name = NAME,
-         description = DESCRIPTION,
-         category = CATEGORY,
+         description = description(pin(open-collector)),
+         category = CATEGORY, 
          subcheck-description  = "Check that open collector pins have a finite pullup resistance.",
          fail-message = "%_ has an infinite pullup resistance" %
           [context(pin(open-collector))]
@@ -186,7 +192,7 @@ pcb-check sink-current (open-collector:DigitalPin, net-voltage:Toleranced, resis
   #CHECK(condition =           ipk < iol(driver),
         name =                 NAME
         description =          CATEGORY
-        category =             DESCRIPTION
+        category =             description(pin(open-collector))
         subcheck-description = "Check an open collector pin's peak sink current is in spec",
         pass-message = "%_ current sink specification %_A satisfies the design requirement %_A"
           % [context(pin(open-collector)), iol(driver), ipk],
@@ -207,7 +213,7 @@ pcb-check input-and-generic-pin-max-voltage-rating (net-voltage:Toleranced, pin-
 
       #CHECK(condition = min-value(net-voltage) > min-value(vih-v)
              name = NAME
-             description = DESCRIPTION
+             description = description(pin)
              category = CATEGORY
              subcheck-description = "Check the net with a net-voltage property is higher than the vih pin specification",
              pass-message = "%_'s vih specification (%_V) is lower than the net voltage (%_V)"
@@ -223,7 +229,7 @@ defn pullup-resistors (open-collectors:Tuple<DigitalPin>,
   val collected-net-voltages = Vector<Toleranced>()
 
   defn is-resistor? (r) :
-    has-property?(r.resistor) and
+    has-property?(r.resistor)   and
     has-property?(r.resistance)
 
   defn collect-net-voltages-and-returns-if-any? (instance:Instance) -> True|False :
@@ -306,7 +312,7 @@ defn vhi-vlo (i:Pin, o:Pin,
   #CHECK(condition = min-value(voh) >= max-value(vih)
          name = NAME
          category = CATEGORY
-         description = DESCRIPTION
+         description = description([i, o])
          subcheck-description = "Check that the min voh is greater than max vih"
          pass-message = "%_'s max voh (%_) greater than %_'s min vih (%_)" % [
             context(i), vih
@@ -321,7 +327,7 @@ defn vhi-vlo (i:Pin, o:Pin,
   #CHECK(condition = max-value(vol) <= min-value(vil)
          name = NAME
          category = CATEGORY
-         description = DESCRIPTION
+         description = description([i, o])
          subcheck-description = "Check that the max vol is less than min vil"
          pass-message = "%_'s max vol (%_) is less than %_'s min vil (%_)" % [
             context(o), voh
@@ -338,7 +344,7 @@ defn gnd-pins (i:Pin, o:Pin, ip:DigitalInput|DigitalIO, op:DigitalOutput|Digital
   #CHECK(condition = connected?([gnd-pin(ip), gnd-pin(op)])
          name = NAME
          category = CATEGORY
-         description = DESCRIPTION
+         description = description([i, o])
          locators = locators
          subcheck-description = "Check that digital i/o pins share a ground net"
          pass-message = "%_ and %_ grounds are connected together"
@@ -365,7 +371,7 @@ pcb-check input-push-pull-levels (input:DigitalPin, output:DigitalPin) :
     #CHECK(condition = in-range?(vin-max, voh)
            name = NAME
            category = CATEGORY
-           description = DESCRIPTION
+           description = description([inpt-pin, outp-pin])
            locators = [inpt-pin, outp-pin]
            pass-message = "%_'s voh (%_) is in range of %_'s max input voltage (%_)" % [
              context(outp-pin), voh
@@ -386,7 +392,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
   #CHECK(
     condition = driver? is CMOSOutput|TTLOutput
     name = NAME
-    description = DESCRIPTION
+    description = description(locators)
     category = CATEGORY
     locators = locators
     subcheck-description = "Check digital output's driver pin is CMOSOutput|TTLOutput"
@@ -396,7 +402,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
   #CHECK(
     condition = driver? is CMOSOutput|TTLOutput
     name = NAME
-    description = DESCRIPTION
+    description = description(outp-pin)
     category = CATEGORY
     locators = [outp-pin]
     subcheck-description = "Check digital output's driver pin is CMOSOutput|TTLOutput"
@@ -406,7 +412,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
   #CHECK(
     condition = io-driver? is CMOSOutput|TTLOutput
     name = NAME
-    description = DESCRIPTION
+    description = description(io-pin)
     category = CATEGORY
     locators = [io-pin]
     subcheck-description = "Check digital i/o's driver pin is CMOSOutput|TTLOutput"
@@ -429,7 +435,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
     #CHECK(
       condition = min-value(voh) >= min-value(vih),
       name = NAME
-      description = DESCRIPTION
+      description = description(locators)
       category = CATEGORY
       locators = locators
       subcheck-description = "Check min voh of io driver is greater than the vih of the io pin",
@@ -445,7 +451,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
     #CHECK(
       condition = max-value(vol) <= min-value(vil),
       name = NAME
-      description = DESCRIPTION
+      description = description(locators)
       category = CATEGORY
       locators = locators
       subcheck-description = "Check max vol of io driver is lower than the vil of the io pin",
@@ -466,7 +472,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
     #CHECK(
       condition = in-range?(max-input-voltage, voh),
       name = NAME
-      description = DESCRIPTION
+      description = description(locators)
       category = CATEGORY
       locators = locators
       subcheck-description = "Check voh of output driver is within its voltage range",
@@ -487,7 +493,7 @@ pcb-check io-push-pull-levels (io:DigitalPin, output:DigitalPin) :
     #CHECK(
       condition = in-range?(max-input-voltage, voh),
       name = NAME
-      description = DESCRIPTION
+      description = description(locators)
       category = CATEGORY
       locators = locators
       subcheck-description = "Check voh of output driver is within its voltage range",

--- a/utils/netlist-checks/io-checks.stanza
+++ b/utils/netlist-checks/io-checks.stanza
@@ -16,10 +16,10 @@ defpackage ocdb/utils/netlist-checks/io-checks :
 val NAME = "IO Checks"
 
 defn description (p:JITXObject) :
-  "%_ digital I/O Properties"
+  "%_ digital I/O Properties" % [ref(p)]
 
 defn description (p:Seqable<JITXObject>) :
-  "%, digital I/O Properties"
+  "%, digital I/O Properties" % [seq(ref, p)]
 
 doc: "Check the i/o pin nets."
 public defn check-io (module:JITXObject, netlist:GlobalNetList) :
@@ -107,7 +107,6 @@ defn open-collector-fail-message (open-collectors:Tuple<DigitalPin>, action:?) :
 ; - check that generic pin/io-pin ratings agree
 defn check-open-collectors (open-collectors:Tuple<DigitalPin>,
                             pin-categories:DigitalPinCategories) :
-  println("Running open collector checks")
   inside pcb-module :
     val [pullup-resistors, net-voltages] =
       pullup-resistors(open-collectors, pin-categories)
@@ -263,13 +262,14 @@ defn pullup-resistors (open-collectors:Tuple<DigitalPin>,
 ;
 defn parallel-resistance (resistors:Tuple<Instance>) -> Double :
   val resistances = map({property(_.resistance) as Double}, resistors)
-
   fatal("Resistance must be positive") when any?({_ < 0.0}, resistances)
 
-  val num = product(resistances)
-  val den = sum(resistances)
-
-  0.0 when (num == 0.0) else (num / den)
+  if length(resistances) == 1:
+    resistances[0]
+  else :
+    val num = product(resistances)
+    val den = sum(resistances)
+    0.0 when (num == 0.0) else (num / den)
 
 ;==============================================================================
 ;================================ CMOS/TTL ====================================

--- a/utils/netlist-checks/single-pin-nets.stanza
+++ b/utils/netlist-checks/single-pin-nets.stanza
@@ -1,3 +1,4 @@
+#use-added-syntax(jitx)
 defpackage ocdb/utils/netlist-checks/single-pin-nets :
   import core
   import collections
@@ -5,7 +6,8 @@ defpackage ocdb/utils/netlist-checks/single-pin-nets :
   import jitx/commands
   import ocdb/utils/netlist-checks/utils
 
-val name = "Single Pin Net Checks"
+val NAME = "Single Pin Net Checks"
+val DESCRIPTION = "Nets have more than one pin"
 
 public defn check-single-pin-nets (module:JITXObject, connections:Connections) :
   inside pcb-module :
@@ -13,7 +15,7 @@ public defn check-single-pin-nets (module:JITXObject, connections:Connections) :
       check single-pin-net(group)
   
 pcb-check single-pin-net (group:Tuple<Pin>) :
-  #CHECK( condition    = length(group) == 1
+  #CHECK( condition    = length(group) > 1
           name         = NAME
           category     = CATEGORY
           description  = DESCRIPTION

--- a/utils/netlist-checks/single-pin-nets.stanza
+++ b/utils/netlist-checks/single-pin-nets.stanza
@@ -1,0 +1,23 @@
+defpackage ocdb/utils/netlist-checks/single-pin-nets :
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+  import ocdb/utils/netlist-checks/utils
+
+val name = "Single Pin Net Checks"
+
+public defn check-single-pin-nets (module:JITXObject, connections:Connections) :
+  inside pcb-module :
+    for group in connected-groups(connections) do :
+      check single-pin-net(group)
+  
+pcb-check single-pin-net (group:Tuple<Pin>) :
+  #CHECK( condition    = length(group) == 1
+          name         = NAME
+          category     = CATEGORY
+          description  = DESCRIPTION
+          subcheck-description = "The net containing %, has more than one pin" % [map(context, group)]
+          fail-message = "%_ is the only pin on a net." % [context(group[0])]
+          pass-message = "%, are on the same net." % [map(context, group)]
+          locators     = group )

--- a/utils/passive-checks/capacitor-checks.stanza
+++ b/utils/passive-checks/capacitor-checks.stanza
@@ -15,7 +15,9 @@ defpackage ocdb/utils/passive-checks/capacitor-checks :
 ;==============================================================================
 ; Some common values re-used in this package
 val NAME        = "Capacitor Checks"
-val DESCRIPTION = "Check capacitor component properties"
+
+defn description (r:JITXObject) :
+  "%_ capacitor properties" % [context(r)]
 
 doc: \<s> 
   Assigns checks to a single capacitor component.
@@ -27,57 +29,20 @@ doc: \<s>
 <s>
 public defn check-capacitor (c:JITXObject) : 
   inside pcb-module :
-    ; First we check if the capacitor has the required
-    ; properties to do any checks.
-    check-capacitor-preconditions(c)
-    ; If this succeeds, we can perform the required checking.
-    if can-run-capacitor-checks?(c) :
-      val type = property(c.type)
-      ; If the cap has a known type, we perform our analysis with
-      ; the known deratings.
-      switch(type) :
-        "ceramic"      : check-ceramic-capacitor(c)
-        "electrolytic" : check-electrolytic-capacitor(c)
-        "mica"         : check-mica-film-capacitor(c)
-        else           : check-unknown-capacitor(c)
+    val type = property(c.type)
+    ; If the cap has a known type, we perform our analysis with
+    ; the known deratings.
+    switch(type) :
+      "ceramic"      : check-ceramic-capacitor(c)
+      "electrolytic" : check-electrolytic-capacitor(c)
+      "mica"         : check-mica-film-capacitor(c)
+      else           : check-unknown-capacitor(c)
 
 ; The basic capacitor check
 defn check-unknown-capacitor (c:JITXObject) :
   inside pcb-module :
     check capacitor-temp(c, false, false)
     check capacitor-voltage(c, false, false)
-
-; TODO: once inside pcb-check lands, reuse logic.
-defn can-run-capacitor-checks? (c:JITXObject) -> True|False :
-  var acc : True|False = true
-  #for prop in [capacitance, operating-point, rated-voltage, rated-temperature, type] :
-    acc = acc and has-property?(c.prop)
-  acc
-
-; Checks a capacitor component to see if it has the approparite properties.
-defn check-capacitor-preconditions (c:JITXObject) :
-  #for prop in [capacitance, operating-point, rated-voltage, rated-temperature, type] :
-    pcb-check prop (c:JITXObject) :
-      val [pass?, sub-dsc, msg] = 
-        within has-prop-msg(c, `prop) :
-          One(has-property?(c.prop))
-      #CHECK(
-        condition = pass?
-        name = NAME
-        description = DESCRIPTION
-        category = CATEGORY
-        subcheck-description = sub-dsc
-        info-message = msg
-        pass-message = msg
-        locators = [c]
-      )
-  inside pcb-module :
-    check capacitance(c)
-    check operating-point(c)
-    check type(c)
-    check rated-temperature(c)
-    check rated-voltage(c)
-
 
 ; Shared check: given a capacitor, an optional case name, and optional
 ; temperature derating, check if OPERATING-TEMPERATURE is within the 
@@ -87,8 +52,11 @@ defn check-capacitor-preconditions (c:JITXObject) :
 ; - case?: an optional case name for the derating value
 ; - derating: an optional derating value. 
 pcb-check capacitor-temp (c:JITXObject, case?:False|String, derating:False|Double) :
+  check-has-properties(NAME, c, [`rated-temperature])
+
   val [min-temp, max-temp] = OPERATING-TEMPERATURE
   val rated-temp = property(c.rated-temperature)
+    $> operating-temperature
   
   val rated-temp* = 
     match(derating:Double) :
@@ -103,7 +71,7 @@ pcb-check capacitor-temp (c:JITXObject, case?:False|String, derating:False|Doubl
     condition = in-range?(rated-temp*, min-temp) and
                 in-range?(rated-temp*, max-temp)
     name = NAME
-    description = DESCRIPTION
+    description = description(c)
     category = CATEGORY
     subcheck-description = "Check rated temperature meets the design requirements."
     pass-message = "%_ rated-temperature %_ meets%_design requirements, min:%_C, max:%_C" 
@@ -121,6 +89,8 @@ pcb-check capacitor-temp (c:JITXObject, case?:False|String, derating:False|Doubl
 ; - derating: an optional double or table of doubles for derating the component
 ;
 pcb-check capacitor-voltage (c:JITXObject, case?:False|String, derating:False|Double|Tuple<[Double, Double]>) :
+  check-has-properties(NAME, c, [`rated-voltage, `operating-point])
+
   val peak-voltage = property(c.operating-point)
     $> peak-voltage
     $> max{ abs(min-value(_0)), abs(max-value(_0)) }
@@ -137,11 +107,11 @@ pcb-check capacitor-voltage (c:JITXObject, case?:False|String, derating:False|Do
     match(case?:String) : " %_ " % [case?]
     else : " "
   
-  val voltage = derating* * max-value(rated-voltage)
+  val voltage = derating* * rated-voltage
   #CHECK(
       condition = peak-voltage < voltage
       name = NAME
-      description = DESCRIPTION
+      description = description(c)
       category = CATEGORY
       subcheck-description = "Check the %_ capacitor voltage derating matches the operating-point voltage" 
         % [property(c.type)]
@@ -188,37 +158,12 @@ val ANODES = [
 ; Checks if the electrolytic capacitor materials
 ; are known to JITX.
 defn check-electrolytic-preconditions (c:JITXObject) :
-  #for prop in [anode, electrolyte] :
-    pcb-check prop (c:JITXObject, supported:Tuple<Equalable>) :
-      val [pass?, sub-dsc, msg] = 
-      within has-prop-msg(c, `prop) :
-        One(has-property?(c.prop))
-      #CHECK(
-        condition   = pass?
-        name        = NAME,
-        description = DESCRIPTION, 
-        category    = CATEGORY,
-        subcheck-description = sub-dsc
-        pass-message = msg,
-        info-message = msg
-      )
-      val value = property(c.prop) as Equalable
-      #CHECK(
-        condition = contains?(supported, value)
-        name        = NAME,
-        description = DESCRIPTION, 
-        category    = CATEGORY,
-        subcheck-description = "Check that the `%_` value is supported" 
-          % [`prop]
-        pass-message = "%_ is a supported value for the `%_` property." 
-          % [value, `prop]
-        fail-message = "%_ is not a supported value for the `%_` property. Derating analysis will not be performed." 
-          % [value, `prop]
-      )
+  pcb-check prop-check (c:JITXObject) :
+    check-has-properties(NAME, c, [`anode, `electrolyte])
+  
   inside pcb-module :
-    check anode(c, ANODES)
-    check electrolyte(c, ELECTROLYTES)
-
+    check prop-check(c)
+  
 defn known-electrolytic-materials? (c:JITXObject) -> True|False :
   has-property?(c.anode) and
   contains?(ANODES, property(c.anode) as Equalable) and
@@ -227,7 +172,7 @@ defn known-electrolytic-materials? (c:JITXObject) -> True|False :
 
 defn check-electrolytic-capacitor (c:JITXObject) :
   inside pcb-module :
-    check-electrolytic-preconditions(c)
+    ; check-electrolytic-preconditions(c)
     check electrolytic-cap-current(c)
     
     ; If we don't recognize the electrolytic cap materials, we 
@@ -239,6 +184,7 @@ defn check-electrolytic-capacitor (c:JITXObject) :
     else :
       val anode       = property(c.anode)
       val electrolyte = property(c.electrolyte)
+
       val [derate-vpk, derate-temp] =
         switch([anode, electrolyte]) :
           ["tantalum", "polymer"] :
@@ -276,15 +222,7 @@ defn check-electrolytic-capacitor (c:JITXObject) :
 ; Checks if the peak current through the cap is above the rated
 ; value.
 pcb-check electrolytic-cap-current (c:JITXObject) :
-  #CHECK(
-    condition = has-property?(c.rated-current-pk)
-    name = NAME
-    description = DESCRIPTION
-    category = CATEGORY
-    subcheck-description = "Check if the capacitor has a peak current rating."
-    info-message = "%_ is missing the `rated-current-pk` property"
-    pass-message = "%_ has the `rated-current-pkg` property"
-  )
+  check-has-properties(NAME, c, [`rated-current-pk, `operating-point])
 
   val rated-current-pk = property(c.rated-current-pk)
   val peak-current     = property(c.operating-point)
@@ -295,7 +233,7 @@ pcb-check electrolytic-cap-current (c:JITXObject) :
   #CHECK(
     condition =  ipk < rated-current-pk,
     name        = NAME
-    description = DESCRIPTION
+    description = description(c)
     category    = CATEGORY
     subcheck-description = "Check the capacitor peak current matches the rated peak current",
     pass-message = "%_ peak current %_A is compatible with the rated peak current %_A" 
@@ -310,5 +248,5 @@ pcb-check electrolytic-cap-current (c:JITXObject) :
 ;==============================================================================
 defn check-mica-film-capacitor (c:JITXObject) :
   inside pcb-module :
-    check capacitor-voltage(c, false, DERATE-CAPACITOR-MICA-VPK)  
     check capacitor-temp(c, false, DERATE-CAPACITOR-MICA-TEMP)
+    check capacitor-voltage(c, false, DERATE-CAPACITOR-MICA-VPK)  

--- a/utils/passive-checks/inductor-checks.stanza
+++ b/utils/passive-checks/inductor-checks.stanza
@@ -11,17 +11,16 @@ defpackage ocdb/utils/passive-checks/inductor-checks :
   import ocdb/utils/generator-utils
 
 val NAME        = "Inductor Checks"
-val DESCRIPTION = "Check inductor component properties"
+defn description (r:JITXObject) :
+  "%_ inductor properties" % [context(r)]
+
 
 doc: \<s> 
   Assigns checks to a single inductor component.
 <s>
 public defn check-inductor (l:JITXObject) :
-  check-inductor-preconditions(l)
-
-  if can-run-inductor-checks?(l) :
-    inside pcb-module :
-      check inductor-power(l)
+  inside pcb-module :
+    check inductor-power(l)
 
 ; TODO: once inside pcb-check lands, reuse/chain logic
 defn can-run-inductor-checks? (l:JITXObject) -> True|False :
@@ -30,33 +29,13 @@ defn can-run-inductor-checks? (l:JITXObject) -> True|False :
     acc = acc and has-property?(l.prop)
   acc
 
-; Checks an inductor component to see if it has the appropriate properties
-defn check-inductor-preconditions (l:JITXObject) :
-  #for prop in [operating-point, rated-power, inductance, dc-resistance] :
-    pcb-check prop (c:JITXObject) :
-      val [pass?, sub-dsc, msg] = 
-        within has-prop-msg(l, `prop) :
-          One(has-property?(l.prop))
-      #CHECK(
-        condition = pass?
-        name = NAME
-        description = DESCRIPTION
-        category = CATEGORY
-        subcheck-description = sub-dsc
-        info-message = msg
-        pass-message = msg
-        locators = [l]
-      )
-
-  inside pcb-module :
-    check operating-point(l)
-    check rated-power(l)
-    check inductance(l)
-    check dc-resistance(l)
-
 ; Check that the power consumed by an inductor is 
 ; below the derated maximum power.
 pcb-check inductor-power (l:JITXObject) :
+  check-has-properties(NAME, l, [`operating-point, 
+                                 `rated-power, 
+                                 `inductance, 
+                                 `dc-resistance])
   val operating-point = property(l.operating-point)
   val rated-power     = property(l.rated-power)
   val inductance      = property(l.inductance)
@@ -71,7 +50,7 @@ pcb-check inductor-power (l:JITXObject) :
   #CHECK(
     condition = power < rated-power*
     name = NAME
-    description = DESCRIPTION
+    description = description(l)
     category = CATEGORY
     subcheck-description = "Check that inductor power derating meets the design requirements"
     pass-message = "Derated power for %_ meets the design requirements: %_W < %_W"

--- a/utils/passive-checks/inductor-checks.stanza
+++ b/utils/passive-checks/inductor-checks.stanza
@@ -14,7 +14,6 @@ val NAME        = "Inductor Checks"
 defn description (r:JITXObject) :
   "%_ inductor properties" % [context(r)]
 
-
 doc: \<s> 
   Assigns checks to a single inductor component.
 <s>

--- a/utils/passive-checks/resistor-checks.stanza
+++ b/utils/passive-checks/resistor-checks.stanza
@@ -16,17 +16,16 @@ defpackage ocdb/utils/passive-checks/resistor-checks :
 ;==============================================================================
 ; Some common values re-used in this package
 val NAME        = "Resistor Checks"
-val DESCRIPTION = "Check resistor component properties"
 
+defn description (r:JITXObject) :
+  "%_ resistor properties" % [context(r)]
 
 doc: \<s> 
   Assigns checks to a single resistor component.
 <s>
 public defn check-resistor (r:JITXObject) :
-  check-resistor-preconditions(r)
-  if can-run-resistor-checks?(r) :
-    inside pcb-module :
-      check resistor-power(r)
+  inside pcb-module :
+    check resistor-power(r)
 
 ; TODO: once inside pcb-check lands, reuse/chain logic
 defn can-run-resistor-checks? (r:JITXObject) -> True|False :
@@ -35,32 +34,11 @@ defn can-run-resistor-checks? (r:JITXObject) -> True|False :
     acc = acc and has-property?(r.prop)
   acc
 
-; Checks a resistor component to see if it has the appropriate properties
-defn check-resistor-preconditions (r:JITXObject) :
-  #for prop in [resistance, operating-point, rated-power] :
-    pcb-check prop (r:JITXObject) :
-      val [pass?, sub-dsc, msg] = 
-        within has-prop-msg(r, `prop) :
-          One(has-property?(r.prop))
-      #CHECK(
-        condition = pass?
-        name = NAME
-        description = DESCRIPTION
-        category = CATEGORY
-        subcheck-description = sub-dsc
-        info-message = msg
-        pass-message = msg
-        locators = [r]
-      )
-    
-  inside pcb-module :
-    check resistance(r)
-    check operating-point(r)
-    check rated-power(r)
-
 ; Check that the power consumed by a resistor is 
 ; below the derated maximum power.
 pcb-check resistor-power (r:JITXObject) :
+  check-has-properties(NAME, r, [`operating-point, `resistance, `rated-power])
+
   val op-point    = property(r.operating-point)
   val resistance  = property(r.resistance)
   val rated-power = property(r.rated-power)
@@ -75,7 +53,7 @@ pcb-check resistor-power (r:JITXObject) :
   #CHECK(
     condition = power < rated-power*
     name = NAME
-    description = DESCRIPTION
+    description = description(r)
     category = CATEGORY
     subcheck-description = "Check that resistor power derating meets the design requirements"
     pass-message = "Derated power for %_  meets the design requirements: %_W < %_W"

--- a/utils/passive-checks/resistor-checks.stanza
+++ b/utils/passive-checks/resistor-checks.stanza
@@ -38,7 +38,6 @@ defn can-run-resistor-checks? (r:JITXObject) -> True|False :
 ; below the derated maximum power.
 pcb-check resistor-power (r:JITXObject) :
   check-has-properties(NAME, r, [`operating-point, `resistance, `rated-power])
-
   val op-point    = property(r.operating-point)
   val resistance  = property(r.resistance)
   val rated-power = property(r.rated-power)

--- a/utils/passive-checks/resonator-checks.stanza
+++ b/utils/passive-checks/resonator-checks.stanza
@@ -59,7 +59,7 @@ public pcb-check resonator-frequency-check (o:JITXObject, intf:CrystalOscillator
   #CHECK(
     condition = frequency(property(o.crystal-resonator)) == frequency(intf),
     name = NAME
-    description = description(x)
+    description = description(o)
     category = CATEGORY
     subcheck-description = "Check the crystal has the correct frequency which meets the design specs",
     pass-message = "Crystal %_ does have the correct frequency %_ to meet design specs %_" 
@@ -79,7 +79,7 @@ public pcb-check resonator-gain-check (o:JITXObject, intf:CrystalOscillator, loa
   #CHECK(
     condition = gain < max-critical-gain(intf),
     name = NAME
-    description = description(x)
+    description = description(o)
     category = CATEGORY
     subcheck-description = "Check the crystal circuit gain meets the design criteria for max-critical-gain",
     pass-message = "Crystal %_ gain %_ meets the design criteria for max-critical-gain %_" 
@@ -97,7 +97,7 @@ public pcb-check resonator-drive-check (o:JITXObject, intf:CrystalOscillator, lo
   #CHECK(
     condition = drive-level(intf) <= max-drive-level(property(o.crystal-resonator)),
     name = NAME
-    description = description(x)
+    description = description(o)
     category = CATEGORY
     subcheck-description = "Check the crystal resonator circuit has the correct drive-level property to match crystal",
     pass-message = "Crystal circuit %_ has the correct drive-level property %_ that matches the crystal spec %_" 
@@ -120,7 +120,7 @@ public pcb-check resonator-pullability-check (o:JITXObject, intf:CrystalOscillat
   #CHECK(
     condition = frequency-tolerance(op) + freq-error < frequency-tolerance(intf),
     name = NAME
-    description = description(x)
+    description = description(o)
     category = CATEGORY
     subcheck-description = "Check the crystal frequency tolerance with pullability meets the design specification",
     pass-message = "Crystal %_ has the correct frequency tolerance %_ that meets the design spec %_" 

--- a/utils/passive-checks/resonator-checks.stanza
+++ b/utils/passive-checks/resonator-checks.stanza
@@ -12,19 +12,19 @@ defpackage ocdb/utils/passive-checks/resonator-checks :
   import ocdb/utils/generator-utils
 
 val NAME        = "Crystal Resonator Checks"
-val DESCRIPTION = "Check crystal resonator component properties"
+
+defn description (r:JITXObject) :
+  "%_ crystal resonator properties" % [context(r)]
 
 doc: \<s> 
   Assigns checks to a single crystal oscillator component.
 <s>
 public defn check-resonator (x:JITXObject, intf:CrystalOscillator, load-cap:JITXObject) :
-  check-resonator-preconditions(x)
-  if can-run-resonator-checks?(x) :
-    inside pcb-module :
-      check resonator-frequency-check(x, intf)
-      check resonator-gain-check(x, intf, load-cap)
-      check resonator-drive-check(x, intf, load-cap)
-      check resonator-pullability-check(x, intf, load-cap)
+  inside pcb-module :
+    check resonator-frequency-check(x, intf)
+    check resonator-gain-check(x, intf, load-cap)
+    check resonator-drive-check(x, intf, load-cap)
+    check resonator-pullability-check(x, intf, load-cap)
 
 ; TODO: once inside pcb-check lands, reuse/chain logic
 defn can-run-resonator-checks? (x:JITXObject) -> True|False :
@@ -40,7 +40,7 @@ defn check-resonator-preconditions (x:JITXObject) :
       #CHECK(
         condition = pass?
         name = NAME
-        description = DESCRIPTION
+        description = description(x)
         category = CATEGORY
         subcheck-description = sub-dsc
         info-message = msg
@@ -53,11 +53,13 @@ defn check-resonator-preconditions (x:JITXObject) :
 
 ; Checks the frequency of an oscillator (o) against an interface on an IC (intf)
 public pcb-check resonator-frequency-check (o:JITXObject, intf:CrystalOscillator) :
+  check-has-properties(NAME, o, [`crystal-resonator])
+
   ; Check critical gain point to ensure oscillation
   #CHECK(
     condition = frequency(property(o.crystal-resonator)) == frequency(intf),
     name = NAME
-    description = DESCRIPTION
+    description = description(x)
     category = CATEGORY
     subcheck-description = "Check the crystal has the correct frequency which meets the design specs",
     pass-message = "Crystal %_ does have the correct frequency %_ to meet design specs %_" 
@@ -69,13 +71,15 @@ public pcb-check resonator-frequency-check (o:JITXObject, intf:CrystalOscillator
 
 ; Checks the critical gain of an oscillator (o) against an interface on an IC (intf)
 public pcb-check resonator-gain-check (o:JITXObject, intf:CrystalOscillator, load-cap:JITXObject) :
+  check-has-properties(NAME, o, [`crystal-resonator])
+
   ; Check critical gain point to ensure oscillation
   val op = property(o.crystal-resonator)
   val gain = 4.0 * ESR(op) * pow(2.0 * PI * frequency(op), 2.0) * pow(shunt-capacitance(op) + load-capacitance(op), 2.0)
   #CHECK(
     condition = gain < max-critical-gain(intf),
     name = NAME
-    description = DESCRIPTION
+    description = description(x)
     category = CATEGORY
     subcheck-description = "Check the crystal circuit gain meets the design criteria for max-critical-gain",
     pass-message = "Crystal %_ gain %_ meets the design criteria for max-critical-gain %_" 
@@ -87,11 +91,13 @@ public pcb-check resonator-gain-check (o:JITXObject, intf:CrystalOscillator, loa
 
 ; Checks the drive level of an oscillator (o) against an interface on an IC (intf)
 public pcb-check resonator-drive-check (o:JITXObject, intf:CrystalOscillator, load-cap:JITXObject) :
+  check-has-properties(NAME, o, [`crystal-resonator])
+
   ; Check drive level against crystal maximum
   #CHECK(
     condition = drive-level(intf) <= max-drive-level(property(o.crystal-resonator)),
     name = NAME
-    description = DESCRIPTION
+    description = description(x)
     category = CATEGORY
     subcheck-description = "Check the crystal resonator circuit has the correct drive-level property to match crystal",
     pass-message = "Crystal circuit %_ has the correct drive-level property %_ that matches the crystal spec %_" 
@@ -103,41 +109,18 @@ public pcb-check resonator-drive-check (o:JITXObject, intf:CrystalOscillator, lo
 
 ; Check pullability of crystal to ensure accuracy
 public pcb-check resonator-pullability-check (o:JITXObject, intf:CrystalOscillator, load-cap:JITXObject) :
+  check-has-properties(NAME, load-cap, [`tolerance, `capacitance])
+  check-has-properties(NAME, o, [`crystal-resonator])
+
   val op = property(o.crystal-resonator)
   val pullability = motional-capacitance(op) / (2.0 * pow(shunt-capacitance(op) + load-capacitance(op), 2.0))
   
-  #CHECK(
-    condition = has-property?(load-cap.tolerance),
-    name = NAME
-    description = DESCRIPTION
-    category = CATEGORY
-    subcheck-description = "Check the crystal-tuning capacitor has the correct tolerance property",
-    pass-message =  "Capacitor %_ has the correct tolerance property for crystal tuning" 
-      % [context(load-cap)],
-    fail-message = "Capacitor %_ does not have the correct tolerance property for crystal tuning"
-       % [context(load-cap)],
-    locators = [load-cap]
-  )
-
-  #CHECK(
-    condition = has-property?(load-cap.capacitance),
-    name = NAME
-    description = DESCRIPTION
-    category = CATEGORY
-    subcheck-description = "Check the crystal-tuning capacitor has the correct capacitance property",
-    pass-message = "Capacitor %_ has the correct capacitance property for crystal tuning" 
-      % [context(load-cap)],
-    fail-message = "Capacitor %_ does not have the correct capacitance property for crystal tuning" 
-      % [context(load-cap)],
-    locators = [load-cap]
-  )
-
   val dC = (property(load-cap.capacitance) as Double) * (property(load-cap.tolerance)[1] as Double)
   val freq-error = (pullability as Double) * (dC as Double) * frequency(op)
   #CHECK(
     condition = frequency-tolerance(op) + freq-error < frequency-tolerance(intf),
     name = NAME
-    description = DESCRIPTION
+    description = description(x)
     category = CATEGORY
     subcheck-description = "Check the crystal frequency tolerance with pullability meets the design specification",
     pass-message = "Crystal %_ has the correct frequency tolerance %_ that meets the design spec %_" 

--- a/utils/passive-checks/utils.stanza
+++ b/utils/passive-checks/utils.stanza
@@ -1,3 +1,4 @@
+#use-added-syntax(jitx)
 defpackage ocdb/utils/passive-checks/utils :
   import core
   import collections
@@ -10,6 +11,30 @@ public defn context (c:JITXObject) :
 
 doc:"Category used by passive component checks."
 public val CATEGORY = "Component Checks"
+
+doc:"Make sure that a component has the correct properties."
+public defn check-has-properties (name:String, 
+                                  thing:JITXObject, 
+                                  properties:Tuple<Symbol>) :
+  val missing = 
+    for prop in properties seq? :
+      match(get-property?(thing, prop)) : 
+        (one:One)   : None()
+        (none:None) : One(prop)
+
+  val condition = not empty?(missing)
+  val pass = "%_ has properties %," % [context(thing), properties]
+  val fail = "%_ is missing a properties %," % [context(thing), missing]
+
+  #CHECK( condition   = condition
+          name        = name
+          locators    = [thing, originating-instantiable(thing)]
+          description = "%_ data consistency" % [context(thing)]
+          category    = "%_ (Data)" % [CATEGORY]
+          subcheck-description = "%_ has properties %," % [context(thing), properties] 
+          info-message = pass
+          pass-message = fail )
+
 
 doc:"Helper to check if a component has a property."
 public defn has-prop-msg (condition: () -> Maybe<True|False>, 

--- a/utils/passive-checks/utils.stanza
+++ b/utils/passive-checks/utils.stanza
@@ -22,9 +22,9 @@ public defn check-has-properties (name:String,
         (one:One)   : None()
         (none:None) : One(prop)
 
-  val condition = not empty?(missing)
-  val pass = "%_ has properties %," % [context(thing), properties]
-  val fail = "%_ is missing a properties %," % [context(thing), missing]
+  val condition = empty?(missing)
+  val pass = "%_ has properties: %," % [context(thing), properties]
+  val fail = "%_ is missing properties: %," % [context(thing), missing]
 
   #CHECK( condition   = condition
           name        = name
@@ -32,8 +32,8 @@ public defn check-has-properties (name:String,
           description = "%_ data consistency" % [context(thing)]
           category    = "%_ (Data)" % [CATEGORY]
           subcheck-description = "%_ has properties %," % [context(thing), properties] 
-          info-message = pass
-          pass-message = fail )
+          info-message = fail
+          pass-message = pass )
 
 
 doc:"Helper to check if a component has a property."

--- a/utils/pin-checks/all.stanza
+++ b/utils/pin-checks/all.stanza
@@ -9,46 +9,12 @@ defpackage ocdb/utils/pin-checks/all :
   import ocdb/utils/pin-checks/power-pin-checks
   import ocdb/utils/pin-checks/reset-pin-checks
 
+
 doc: "Check the pins of an instance."
 public defn check-pins (instance:JITXObject) :
   for pin in pins(instance) do :
-    check-connectivity(pin)
     check-generic-pin(pin)      when has-property?(pin.generic-pin)
     check-power-pin(pin)        when has-property?(pin.power-pin)
     ; check-power-supply-pin(pin) when has-property?(pin.power-supply-pin)
     check-reset-pin(pin)        when has-property?(pin.reset-pin)
 
-defn check-connectivity (p:JITXObject) :
-  inside pcb-module :
-    check connectivity(p)
-
-; Checks that a pin is connected (or not). 
-; if no connect, fail if connected. If not no connect, fail if unconnected.
-pcb-check connectivity (p:JITXObject) :
-  val connected-pins = connected-pins(p)
-  if no-connect?(p) :
-    #CHECK(
-      condition = empty?(connected-pins)
-      name = "Pin Connectivity"
-      category = CATEGORY
-      description = "Check that a no-connect pin is not connected"
-      subcheck-description = "Check that no-connect pins are not connected"
-      pass-message = "%_ is marked no-connect and not connected"
-        % [context(p)]
-      fail-message = "%_ is marked no-connected, but is connected to other pins: %,"
-        % [context(p), seq(context, connected-pins)] 
-      locators = [p]
-    )
-  else :
-    #CHECK(
-      condition = connected?(p)
-      name = "Pin Connectivity"
-      category = CATEGORY
-      description = "Check that a pin is connected"
-      subcheck-description = "Check that pins are connected"
-      pass-message = "%_ is connected to %,"
-        % [context(p), seq(context, connected-pins)]
-      fail-message = "%_ is unconnected but not marked no-connect" 
-        % [context(p)]
-      locators = [p]
-    )

--- a/utils/propagation.stanza
+++ b/utils/propagation.stanza
@@ -1,0 +1,4 @@
+defpackage ocdb/utils/propagation :
+  import core
+
+public var PROPAGATION-FINISHED : True|False = false

--- a/utils/property-structs.stanza
+++ b/utils/property-structs.stanza
@@ -14,6 +14,12 @@ public pcb-struct ocdb/utils/property-structs/OperatingPoint :
   peak-voltage:Toleranced
   peak-current:Toleranced
 
+defmethod print (o:OutputStream, op:OperatingPoint) :
+  print(o, "OperatingPoint(peak-voltage: %_, peak-current: %_)" % [
+    peak-voltage(op),
+    peak-current(op)
+  ])
+
 public pcb-struct ocdb/utils/property-structs/PowerRail :
   rail:JITXObject
   voltage:Toleranced

--- a/utils/stm.stanza
+++ b/utils/stm.stanza
@@ -284,7 +284,6 @@ public defn create-pin-properties (json1:JSON) -> STMPinProperties :
               "Left" : Left,
               "Right" : Right
           (side-val) : stm-exception!("Invalid Pin Name")
-        
         val power-props? = match(pin-item["power-pin?"]) :
           (power-val:True) : power-val
           (power-val:False) : power-val


### PR DESCRIPTION
- run-design has a final eval-when statement to force i/o checks after propagation of net-voltages
- changed description in checks to contain refs
- removed connectivity check for pins and added single-pin-net check
- removed conditional check generation, moved to info check in passive-checks/utils