### PR TITLE
Add two fixes to the voltage propagation utility

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.7-dev.1
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.7-dev.2
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -17,6 +17,7 @@ defpackage ocdb/utils/generator-utils:
   import ocdb/utils/bundles
   import ocdb/utils/relative-voltages
   import ocdb/utils/propagation
+  import ocdb/utils/voltage-propagation
 
 ; =======================================
 ; Ciruit convenience functions
@@ -288,36 +289,68 @@ defn net-voltage! (voltages: Tuple<Toleranced>, item: ConnectedItems) -> Toleran
 ; Run transformations to propagate voltages from sources, and run delayed evaluations
 ; =======================================
 public defn run-final-passes (module:Instantiable) -> Instantiable :
-  val result-module = transform-module{calculate-operating-points, _} $
-    let loop (design: Instantiable = module, i: Int = 0) :
-      defn run-eval-loop (design: Instantiable) :
-        val design* = run-evals?(design)
-        match(design*: Instantiable) : loop(design*, i + 1)
-        else : design
+  ;Helper: Throw error message indicating that the maximum number of iterations
+  ;has been reached.
+  defn throw-max-iterations-error () :
+    val msg = "The 'run-final-passes' utility has reached the maximum number of iterations without \
+               converging. This occurs most commonly when an 'eval-when' block generates more \
+               'eval-when' blocks which contain further 'eval-when' blocks."
+    throw(Exception(msg))           
 
-      if i == 5 :
-        throw $ Exception("A loop executing eval-whens, propagating net voltages and assigning pins has been \
-                           encountered: 5 iterations reached. Check that no eval-when generate other eval-whens in an \
-                           infinite loop, or that there is no infinite loop of 2nd order between eval-when execution \
-                           and net voltage propagation or pin assignment.")
-      
-      
-      ;TODO: Review the order and necessity of those algos
-      val filename = to-string("voltage-propagation-iteration%_.txt" % [i])
-      design $> ocdb/utils/voltage-propagation/propagate-voltages{_, filename}
-             ;$> transform-module{propagate-net-voltages, _}
-             ;$> transform-module{propagate-relative-voltages, _}
-             $> assign-pins
-             $> run-eval-loop
-  
+
+  ;On each iteration:
+  ;  1) Assign pins
+  ;  2) Propagate voltages.
+  ;  3) Run eval whens
+  ;  4) If progress is made, then loop again if the total number of iterations
+  ;     hasn't been reached.
+  ;Arguments:
+  ;- num-iterations: The number of iterations performed thus far.
+  ;  On the initial call, this starts from 0.
+  defn iteratively-run-eval-whens (design:Instantiable,
+                                   num-iterations:Int) -> Instantiable :
+    val max-iterations = 5
+    val voltage-prop-report = to-string("voltage-propagation-iteration%_.txt" % [num-iterations])
+    val assigned-pins = assign-pins(design)
+    val annotated-voltages = propagate-voltages(assigned-pins, voltage-prop-report)
+    val new-design = run-evals?(annotated-voltages)
+    match(new-design:Instantiable) :
+      val new-num-iterations = num-iterations + 1
+      if new-num-iterations < max-iterations :
+        iteratively-run-eval-whens(new-design, new-num-iterations)
+      else :
+        throw-max-iterations-error()
+    else :
+      annotated-voltages
+
+  ;Main flow:
+  ;  1) Iteratively run evals
+  ;  2) Calculate the operating points.
+  ;  3) Iteratively run evals to finish.
+  ;  4) Flag the global variable PROPAGATION-FINISHED as true.
+  ;  5) Now that it is flagged, run evals one last time.
+
+  ;Steps 1, 2, 3:
+  val new-design = module
+                $> iteratively-run-eval-whens{_, 0}
+                $> transform-module{calculate-operating-points, _}
+                $> iteratively-run-eval-whens{_, 0}
+  set-main-module(new-design)
+
+  ;Step 4.
   PROPAGATION-FINISHED = true
-  val final-module = run-evals(result-module)
-  
-  ; If we did not set the main module, a user forgetting to set it himself on the new module would be exporting
-  ; the module before adding operating points (the main module is set in the loop to be able to assign pins).
-  ; Such bug would be invisible.
-  set-main-module(final-module)
-  final-module
+
+  ;Step 5.
+  match(run-evals?(new-design)) :
+    ;Case: Evals were ran. Set it as the main module, and
+    ;return it.
+    (design:Instantiable) :
+      set-main-module(design)
+      design
+      
+    ;Case: Nothing ran, just return the design as is.
+    (f:False) :
+      new-design
 
 ; FIXME: assign-pins was obviously not meant to be used like this, it depends on the flattening
 ; Is run-evals? actually accessing the information resulting from the pin assignment?

