### PR TITLE
JITX-3926: add database-part()

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -17,8 +17,6 @@ defpackage ocdb/utils/db-parts :
   import ocdb/utils/defaults
   import ocdb/utils/landpatterns
   import ocdb/utils/generator-utils
-  import ocdb/utils/generic-components
-  import ocdb/utils/parts
   import ocdb/utils/property-structs
   import ocdb/utils/symbols
   import ocdb/utils/design-vars
@@ -58,27 +56,6 @@ public pcb-struct ocdb/utils/db-parts/SellerOfferPrice :
 
 defmethod print (o:OutputStream, s:SellerOfferPrice) : 
   print(o, "SellerOfferPrice(quantity = %_, converted-price = %_)" % [quantity(s), converted-price(s)])
-
-
-; ========================================================
-; ==================== PartsDB ===========================
-; ========================================================
-
-public defn ComponentCode (user-properties:Tuple<KeyValue>) -> ComponentCode :
-  val results = parts-db-query(user-properties, 1)
-  val first-result = results[0]
-  ComponentCode(first-result as JObject)
-
-public defn ComponentCodes (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<ComponentCode> :
-  map{ComponentCode, _} $ parts-db-query(user-properties, limit) as Tuple<JObject>
-
-defn parts-db-query (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<JSON> :
-  val query-properties = remove-duplicate-keys $ [
-    ["_type" => "parts-db"],
-    user-properties
-  ]
-  dbquery(query-properties, limit) as Tuple<JObject>
-
 
 ;============================================================
 ;====================== Resistor ============================

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -17,6 +17,8 @@ defpackage ocdb/utils/db-parts :
   import ocdb/utils/defaults
   import ocdb/utils/landpatterns
   import ocdb/utils/generator-utils
+  import ocdb/utils/generic-components
+  import ocdb/utils/parts
   import ocdb/utils/property-structs
   import ocdb/utils/symbols
   import ocdb/utils/design-vars
@@ -56,6 +58,27 @@ public pcb-struct ocdb/utils/db-parts/SellerOfferPrice :
 
 defmethod print (o:OutputStream, s:SellerOfferPrice) : 
   print(o, "SellerOfferPrice(quantity = %_, converted-price = %_)" % [quantity(s), converted-price(s)])
+
+
+; ========================================================
+; ==================== PartsDB ===========================
+; ========================================================
+
+public defn ComponentCode (user-properties:Tuple<KeyValue>) -> ComponentCode :
+  val results = parts-db-query(user-properties, 1)
+  val first-result = results[0]
+  ComponentCode(first-result as JObject)
+
+public defn ComponentCodes (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<ComponentCode> :
+  map{ComponentCode, _} $ parts-db-query(user-properties, limit) as Tuple<JObject>
+
+defn parts-db-query (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<JSON> :
+  val query-properties = remove-duplicate-keys $ [
+    ["_type" => "parts-db"],
+    user-properties
+  ]
+  dbquery(query-properties, limit) as Tuple<JObject>
+
 
 ;============================================================
 ;====================== Resistor ============================

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -17,6 +17,7 @@ defpackage ocdb/utils/generic-components:
   import ocdb/utils/property-structs
   import ocdb/utils/symbol-utils
   import ocdb/utils/checks
+  import ocdb/utils/parts
 
 ; ========================================================
 ; ====== Standard packages for the passive solver ========
@@ -129,6 +130,24 @@ public defn closest-std-val (v:Double, tol:Double) :
 
   match-val * pow(10.0, expon)
 
+
+; ========================================================
+; ==================== PartsDB ===========================
+; ========================================================
+
+public defn database-part (mpn: String) -> Instantiable :
+  to-jitx $ ComponentCode(["mpn" => mpn])
+
+public defn database-part (mpn: String, manufacturer: String) -> Instantiable :
+  to-jitx $ ComponentCode(["mpn" => mpn, "manufacturer" => manufacturer])
+
+public defn database-parts (user-params:Tuple<KeyValue>) -> Tuple<Instantiable> :
+  map(to-jitx, ComponentCodes(user-params, 10))
+
+public defn database-parts (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
+  map(to-jitx, ComponentCodes(user-params, limit))
+
+
 ; ========================================================
 ; ========== Generic passive components ==================
 ; ========================================================
@@ -139,7 +158,7 @@ defn smd-query-properties () -> Tuple<KeyValue<String, ?>> :
    "minimum_quantity" => 1
    "min-stock" => 5 * DESIGN-QUANTITY]
 
-defn remove-duplicate-keys (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
+public defn remove-duplicate-keys (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
   to-tuple $ to-hashtable<String, ?>(cat-all(hs))
 
 

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -146,6 +146,10 @@ public defn database-part (mpn: String, manufacturer: String) -> Instantiable :
   to-jitx $ ComponentCode(["mpn" => mpn, "manufacturer" => manufacturer])
 
 ; WARNING: This is an alpha feature at the moment.
+public defn database-part (user-params:Tuple<KeyValue>) -> Instantiable :
+  to-jitx $ ComponentCode(user-params)
+
+; WARNING: This is an alpha feature at the moment.
 public defn database-parts (user-params:Tuple<KeyValue>) -> Tuple<Instantiable> :
   map(to-jitx, ComponentCodes(user-params, 10))
 

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -135,15 +135,21 @@ public defn closest-std-val (v:Double, tol:Double) :
 ; ==================== PartsDB ===========================
 ; ========================================================
 
+; TODO: JITX-4034 - Remove these warnings
+
+; WARNING: This is an alpha feature at the moment.
 public defn database-part (mpn: String) -> Instantiable :
   to-jitx $ ComponentCode(["mpn" => mpn])
 
+; WARNING: This is an alpha feature at the moment.
 public defn database-part (mpn: String, manufacturer: String) -> Instantiable :
   to-jitx $ ComponentCode(["mpn" => mpn, "manufacturer" => manufacturer])
 
+; WARNING: This is an alpha feature at the moment.
 public defn database-parts (user-params:Tuple<KeyValue>) -> Tuple<Instantiable> :
   map(to-jitx, ComponentCodes(user-params, 10))
 
+; WARNING: This is an alpha feature at the moment.
 public defn database-parts (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
   map(to-jitx, ComponentCodes(user-params, limit))
 

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -536,8 +536,7 @@ public defn to-jitx (c: ComponentCode) -> Instantiable :
         (b:Bundle) :
           b
         (f:False) :
-          ; TODO: Provide support for bundles with options
-          get-bundle-by-name(name, []) as Bundle
+          get-bundle-by-name(name) as Bundle
 
     ; Supports
     for s in /supports(c) do :

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -5,12 +5,16 @@ defpackage ocdb/utils/parts :
   import json
   import lang-utils
 
-  import jitx
+  import jitx with :
+    prefix(Resistor) => EModel-
+    prefix(Capacitor) => EModel-
+    prefix(Inductor) => EModel-
   import jitx/commands
   import jitx/value
 
   import ocdb/utils/box-symbol
   import ocdb/utils/bundles
+  import ocdb/utils/db-parts
   import ocdb/utils/property-structs
 
 ;======================================
@@ -347,28 +351,34 @@ public-when(TESTING) defn PinByRequireCode (json: JObject) -> PinByRequireCode :
 defn EModel (json: JObject) -> EModel :
   val emodel-json = json["value"] as JObject
   switch(json["type"] as String) :
-    "resistor": Resistor(emodel-json)
-    "capacitor": Capacitor(emodel-json)
-    "inductor": Inductor(emodel-json)
+    "resistor": EModel-Resistor(emodel-json)
+    "capacitor": EModel-Capacitor(emodel-json)
+    "inductor": EModel-Inductor(emodel-json)
 
-defn Resistor (json: JObject) -> Resistor :
-  Resistor(double-or-unknown(json["resistance"]),
-           double-or-unknown(json["tolerance"]),
-           double-or-unknown(json["max_power"]))
+defn EModel-Resistor (json: JObject) -> EModel-Resistor :
+  EModel-Resistor(
+    double-or-unknown(json["resistance"]),
+    double-or-unknown(json["tolerance"]),
+    double-or-unknown(json["max_power"])
+  )
 
-defn Capacitor (json: JObject) -> Capacitor :
-  Capacitor(double-or-unknown(json["capacitance"]),
-            double-or-unknown(json["tolerance"]),
-            double-or-unknown(json["max_voltage"]),
-            bool-or-unknown(json["polarized"]),
-            bool-or-unknown(json["low_esr"]),
-            string-or-unknown(json["temperature_coefficient"]),
-            string-or-unknown(json["dielectric"]))
+defn EModel-Capacitor (json: JObject) -> EModel-Capacitor :
+  EModel-Capacitor(
+    double-or-unknown(json["capacitance"]),
+    double-or-unknown(json["tolerance"]),
+    double-or-unknown(json["max_voltage"]),
+    bool-or-unknown(json["polarized"]),
+    bool-or-unknown(json["low_esr"]),
+    string-or-unknown(json["temperature_coefficient"]),
+    string-or-unknown(json["dielectric"])
+  )
 
-defn Inductor (json: JObject) -> Inductor :
-  Inductor(double-or-unknown(json["inductance"]),
-           double-or-unknown(json["tolerance"]),
-           double-or-unknown(json["max_current"]))
+defn EModel-Inductor (json: JObject) -> EModel-Inductor :
+  EModel-Inductor(
+    double-or-unknown(json["inductance"]),
+    double-or-unknown(json["tolerance"]),
+    double-or-unknown(json["max_current"])
+  )
 
 defn double-or-unknown (json: JSON) -> Double|UNKNOWN :
   match(json):

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -536,7 +536,8 @@ public defn to-jitx (c: ComponentCode) -> Instantiable :
         (b:Bundle) :
           b
         (f:False) :
-          get-bundle-by-name(name) as Bundle
+          ; TODO: Provide support for bundles with options
+          get-bundle-by-name(name, []) as Bundle
 
     ; Supports
     for s in /supports(c) do :

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -22,14 +22,19 @@ defpackage ocdb/utils/parts :
 ;============ Public API ==============
 ;======================================
 
+; TODO: JITX-4034 - Remove these warnings
+
+; WARNING: This is an alpha feature at the moment.
 public defn ComponentCode (user-properties:Tuple<KeyValue>) -> ComponentCode :
   val results = parts-db-query(user-properties, 1)
   val first-result = results[0]
   ComponentCode(first-result as JObject)
 
+; WARNING: This is an alpha feature at the moment.
 public defn ComponentCodes (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<ComponentCode> :
   map{ComponentCode, _} $ parts-db-query(user-properties, limit) as Tuple<JObject>
 
+; WARNING: This is an alpha feature at the moment.
 public defstruct ComponentCode :
   name: String
   description: String

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -15,11 +15,20 @@ defpackage ocdb/utils/parts :
   import ocdb/utils/box-symbol
   import ocdb/utils/bundles
   import ocdb/utils/db-parts
+  import ocdb/utils/generic-components
   import ocdb/utils/property-structs
 
 ;======================================
 ;============ Public API ==============
 ;======================================
+
+public defn ComponentCode (user-properties:Tuple<KeyValue>) -> ComponentCode :
+  val results = parts-db-query(user-properties, 1)
+  val first-result = results[0]
+  ComponentCode(first-result as JObject)
+
+public defn ComponentCodes (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<ComponentCode> :
+  map{ComponentCode, _} $ parts-db-query(user-properties, limit) as Tuple<JObject>
 
 public defstruct ComponentCode :
   name: String
@@ -50,6 +59,13 @@ with :
 ;======================================
 ;============= Internals ==============
 ;======================================
+
+defn parts-db-query (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<JSON> :
+  val query-properties = remove-duplicate-keys $ [
+    ["_type" => "parts-db"],
+    user-properties
+  ]
+  dbquery(query-properties, limit) as Tuple<JObject>
 
 ;--------------------------------------
 ;------------- Component --------------


### PR DESCRIPTION
## Summary
Provide access to the PartsDB from user code.

## Details
The parsing/to-jitx code it already available in `parts.stanza`,
but was limited to user-provided input (e.g. local JSON files).

With this change, users can now load from MongoDB, via the backend proxy.

The code is based off @PhilippeFerreiraDeSousa's work in the prototype branch.

## Test Plan
Open JITX Shell:
```
import ocdb/utils/generic-components

; mpn only
view $ database-part("RK09K1130AP5")

; mpn + manufacturer
view $ database-part("RK09K1130AP5", "ALPSALPINE")

; query for multiple (requires associated jitx-client PR)
view $ database-parts(["category" => "resistor"])[0]
```