### PR TITLE
JITX-4098: Support filtering by vendor part number availability

### DIFF
--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -22,7 +22,7 @@ public defstruct ComponentCode :
   description: String
   manufacturer: String
   mpn: String
-  vendor-part-numbers: VendorPartNumbersCode
+  vendor-part-numbers: HashTable<String, VendorPartNumberCode>
   category: Category|UNKNOWN
   emodel: EModel|False
   pin-properties: False|PinPropertiesCode
@@ -141,8 +141,9 @@ public-when(TESTING) defstruct NoConnectCode :
 with :
   printer => true
 
-public-when(TESTING) defstruct VendorPartNumbersCode :
-  lcsc: String|UNKNOWN
+public-when(TESTING) defstruct VendorPartNumberCode :
+  exists: True
+  value: String
 with :
   printer => true
 
@@ -192,7 +193,7 @@ public defn ComponentCode (json: JObject) -> ComponentCode :
     json["description"] as String,
     json["manufacturer"] as String,
     json["mpn"] as String,
-    VendorPartNumbersCode(json["vendor_part_numbers"] as JObject),
+    VendorPartNumbers(json["vendor_part_numbers"] as JObject),
     category-or-unknown(json["category"]),
     emodel,
     PinPropertiesCode(json["pin_properties"] as JObject),
@@ -212,10 +213,14 @@ public defn ComponentCode (json: JObject) -> ComponentCode :
     map(SupportCode, json-supports),
   )
 
-defn VendorPartNumbersCode (json: JObject) -> VendorPartNumbersCode :
-  VendorPartNumbersCode(
-    string-or-unknown(json["lcsc"])
-  )
+defn VendorPartNumbers (json: JObject) -> HashTable<String, VendorPartNumberCode> :
+  val vendor_part_numbers = HashTable<String, VendorPartNumberCode>()
+  for key-value in entries(json) do:
+    val vendor = key(key-value)
+    val vendor-part-object = value(key-value) as JObject
+    val vendor-part-number = vendor-part-object["value"] as String
+    vendor_part_numbers[vendor] = VendorPartNumberCode(true, vendor-part-number)
+  vendor_part_numbers
 
 defn PinPropertiesCode (json: JObject) -> PinPropertiesCode :
   PinPropertiesCode(

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -142,7 +142,7 @@ with :
   printer => true
 
 public-when(TESTING) defstruct VendorPartNumberCode :
-  exists: True
+  exists: True|False
   value: String
 with :
   printer => true


### PR DESCRIPTION
## 1. Remove `lcsc` as a hardcoded vendor key
- Use a HashTable where any String can be a vendor key
- Allow adding in further vendors without having to update schema/client

## 2. Include an `exists` boolean
Allow parametric queries to filter to parts that include this key:
```
database-part(["vendor_part_numbers.lcsc.exists" => true])
```

We already support `_sellers` behavior for filtering by offers - so, it may turn out we don't
need this particular filter in the long run - but, it gives us the option, as we test/learn.