### PR TITLE
add description for DESIGN-QUANTITY

### DIFF
--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -54,6 +54,8 @@ public var APPROVED-DISTRIBUTOR-LIST = ["Allied Electronics & Automation"
                                         "Future Electronics"
                                         "Mouser"
                                         "Newark"]
+
+; Set it to the number of boards you intend to fabricate. Used to find components in stock when pulling components from the JITX database.
 public var DESIGN-QUANTITY = 100
 
 ; Set it to false to error out when a part is not in stock.


### PR DESCRIPTION

add a description for DESIGN-QUANTITY.

See this comment on why this is added: https://linear.app/jitx/issue/JITX-3268#comment-58ae8a6e

(replacing https://github.com/JITx-Inc/open-components-database/pull/320, which mistakenly merged to `main` branch)