### PR TITLE
JITX-4098: Make vendor-part-numbers immutable

### DIFF
--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -40,7 +40,7 @@ public defstruct ComponentCode :
   description: String
   manufacturer: String
   mpn: String
-  vendor-part-numbers: HashTable<String, String>
+  vendor-part-numbers: Tuple<KeyValue<String, String>>
   category: Category|UNKNOWN
   emodel: EModel|False
   pin-properties: False|PinPropertiesCode
@@ -232,13 +232,8 @@ public defn ComponentCode (json: JObject) -> ComponentCode :
     map(SupportCode, json-supports),
   )
 
-defn VendorPartNumbers (json: JObject) -> HashTable<String, String> :
-  val vendor_part_numbers = HashTable<String, String>()
-  for key-value in entries(json) do:
-    val vendor = key(key-value)
-    val vendor-part-number = value(key-value) as String
-    vendor_part_numbers[vendor] = vendor-part-number
-  vendor_part_numbers
+defn VendorPartNumbers (json: JObject) -> Tuple<KeyValue<String, String>> :
+  entries(json) as Tuple<KeyValue<String, String>>
 
 defn PinPropertiesCode (json: JObject) -> PinPropertiesCode :
   PinPropertiesCode(


### PR DESCRIPTION
Incorporate @PhilippeFerreiraDeSousa's suggestions from:
- #348 

1. Make `vendor_part_numbers` immutable
2. Use succinct deserialization