### PR TITLE
Side to side

### DIFF
--- a/components/korean-hroparts-elec/TYPE-C-31-M-12.stanza
+++ b/components/korean-hroparts-elec/TYPE-C-31-M-12.stanza
@@ -76,7 +76,7 @@ public pcb-component component :
   reference-prefix = "J"
   ; datasheet = "https://datasheet.lcsc.com/lcsc/2205251630_Korean-Hroparts-Elec-TYPE-C-31-M-12_C165948.pdf"
   pin-properties :
-    [pin:Ref | pads:Ref ... | Side:Dir]
+    [pin:Ref | pads:Ref ... | side:Dir]
     [VBUS | A4-B9 B4-A9 | Right]
     [CC1 | A5 | Right]
     [CC2 | B5 | Right]


### PR DESCRIPTION
Fix property name typo in USB-C.
This error encourages the `pin-properties` macro to warn the user when they use a property with wrong case.