### PR TITLE
parts: use assign-symbols multi, treating bank as Int

### DIFF
--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -516,17 +516,12 @@ public defn to-jitx (c: ComponentCode) -> Instantiable :
     val landpattern-def = to-jitx(landpattern(c), jitx-pads-by-pcb-pad-name)
     assign-landpattern(landpattern-def)
 
-    ; FIXME!: Can delete this paragraph and keep multi symbol case ?
-    if length(symbols(c)) == 1 :
-      val s = symbols(c)[0]
-      assign-symbol(to-jitx(s))
-    else :
-      assign-symbols(
-        for s in symbols(c) map :
-          val bank = bank(s)
-          val jitx-symbol = to-jitx(s)
-          Ref(bank) => jitx-symbol
-      )
+    assign-symbols(
+      for s in symbols(c) map :
+        val bank = bank(s)
+        val jitx-symbol = to-jitx(s)
+        bank => jitx-symbol
+    )
 
     ; Bundles
     val local-bundles-by-name = HashTable<String, Bundle>()

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -518,9 +518,7 @@ public defn to-jitx (c: ComponentCode) -> Instantiable :
 
     assign-symbols(
       for s in symbols(c) map :
-        val bank = bank(s)
-        val jitx-symbol = to-jitx(s)
-        bank => jitx-symbol
+        bank(s) => to-jitx(s)
     )
 
     ; Bundles


### PR DESCRIPTION
Remove "FIXME!", and always use the "multi" path for assign-symbols.

The main change was to always treat banks as `Int`, rather than `Ref`:
```
Ref(bank) => jitx-symbol
    -->
bank => jitx-symbol
```

This should be safe, because the schema requires that they always be integers.