### PR TITLE
JITX-4098: vendor_part_numbers - update to use "_exists" API

### DIFF
--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -40,7 +40,7 @@ public defstruct ComponentCode :
   description: String
   manufacturer: String
   mpn: String
-  vendor-part-numbers: HashTable<String, VendorPartNumberCode>
+  vendor-part-numbers: HashTable<String, String>
   category: Category|UNKNOWN
   emodel: EModel|False
   pin-properties: False|PinPropertiesCode
@@ -166,12 +166,6 @@ public-when(TESTING) defstruct NoConnectCode :
 with :
   printer => true
 
-public-when(TESTING) defstruct VendorPartNumberCode :
-  exists: True|False
-  value: String
-with :
-  printer => true
-
 public-when(TESTING) defstruct PinPropertiesCode :
   pins: Tuple<PinPropertyCode>
   power-pins: Tuple<PowerPinCode>
@@ -238,13 +232,12 @@ public defn ComponentCode (json: JObject) -> ComponentCode :
     map(SupportCode, json-supports),
   )
 
-defn VendorPartNumbers (json: JObject) -> HashTable<String, VendorPartNumberCode> :
-  val vendor_part_numbers = HashTable<String, VendorPartNumberCode>()
+defn VendorPartNumbers (json: JObject) -> HashTable<String, String> :
+  val vendor_part_numbers = HashTable<String, String>()
   for key-value in entries(json) do:
     val vendor = key(key-value)
-    val vendor-part-object = value(key-value) as JObject
-    val vendor-part-number = vendor-part-object["value"] as String
-    vendor_part_numbers[vendor] = VendorPartNumberCode(true, vendor-part-number)
+    val vendor-part-number = value(key-value) as String
+    vendor_part_numbers[vendor] = vendor-part-number
   vendor_part_numbers
 
 defn PinPropertiesCode (json: JObject) -> PinPropertiesCode :


### PR DESCRIPTION
Simplify the PartsDB schema by removing unnecessary `exists/value` fields.

Thanks @PhilippeFerreiraDeSousa for pointing out that the API already supports `_exists`!

```
# Before
database-part(["category" => "resistor", "vendor_part_numbers.lcsc.exists" => true])

# After
database-part(["category" => "resistor", "_exist" => ["vendor_part_numbers.lcsc"]])
```