### PR TITLE
Multi part search

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -118,6 +118,12 @@ public defn Part (user-properties:Tuple<KeyValue>) -> Part :
                                                   user-properties]
   Part $ dbquery-first-allow-non-stock(query-properties) as JObject
 
+public defn Parts (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Part> :
+  val query-properties = remove-duplicate-keys $ [["_type" => "LCSC"],
+                                                  user-properties]
+  ;Query the database with the given properties
+  map{Part, _} $ dbquery(query-properties, limit) as Tuple<JObject>
+
 defn remove-duplicate-keys (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
   to-tuple $ to-hashtable<String, ?>(cat-all(hs))
 

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -143,6 +143,9 @@ public defn database-part (mpn: String, manufacturer: String) -> Instantiable :
 public defn database-part (user-properties:Tuple<KeyValue>) -> Instantiable :
   to-jitx $ Part(user-properties)
 
+public defn database-parts (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
+  map(to-jitx, Parts(user-params, limit))
+
 ; ========================================================
 ; ========== Generic passive components ==================
 ; ========================================================


### PR DESCRIPTION
Search of multiple parts at once is needed by the Component search UI

```
val parts = database-parts([], 2)
do(print-def, parts)
```

```
pcb-component D195 :
  name = "component"
  description = "62.5mW Thick Film Resistors 50V ±100ppm/℃ ±5% -55℃~+155℃ 22Ω 0402  Chip Resistor - Surface Mount ROHS"
  manufacturer = "RALEC"
  mpn = "RTT02220JTH"
  emodel = Resistor(22.0)
  pin-array p:pin[1, 2] (L205/D195) :
    pin p[1] (L203/D195)
    pin p[2] (L204/D195)
  property(L203/D195.pads) = [p[1]]
  property(L203/D195.side) = Left
  property(L203/D195.pin-properties-row-index) = 1
  property(L204/D195.pads) = [p[2]]
  property(L204/D195.side) = Right
  property(L204/D195.pin-properties-row-index) = 0
  property(L204/D195.electrical-type) = "Input"
  property(L203/D195.electrical-type) = "Input"
  package = D190 :
    L203/D195 => L194/D190
    L204/D195 => L193/D190
  symbol = D211 :
    L203/D195 => L213/D211
    L204/D195 => L215/D211
  property(self.ki_keywords) = "C102894"
  property(self.LCSC) = "C102894"
  property(self.metadata) = ["datasheets" => "https://datasheet.lcsc.com/lcsc/1811101103_RALEC-RTT02220JTH_C102894.pdf"]
  property(self.Package) = "0402"
  property(self.Price) = "20-180:0.000382857,200-580:0.000295714,600-1980:0.000250000,2000-9980:0.000228571,10000-10020:0.000201429,10040-19980:0.000201429,40000-:0.000197143,20000-39980:0.000198571"
  property(self.Second-Category) = "Chip Resistor - Surface Mount"
  property(self.Solder-Joint) = "2"
  property(self.First-Category) = "Resistors"
  property(self.Stock) = "196031"
  property(self.Library-Type) = "Extended"
pcb-component D202 :
  name = "component"
  description = "62.5mW Thick Film Resistors 50V ±100ppm/℃ ±1% -55℃~+155℃ 1kΩ 0402  Chip Resistor - Surface Mount ROHS"
  manufacturer = "YAGEO"
  mpn = "RC0402FR-071KL"
  emodel = Resistor(1000.0)
  pin-array p:pin[1, 2] (L218/D202) :
    pin p[1] (L216/D202)
    pin p[2] (L217/D202)
  property(L216/D202.pads) = [p[1]]
  property(L216/D202.side) = Left
  property(L216/D202.pin-properties-row-index) = 1
  property(L217/D202.pads) = [p[2]]
  property(L217/D202.side) = Right
  property(L217/D202.pin-properties-row-index) = 0
  property(L217/D202.electrical-type) = "Input"
  property(L216/D202.electrical-type) = "Input"
  package = D197 :
    L216/D202 => L201/D197
    L217/D202 => L200/D197
  symbol = D224 :
    L216/D202 => L226/D224
    L217/D202 => L228/D224
  property(self.ki_keywords) = "C106235"
  property(self.LCSC) = "C106235"
  property(self.metadata) = ["datasheets" => "https://datasheet.lcsc.com/lcsc/1809301716_YAGEO-RC0402FR-071KL_C106235.pdf"]
  property(self.Package) = "0402"
  property(self.Price) = "20-180:0.000467143,200-580:0.000358571,600-1980:0.000305714,2000-9980:0.000275714,10000-10020:0.000252857,10040-19980:0.000252857,40000-:0.000248571,20000-39980:0.000250000"
  property(self.Second-Category) = "Chip Resistor - Surface Mount"
  property(self.Solder-Joint) = "2"
  property(self.First-Category) = "Resistors"
  property(self.Stock) = "1088171"
  property(self.Library-Type) = "Extended"
```