--- a/utils/voltage-propagation.stanza
+++ b/utils/voltage-propagation.stanza
@@ -28,31 +28,33 @@ public defn propagate-voltages (module:Instantiable, report-file:String|False) -
 
     ;Perform voltage propagation here.
     val [group-voltages, object-voltages] = propagate-relative-relations(
-                                              starting-points,
+                                              groups(starting-points),
                                               relations)
 
     ;Check for any inconsistencies now that all voltages are solved.
     val inconsistencies = check-consistency(
-                            starting-points,
+                            groups(starting-points),
                             group-voltages,
                             object-voltages,
                             relations)
 
-    ;Generate a human-readable report of the algorithm results, and
-    ;save it to a file.
+    ;Generate a human-readable report of the algorithm results.
+    val report = generate-report(connected-groups,
+                                 starting-points,
+                                 relations,
+                                 group-voltages,
+                                 object-voltages,
+                                 inconsistencies)
+    ;Write the entirety of the report to a file, if desired.
     match(report-file:String) :
-      val report = generate-report(connected-groups,
-                                   starting-points,
-                                   relations,
-                                   group-voltages,
-                                   object-voltages,
-                                   inconsistencies)
       spit(report-file, report)
-      ;println("Voltage propagation report saved to %~." % [report-file])
-  
+      
+    ;Print out just the inconsistency section to the screen.
+    print(/inconsistencies(report))
+
     ;Backannotate the design and write out all of the new solved voltages.
     back-annotate-design(connected-groups,
-                         starting-points,
+                         groups(starting-points),
                          group-voltages,
                          object-voltages)
 
@@ -99,7 +101,7 @@ defn collect-connected-groups () -> Tuple<ConnectedGroup> :
   ;for each.
   val groups = Vector<ConnectedGroup>()
   for items in all-connected-items(self) do :
-  
+
     ;Bundle information into an item.
     defn make-item (obj:JITXObject, type:ItemType) -> Item :
       Item(obj, type, property?(obj.net-voltage))
@@ -133,7 +135,7 @@ defn collect-connected-groups () -> Tuple<ConnectedGroup> :
   for item in all-items-with-properties(self, [`net-voltage]) do :
     if not group-set[object(item)] :
       val voltage = value(item)
-      if voltage is Double|Toleranced :      
+      if voltage is Double|Toleranced :
         val group-item = Item(object(item), ComponentPinType, One(voltage))
         add(groups, ConnectedGroup(next(id-counter), [group-item]))
 
@@ -143,6 +145,17 @@ defn collect-connected-groups () -> Tuple<ConnectedGroup> :
 ;============================================================
 ;============= Discover the Starting Points =================
 ;============================================================
+
+;Represents the result of the starting point analysis.
+defstruct StartingPoints :
+  groups:Tuple<GroupVoltage>
+  groups-with-multiple-voltages:Tuple<MultiVoltageGroup>
+
+;Represents a group containing multiple items with different
+;absolute voltages.
+defstruct MultiVoltageGroup :
+  id:Int
+  items:Tuple<Item>
 
 ;Represents a group with a known voltage.
 ;- id: The identifier of the group.
@@ -160,7 +173,7 @@ defn voltage (v:GroupVoltage) -> Double|Toleranced :
 ;we know the absolute voltage. Find all the starting points
 ;for the propagation algorithm.
 
-defn starting-points (groups:Tuple<ConnectedGroup>) -> Vector<GroupVoltage> :
+defn starting-points (groups:Tuple<ConnectedGroup>) -> StartingPoints :
 
   ;Return true if the item has an absolute voltage.
   ;Checks whether its voltage is Double|Toleranced.
@@ -181,17 +194,41 @@ defn starting-points (groups:Tuple<ConnectedGroup>) -> Vector<GroupVoltage> :
   ;Accumulate all the starting points here.
   val starting-points = Vector<GroupVoltage>()
 
+  ;Accumulate all the groups with multiple voltages here.
+  val multi-voltage-groups = Vector<MultiVoltageGroup>()
+
   ;Scan through each group and check whether there exists
   ;an item with an absolute voltage. If there is, then add
   ;a new GroupVoltage object to 'starting-points'.
   for group in groups do :
-    val annotated-items = filter(has-absolute-voltage?, items(group))
+    val annotated-items = to-tuple $
+      filter(has-absolute-voltage?, items(group))
     if not empty?(annotated-items) :
+      ;Select the most specific source to proceed with
+      ;the rest of the algorithm.
       val source = minimum(specificity, annotated-items)
-      add(starting-points, GroupVoltage(id(group), source))        
+      add(starting-points, GroupVoltage(id(group), source))
+      
+      ;If there are ambiguities, then record that for the
+      ;error report later.
+      if length(annotated-items) > 1 :
+        ;Return true if a and b have the same voltage.
+        defn same-voltage? (a:Item, b:Item) -> True|False :
+          value!(voltage(a)) == value!(voltage(b))
+
+        ;Compute whether all of the items in the group have the
+        ;same absolute voltage.
+        val all-same-voltage? = 
+          for i in 1 to length(annotated-items) all? :
+            same-voltage?(annotated-items[i], annotated-items[0])
+            
+        ;If they do not, then add it to the error report.
+        if not all-same-voltage? :
+          add(multi-voltage-groups, MultiVoltageGroup(id(group), annotated-items))      
 
   ;Return all the starting points.
-  starting-points
+  StartingPoints(to-tuple(starting-points)
+                 to-tuple(multi-voltage-groups))
 
 ;============================================================
 ;============ Discover Relative Voltage Relations ===========
@@ -233,7 +270,7 @@ defn relative-relations (groups:Tuple<ConnectedGroup>) -> Vector<RelativeRelatio
 
   ;An entry, OBJ => G, means that object 'OBJ' is in connected group 'G'.
   val group-table = HashTable<JITXObject,Int>()
-  
+
   ;An entry, OBJ => ITEM, means that object 'OBJ' corresponds to item 'ITEM'.
   val item-table = HashTable<JITXObject,Item>()
 
@@ -287,7 +324,7 @@ defstruct ObjectVoltageFromRelativeRelation :
   relation:RelativeRelation
   voltage:Double|Toleranced
 
-defn propagate-relative-relations (start:Vector<GroupVoltage>,
+defn propagate-relative-relations (start:Tuple<GroupVoltage>,
                                    relations:Vector<RelativeRelation>)
                                 ->[Vector<GroupVoltageFromRelativeRelation>
                                    Vector<ObjectVoltageFromRelativeRelation>]:
@@ -357,7 +394,7 @@ defn propagate-relative-relations (start:Vector<GroupVoltage>,
 
   ;Propagate voltages until we make no more progress.
   let loop () :
-  
+
     ;Track whether we made progress on this iteration.
     var progress? = false
 
@@ -367,7 +404,7 @@ defn propagate-relative-relations (start:Vector<GroupVoltage>,
       if not key?(voltage-table, key(entry)) :
         if compute-voltage(key(entry), value(entry)) :
           progress? = true
-          
+
     ;If progress was made, then iterate again.
     loop() when progress?
 
@@ -379,7 +416,7 @@ defn propagate-relative-relations (start:Vector<GroupVoltage>,
       if applicable-primary-relation?(r) :
         val voltage = resolve-voltage(r)
         add(object-voltages, ObjectVoltageFromRelativeRelation(target(r), r, voltage))
-    
+
   ;Return the results
   [new-voltages, object-voltages]
 
@@ -405,11 +442,11 @@ defstruct InconsistentRelation :
   anchor-voltage: Double|Toleranced
   relation:RelativeRelation
 
-defn check-consistency (start:Vector<GroupVoltage>
+defn check-consistency (start:Tuple<GroupVoltage>
                         group-voltages:Vector<GroupVoltageFromRelativeRelation>
                         object-voltages:Vector<ObjectVoltageFromRelativeRelation>
                         relations:Vector<RelativeRelation>) :
-  ;Build table of voltages. 
+  ;Build table of voltages.
   val group-voltage-table = IntTable<Double|Toleranced>()
   val object-voltage-table = HashTable<JITXObject,Double|Toleranced>()
   for v in start do :
@@ -456,7 +493,7 @@ defn check-consistency (start:Vector<GroupVoltage>
 ;'.net-voltage' properties in the design.
 
 defn back-annotate-design (groups:Tuple<ConnectedGroup>,
-                           start:Vector<GroupVoltage>
+                           start:Tuple<GroupVoltage>
                            group-voltages:Vector<GroupVoltageFromRelativeRelation>
                            object-voltages:Vector<ObjectVoltageFromRelativeRelation>) :
   inside pcb-module :
@@ -500,7 +537,7 @@ defstruct ResultSummary :
 
 ;Summarize all of the solved and unsolved voltages.
 defn summarize-results (group:Tuple<ConnectedGroup>,
-                        starting-points:Vector<GroupVoltage>,
+                        starting-points:Tuple<GroupVoltage>,
                         group-voltages:Vector<GroupVoltageFromRelativeRelation>,
                         object-voltages:Vector<ObjectVoltageFromRelativeRelation>) -> ResultSummary :
   ;Build group table.
@@ -533,26 +570,33 @@ defn summarize-results (group:Tuple<ConnectedGroup>,
   ;Return summary.
   ResultSummary(
     to-tuple(solved),
-    unsolved)  
-    
+    unsolved)
+
 
 ;============================================================
 ;===================== Save Report ==========================
 ;============================================================
 
+;Represents the final report summary.
+deftype Report
+
+;Retrieve only the detected inconsistencies.
+defmulti inconsistencies (r:Report) -> ?
+
+;Compute a report summarizing the voltage propagation.
 defn generate-report (groups:Tuple<ConnectedGroup>,
-                      starting-points:Vector<GroupVoltage>,
+                      starting-points:StartingPoints,
                       relations:Vector<RelativeRelation>,
                       group-voltages:Vector<GroupVoltageFromRelativeRelation>,
                       object-voltages:Vector<ObjectVoltageFromRelativeRelation>,
-                      inconsistencies:Vector<InconsistentRelation>) :
+                      inconsistencies:Vector<InconsistentRelation>) -> Report :
 
   ;Summarize all of the results.
   val summary = summarize-results(groups,
-                                  starting-points,
+                                  /groups(starting-points),
                                   group-voltages,
                                   object-voltages)
-                      
+
   ;Helper: Return a human readable name for the given item if there
   ;is a sensible one.
   defn readable-name? (item:Item) -> String|False :
@@ -602,7 +646,7 @@ defn generate-report (groups:Tuple<ConnectedGroup>,
   ;Helper: Create a human readable description of the given relative relation.
   defn readable-relation (r:RelativeRelation) -> String :
     match(voltage(r)) :
-      (v:FractionalVoltage) :        
+      (v:FractionalVoltage) :
         to-string("voltage of %_ = %_ V * voltage of %_" % [target-name(r), factor(v), anchor-name(r)])
       (v:OffsetVoltage) :
         to-string("voltage of %_ = %_ V + voltage of %_" % [target-name(r), factor(v), anchor-name(r)])
@@ -611,7 +655,37 @@ defn generate-report (groups:Tuple<ConnectedGroup>,
   defn item-name (v:SolvedVoltage) -> String :
     readable-name(object(v), item(v))
 
-  new Printable :
+  ;Helper: Print out just the inconsistencies.
+  defn print-inconsistencies (o:OutputStream) -> False :
+      ;Shorthands
+      val o2 = IndentedStream(o)
+      val o3 = IndentedStream(o2)
+      defn Pln (x) : println(o, x)
+      defn Pln2 (x) : println(o2, x)
+      defn Pln3 (x) : println(o3, x)
+
+      ;Print out groups with multiple voltages.
+      for group in groups-with-multiple-voltages(starting-points) do :
+        Pln("Group %_ contains multiple items annotated with different absolute voltages:\n" % [id(group)])
+        for item in items(group) do :
+          Pln2("Voltage of %_ is %_\n" % [readable-name!(item), value!(voltage(item))])
+          
+      ;Print out inconsistencies in the voltage relationships.
+      for (err in inconsistencies, index in 1 to false) do :
+        val r = relation(err)
+        Pln2("%_) Inconsistency found. The following is specified:\n" % [index])
+        Pln3(readable-relation(r))
+        Pln2("")
+        Pln2("However:\n")
+        Pln3("voltage of %_ is %_\n" % [target-name(r), target-voltage(err)])
+        Pln3("voltage of %_ is %_\n" % [anchor-name(r), anchor-voltage(err)])      
+
+  new Report :
+    defmethod inconsistencies (this) :
+      new Printable :
+        defmethod print (o:OutputStream, this) :
+          print-inconsistencies(o)
+          
     defmethod print (o:OutputStream, this) :
       ;Shorthands
       val o2 = IndentedStream(o)
@@ -619,7 +693,7 @@ defn generate-report (groups:Tuple<ConnectedGroup>,
       defn Pln (x) : println(o, x)
       defn Pln2 (x) : println(o2, x)
       defn Pln3 (x) : println(o3, x)
-      
+
       Pln("### Performing voltage propagation analysis ###\n")
       Pln("Detect which items are electrically connected together:\n")
       for group in groups do :
@@ -634,7 +708,7 @@ defn generate-report (groups:Tuple<ConnectedGroup>,
       Pln("Voltage propagation starts by searching for items that have a\n\
            '.net-voltage' property of type 'Double' or 'Toleranced'.\n")
       Pln("The following starting points were found:\n")
-      for start in starting-points do :
+      for start in /groups(starting-points) do :
         Pln2("%_ in group %_ has voltage %_\n" % [readable-name!(source(start)), id(start), voltage(start)])
 
       Pln("### Relative Voltages ###\n")
@@ -647,7 +721,7 @@ defn generate-report (groups:Tuple<ConnectedGroup>,
         for r in relations do :
           Pln2(readable-relation(r))
           Pln2("")
-        
+
       Pln("### Propagation of Relative Voltages ###\n")
       Pln("From these relative voltages, we can compute the voltages of\n\
            other pins and nets.\n")
@@ -672,23 +746,22 @@ defn generate-report (groups:Tuple<ConnectedGroup>,
       Pln("### Final Check for Inconsistencies ###\n")
       Pln("Finally, check whether all the computed voltages are consistent\n\
            with what was declared in the design.\n")
-      if empty?(inconsistencies) :
+
+      ;Compute whether or not there are any inconsistencies.
+      val no-inconsistencies? = empty?(groups-with-multiple-voltages(starting-points))
+                            and empty?(inconsistencies)
+
+      ;If there are no inconsistencies
+      if no-inconsistencies? :
         Pln("No inconsistencies found.\n")
       else :
-        for (err in inconsistencies, index in 1 to false) do :
-          val r = relation(err)
-          Pln2("%_) Inconsistency found. The following is specified:\n" % [index])
-          Pln3(readable-relation(r))
-          Pln2("")
-          Pln2("However:\n")
-          Pln3("voltage of %_ is %_\n" % [target-name(r), target-voltage(err)])
-          Pln3("voltage of %_ is %_\n" % [anchor-name(r), anchor-voltage(err)])      
-          
+        print-inconsistencies(o)
+
       Pln("### Final Summary ###\n")
       Pln("Solved Voltages:\n")
       for s in solved(summary) do :
         Pln2("voltage of %_ is %_\n" % [item-name(s), voltage(s)])
-        
+
       Pln("Unsolved Voltages:\n")
       for group in unsolved(summary) do :
         Pln2("Connected group %_:" % [id(group)])
@@ -696,12 +769,12 @@ defn generate-report (groups:Tuple<ConnectedGroup>,
           match(readable-name?(item)) :
             (s:String) : Pln3(s)
             (f:False) : false
-        Pln2("")        
+        Pln2("")
 
 ;<doc>=======================================================
 ;===================== Report Example =======================
 ;============================================================
-      
+
 ### Performing voltage progagation analysis ###
 
 Detect which items are electrically connected together:
@@ -711,13 +784,13 @@ Detect which items are electrically connected together:
     component pin r[3]
     abstract pin r[4]
     net GND
-    
+
   Connected group 1:
     module pin r[3]
     component pin r[3]
     abstract pin r[4]
     net GND
-    
+
   etc...
 
 ### Starting Points ###
@@ -747,7 +820,7 @@ The following relative voltages were found:
 ### Propagation of Relative Voltages ###
 
 From these relative voltages, we can compute the voltages of
-other pins and nets. 
+other pins and nets.
 
 1) From knowing:
 


### PR DESCRIPTION
Add two fixes to the voltage propagation utility.
- Reworked run final passes to run in a more robust order. 
- Voltage propagation now checks for multiple conflicting voltages on the same net.