### PR TITLE
JITX-4095: Wrap component with queryable parts

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -17,6 +17,7 @@ defpackage ocdb/utils/db-parts :
   import ocdb/utils/defaults
   import ocdb/utils/landpatterns
   import ocdb/utils/generator-utils
+  import ocdb/utils/parts
   import ocdb/utils/property-structs
   import ocdb/utils/symbols
   import ocdb/utils/design-vars
@@ -83,6 +84,8 @@ public defstruct Resistor <: Component :
   TCR: TCR|False ; Temperature coefficient of resistance (ohms/ohm*degC)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
+  component: ComponentCode|False
+  vendor-part-numbers: Tuple<KeyValue<String, String>>
 
 public defn delta-resistance (resistor: Resistor, temperature: Double) -> Double :
   val tcr = TCR(resistor) as TCR
@@ -99,13 +102,28 @@ public defn Resistor (raw-json: JObject) -> Resistor :
   val json = filter-json(raw-json)
   val [x, y, z] = parse-dimensions(json["dimensions"] as JObject)
 
+  val component = if get?(json, "component") is JObject:
+    ComponentCode(json["component"] as JObject)
+  else:
+    false
+
+  val mounting = if get?(json, "mounting") is String:
+    json["mounting"] as String
+  else:
+    ""
+
+  val vendor-part-numbers = if get?(json, "vendor_part_numbers") is JObject:
+    VendorPartNumbers(json["vendor_part_numbers"] as JObject)
+  else:
+    []
+
   Resistor(json["manufacturer"] as String,
            json["mpn"] as String,
            json["trust"] as String,
            x,
            y,
            z,
-           json["mounting"] as String,
+           mounting,
            parse-rated-temperature(json),
            optional-string(json, "case"),
            parse-sourcing(json),
@@ -118,7 +136,9 @@ public defn Resistor (raw-json: JObject) -> Resistor :
            optional-double(json, "rated-power"),
            resistance-tcr(json),
            parse-sellers(json),
-           optional-double(json, "resolved_price"))
+           optional-double(json, "resolved_price"),
+           component,
+           vendor-part-numbers)
 
 defn resistance-tcr (json: JObject) -> TCR|False :
   val tcr-json = get?(json, "tcr")
@@ -164,8 +184,8 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
       landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
 
     emodel = EModel-Resistor(resistance(resistor),
-                             emodel-pourcentage-tolerance(tolerance(resistor)),
-                             double-or-unknown(rated-power(resistor)))
+                            emodel-pourcentage-tolerance(tolerance(resistor)),
+                            double-or-unknown(rated-power(resistor)))
     reference-prefix = "R"
     val TCR = TCR(resistor)
     val rated-temperature = rated-temperature(resistor)
@@ -192,6 +212,7 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
     match(TCR: TCR): property(self.TCR) = [positive(TCR), negative(TCR)]
     spice :
       "[R] <p[1]> <p[2]> <resistance>"
+    property(self.vendor-part-numbers) = vendor-part-numbers(resistor)
   my-resistor
 
 ; ========================================================
@@ -287,6 +308,8 @@ defstruct Capacitor <: Component :
   rated-current-rms: Double|False ; Maximum rms current rating from manufacturer (Amperes)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
+  component: ComponentCode|False
+  vendor-part-numbers: Tuple<KeyValue<String, String>>
 
 defstruct ESR :
   value: Double
@@ -296,18 +319,33 @@ public defn Capacitor (raw-json: JObject) -> Capacitor :
   val json = filter-json(raw-json)
   val [x, y, z] = parse-dimensions(json["dimensions"] as JObject)
 
+  val component = if get?(json, "component") is JObject:
+    ComponentCode(json["component"] as JObject)
+  else:
+    false
+
+  val mounting = if get?(json, "mounting") is String:
+    json["mounting"] as String
+  else:
+    ""
+
+  val vendor-part-numbers = if get?(json, "vendor_part_numbers") is JObject:
+    VendorPartNumbers(json["vendor_part_numbers"] as JObject)
+  else:
+    []
+
   Capacitor(json["manufacturer"] as String,
             json["mpn"] as String,
             json["trust"] as String,
             x,
             y,
             z,
-            json["mounting"] as String,
+            mounting,
             parse-rated-temperature(json),
             optional-string(json, "case"),
             parse-sourcing(json),
             entries(json["metadata"] as JObject),
-            ; Resistor specific properties
+            ; Capacitor specific properties
             json["type"] as String,
             parse-tolerance(json),
             json["capacitance"] as Double,
@@ -320,7 +358,9 @@ public defn Capacitor (raw-json: JObject) -> Capacitor :
             optional-double(json, "rated-current-pk"),
             optional-double(json, "rated-current-rms"),
             parse-sellers(json),
-            optional-double(json, "resolved_price"))
+            optional-double(json, "resolved_price"),
+            component,
+            vendor-part-numbers)
 
 defn parse-esr (json: JObject) -> ESR|False :
   val esr-json = get?(json, "esr")
@@ -406,6 +446,8 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
       else :
         spice :
           "[C] <p[1]> <p[2]> <capacitance(capacitor)>"
+
+    property(self.vendor-part-numbers) = vendor-part-numbers(capacitor)
 
     emodel = EModel-Capacitor(capacitance(capacitor),
                              emodel-pourcentage-tolerance(tolerance(capacitor)),
@@ -531,10 +573,27 @@ defstruct Inductor <: Component :
   self-resonant-frequency: Double|False ; Frequency at which inductor impedance becomes very high / open circuit (freq in Hz)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
+  component: ComponentCode|False
+  vendor-part-numbers: Tuple<KeyValue<String, String>>
 
 public defn Inductor (raw-json: JObject) -> Inductor :
   val json = filter-json(raw-json)
   val [x, y, z] = parse-dimensions(json["dimensions"] as JObject)
+
+  val component = if get?(json, "component") is JObject:
+    ComponentCode(json["component"] as JObject)
+  else:
+    false
+
+  val mounting = if get?(json, "mounting") is String:
+    json["mounting"] as String
+  else:
+    ""
+
+  val vendor-part-numbers = if get?(json, "vendor_part_numbers") is JObject:
+    VendorPartNumbers(json["vendor_part_numbers"] as JObject)
+  else:
+    []
 
   Inductor(json["manufacturer"] as String,
            json["mpn"] as String,
@@ -542,7 +601,7 @@ public defn Inductor (raw-json: JObject) -> Inductor :
            x,
            y,
            z,
-           json["mounting"] as String,
+           mounting,
            parse-rated-temperature(json),
            optional-string(json, "case"),
            parse-sourcing(json),
@@ -559,7 +618,9 @@ public defn Inductor (raw-json: JObject) -> Inductor :
            optional-double(json, "quality-factor"),
            optional-double(json, "self-resonant-frequency"),
            parse-sellers(json),
-           optional-double(json, "resolved_price"))
+           optional-double(json, "resolved_price"),
+           component,
+           vendor-part-numbers)
 
 ; ========================================================
 ; ======================== to-jitx =======================
@@ -620,6 +681,7 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
     property(self.self-resonant-frequency) = self-resonant-frequency(inductor)
     spice :
       "[L] <p[1]> <p[2]> <inductance>"
+    property(self.vendor-part-numbers) = vendor-part-numbers(inductor)
   my-inductor
 
 ; ========================================================
@@ -844,7 +906,7 @@ defn parse-tolerance (json: JObject) -> MinMaxRange|False :
   match(tolerance-json: JObject) :
       MinMaxRange(tolerance-json["min"] as Double, tolerance-json["max"] as Double)
 
-defn parse-sourcing (json: JObject) -> Sourcing :
+public defn parse-sourcing (json: JObject) -> Sourcing :
   ; minimum-quantity and stock are float in MongoDB even though the python scraper do gives python ints to pymongo.
   Sourcing(optional-double(json, "price"), to-int(json["minimum_quantity"] as Double), to-int(json["stock"] as Double))
 

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -102,28 +102,13 @@ public defn Resistor (raw-json: JObject) -> Resistor :
   val json = filter-json(raw-json)
   val [x, y, z] = parse-dimensions(json["dimensions"] as JObject)
 
-  val component = if get?(json, "component") is JObject:
-    ComponentCode(json["component"] as JObject)
-  else:
-    false
-
-  val mounting = if get?(json, "mounting") is String:
-    json["mounting"] as String
-  else:
-    ""
-
-  val vendor-part-numbers = if get?(json, "vendor_part_numbers") is JObject:
-    VendorPartNumbers(json["vendor_part_numbers"] as JObject)
-  else:
-    []
-
   Resistor(json["manufacturer"] as String,
            json["mpn"] as String,
            json["trust"] as String,
            x,
            y,
            z,
-           mounting,
+           optional-mounting(json),
            parse-rated-temperature(json),
            optional-string(json, "case"),
            parse-sourcing(json),
@@ -137,8 +122,8 @@ public defn Resistor (raw-json: JObject) -> Resistor :
            resistance-tcr(json),
            parse-sellers(json),
            optional-double(json, "resolved_price"),
-           component,
-           vendor-part-numbers)
+           optional-component(json),
+           parse-vendor-part-numbers(json))
 
 defn resistance-tcr (json: JObject) -> TCR|False :
   val tcr-json = get?(json, "tcr")
@@ -319,28 +304,13 @@ public defn Capacitor (raw-json: JObject) -> Capacitor :
   val json = filter-json(raw-json)
   val [x, y, z] = parse-dimensions(json["dimensions"] as JObject)
 
-  val component = if get?(json, "component") is JObject:
-    ComponentCode(json["component"] as JObject)
-  else:
-    false
-
-  val mounting = if get?(json, "mounting") is String:
-    json["mounting"] as String
-  else:
-    ""
-
-  val vendor-part-numbers = if get?(json, "vendor_part_numbers") is JObject:
-    VendorPartNumbers(json["vendor_part_numbers"] as JObject)
-  else:
-    []
-
   Capacitor(json["manufacturer"] as String,
             json["mpn"] as String,
             json["trust"] as String,
             x,
             y,
             z,
-            mounting,
+            optional-mounting(json),
             parse-rated-temperature(json),
             optional-string(json, "case"),
             parse-sourcing(json),
@@ -359,8 +329,8 @@ public defn Capacitor (raw-json: JObject) -> Capacitor :
             optional-double(json, "rated-current-rms"),
             parse-sellers(json),
             optional-double(json, "resolved_price"),
-            component,
-            vendor-part-numbers)
+            optional-component(json),
+            parse-vendor-part-numbers(json))
 
 defn parse-esr (json: JObject) -> ESR|False :
   val esr-json = get?(json, "esr")
@@ -580,28 +550,13 @@ public defn Inductor (raw-json: JObject) -> Inductor :
   val json = filter-json(raw-json)
   val [x, y, z] = parse-dimensions(json["dimensions"] as JObject)
 
-  val component = if get?(json, "component") is JObject:
-    ComponentCode(json["component"] as JObject)
-  else:
-    false
-
-  val mounting = if get?(json, "mounting") is String:
-    json["mounting"] as String
-  else:
-    ""
-
-  val vendor-part-numbers = if get?(json, "vendor_part_numbers") is JObject:
-    VendorPartNumbers(json["vendor_part_numbers"] as JObject)
-  else:
-    []
-
   Inductor(json["manufacturer"] as String,
            json["mpn"] as String,
            json["trust"] as String,
            x,
            y,
            z,
-           mounting,
+           optional-mounting(json),
            parse-rated-temperature(json),
            optional-string(json, "case"),
            parse-sourcing(json),
@@ -619,8 +574,8 @@ public defn Inductor (raw-json: JObject) -> Inductor :
            optional-double(json, "self-resonant-frequency"),
            parse-sellers(json),
            optional-double(json, "resolved_price"),
-           component,
-           vendor-part-numbers)
+           optional-component(json),
+           parse-vendor-part-numbers(json))
 
 ; ========================================================
 ; ======================== to-jitx =======================
@@ -941,6 +896,22 @@ public defn parse-sellers (json: JObject) -> Tuple<Seller>|False:
           SellerOffer{int(json-offer["inventory_level"]), _} $
             for json-price in json-offer["prices"] as Tuple<JObject> map :
               SellerOfferPrice(int(json-price["quantity"]), json-price["converted_price"] as Double)
+
+defn optional-component (json: JObject) -> ComponentCode|False :
+  match(get?(json, "component")) :
+    (j:JObject) :
+      ComponentCode(j)
+    (_) : false
+
+defn optional-mounting (json: JObject) -> String :
+  match(get?(json, "mounting")) :
+    (s:String) : s
+    (_) : ""
+
+defn parse-vendor-part-numbers (json: JObject) -> Tuple<KeyValue<String, String>> :
+  match(get?(json, "vendor_part_numbers")) :
+    (j:JObject) : VendorPartNumbers(j)
+    (_) : []
 
 ;============================================================
 ;===================== Other utils ==========================

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -139,23 +139,23 @@ public defn closest-std-val (v:Double, tol:Double) :
 
 ; WARNING: This is an alpha feature at the moment.
 public defn database-part (mpn: String) -> Instantiable :
-  to-jitx $ ComponentCode(["mpn" => mpn])
+  to-jitx $ PartsDBComponent(["mpn" => mpn])
 
 ; WARNING: This is an alpha feature at the moment.
 public defn database-part (mpn: String, manufacturer: String) -> Instantiable :
-  to-jitx $ ComponentCode(["mpn" => mpn, "manufacturer" => manufacturer])
+  to-jitx $ PartsDBComponent(["mpn" => mpn, "manufacturer" => manufacturer])
 
 ; WARNING: This is an alpha feature at the moment.
 public defn database-part (user-params:Tuple<KeyValue>) -> Instantiable :
-  to-jitx $ ComponentCode(user-params)
+  to-jitx $ PartsDBComponent(user-params)
 
 ; WARNING: This is an alpha feature at the moment.
 public defn database-parts (user-params:Tuple<KeyValue>) -> Tuple<Instantiable> :
-  map(to-jitx, ComponentCodes(user-params, 10))
+  map(to-jitx, PartsDBComponents(user-params, 10))
 
 ; WARNING: This is an alpha feature at the moment.
 public defn database-parts (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  map(to-jitx, ComponentCodes(user-params, limit))
+  map(to-jitx, PartsDBComponents(user-params, limit))
 
 
 ; ========================================================

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -25,56 +25,105 @@ defpackage ocdb/utils/parts :
 ; TODO: JITX-4034 - Remove these warnings
 
 ; WARNING: This is an alpha feature at the moment.
-public defn ComponentCode (user-properties:Tuple<KeyValue>) -> ComponentCode :
-  val results = parts-db-query(user-properties, 1)
-  val first-result = results[0]
-  ComponentCode(first-result as JObject)
+public defn PartsDBComponent (user-properties:Tuple<KeyValue>) -> Component :
+  val query-properties = remove-duplicate-keys $ [
+    ["_type" => "parts-db"],
+    user-properties
+  ]
+  parse-component $ dbquery-first(query-properties) as JObject
 
 ; WARNING: This is an alpha feature at the moment.
-public defn ComponentCodes (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<ComponentCode> :
-  map{ComponentCode, _} $ parts-db-query(user-properties, limit) as Tuple<JObject>
+public defn PartsDBComponents (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Component> :
+  val query-properties = remove-duplicate-keys $ [
+    ["_type" => "parts-db"],
+    user-properties
+  ]
+  map{parse-component, _} $ dbquery(query-properties, limit) as Tuple<JObject>
 
 ; WARNING: This is an alpha feature at the moment.
-public defstruct ComponentCode :
-  name: String
+public defstruct Part <: Component :
+  component: ComponentCode
   description: String
   manufacturer: String
   mpn: String
   vendor-part-numbers: Tuple<KeyValue<String, String>>
   category: Category|UNKNOWN
-  emodel: EModel|False
-  pin-properties: False|PinPropertiesCode
-  pcb-pads: Tuple<PCBPadCode>
-  landpattern: LandPatternCode
-  symbols: Tuple<SymbolCode>
-  datasheet: String
-  image: String|UNKNOWN
   trust: String
   mounting: String|UNKNOWN
   case: String|UNKNOWN
   dimensions: DimensionsCode
-  sourcing: SourcingCode
+  sourcing: Sourcing
+  rated-temperature: Toleranced|False
+  ; Power dissipation limit as rated by manufacturer. One value, or PWL function (W | [degC, W])
+  rated-power: Double|False
+
+  ; Optionally appended by jit-backend (does not come from parts-db)
+  sellers: Tuple<Seller>|False with: (as-method => true)
+  resolved-price: Double|False with: (as-method => true)
+with :
+  printer => true
+
+; Parse parts conditionally, based on their category.
+public defn parse-component (json: JObject) -> Component :
+  val component-code = json["component"] as JObject
+  match(component-code["landpattern"]):
+    (lp:JObject):
+      ; If the landpattern is included, this part should have everything it needs.
+      Part(json)
+    (c):
+      ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
+      ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
+      match(json["category"]):
+        (c:String):
+          switch(c):
+            "capacitor": Capacitor(json)
+            "inductor": Inductor(json)
+            "resistor": Resistor(json)
+
+;======================================
+;============= Internals ==============
+;======================================
+
+defn Part (json: JObject) -> Part :
+  Part(
+    ComponentCode(json["component"] as JObject),
+    json["description"] as String,
+    json["manufacturer"] as String,
+    json["mpn"] as String,
+    VendorPartNumbers(json["vendor_part_numbers"] as JObject),
+    category-or-unknown(json["category"]),
+    json["trust"] as String,
+    string-or-unknown(json["mounting"]),
+    string-or-unknown(json["case"]),
+    DimensionsCode(json["dimensions"] as JObject),
+    parse-sourcing(json),
+    parse-rated-temperature(json),
+    optional-double(json, "rated-power"),
+    parse-sellers(json),
+    optional-double(json, "resolved_price"),
+  )
+
+;--------------------------------------
+;----------- Component Code -----------
+;--------------------------------------
+
+public defstruct ComponentCode :
+  name: String
+  description: String
+  manufacturer: String
+  mpn: String
+  reference_prefix: String
+  emodel: EModel|False
+  pin-properties: False|PinPropertiesCode
+  pcb-pads: Tuple<PCBPadCode>
+  landpattern: LandPatternCode|False
+  symbols: Tuple<SymbolCode>
   metadata: Tuple<MetadataCode>
   properties: Tuple<ComponentPropertyCode>
   bundles:Tuple<BundleCode>
   supports:Tuple<SupportCode>
 with :
   printer => true
-
-;======================================
-;============= Internals ==============
-;======================================
-
-defn parts-db-query (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<JSON> :
-  val query-properties = remove-duplicate-keys $ [
-    ["_type" => "parts-db"],
-    user-properties
-  ]
-  dbquery(query-properties, limit) as Tuple<JObject>
-
-;--------------------------------------
-;------------- Component --------------
-;--------------------------------------
 
 public-when(TESTING) defstruct BundleCode :
   name: String
@@ -135,13 +184,6 @@ public-when(TESTING) defstruct DimensionsCode :
 with :
   printer => true
 
-public-when(TESTING) defstruct SourcingCode :
-  price: Double|UNKNOWN
-  minimum-quantity: Int
-  stock: Int
-with :
-  printer => true
-
 public-when(TESTING) defstruct TolerancedCode :
   typical: Double
   plus: Double
@@ -162,7 +204,7 @@ with :
   printer => true
 
 public-when(TESTING) defstruct NoConnectCode :
-  pin-name: String
+  pin: PinByTypeCode
 with :
   printer => true
 
@@ -174,7 +216,7 @@ with :
   printer => true
 
 public-when(TESTING) defstruct PinPropertyCode :
-  pin-name: String
+  pin: PinByTypeCode
   pads: Tuple<PinByTypeCode>
   direction: Dir
   electrical-type: String
@@ -183,7 +225,7 @@ with :
   printer => true
 
 public-when(TESTING) defstruct PowerPinCode :
-  pin-name: String
+  pin: PinByTypeCode
   min-voltage: Double
   max-voltage: Double
 with :
@@ -207,32 +249,30 @@ public defn ComponentCode (json: JObject) -> ComponentCode :
     (e:JObject):
       EModel(e)
 
+  val landpattern = match(json["landpattern"]):
+    (_:JNull):
+      false
+    (e:JObject):
+      LandPatternCode(json["landpattern"] as JObject)
+
   ComponentCode(
     name,
     json["description"] as String,
     json["manufacturer"] as String,
     json["mpn"] as String,
-    VendorPartNumbers(json["vendor_part_numbers"] as JObject),
-    category-or-unknown(json["category"]),
+    json["reference_prefix"] as String,
     emodel,
     PinPropertiesCode(json["pin_properties"] as JObject),
     map(PCBPadCode, json["pcb_pads"] as Tuple<JObject>),
-    LandPatternCode(json["landpattern"] as JObject),
+    landpattern,
     map(SymbolCode, json["symbols"] as Tuple<JObject>),
-    json["datasheet"] as String,
-    string-or-unknown(json["image"]),
-    json["trust"] as String,
-    string-or-unknown(json["mounting"]),
-    string-or-unknown(json["case"]),
-    DimensionsCode(json["dimensions"] as JObject),
-    SourcingCode(json["sourcing"] as JObject),
     map(MetadataCode, json["metadata"] as Tuple<JObject>),
     map(ComponentPropertyCode, json["properties"] as Tuple<JObject>),
     map(BundleCode, json-bundles),
     map(SupportCode, json-supports),
   )
 
-defn VendorPartNumbers (json: JObject) -> Tuple<KeyValue<String, String>> :
+public defn VendorPartNumbers (json: JObject) -> Tuple<KeyValue<String, String>> :
   entries(json) as Tuple<KeyValue<String, String>>
 
 defn PinPropertiesCode (json: JObject) -> PinPropertiesCode :
@@ -243,7 +283,7 @@ defn PinPropertiesCode (json: JObject) -> PinPropertiesCode :
   )
 
 public-when(TESTING) defn PinPropertyCode (json: JObject) -> PinPropertyCode :
-  PinPropertyCode(json["pin_name"] as String,
+  PinPropertyCode(PinByTypeCode(json["pin"] as JObject),
                   map(PinByTypeCode, json["pads"] as Tuple<JObject>),
                   Dir(json["direction"] as String),
                   json["electrical_type"] as String,
@@ -254,12 +294,6 @@ public-when(TESTING) defn DimensionsCode (json: JObject) -> DimensionsCode :
   val y = json["y"] as Double
   val z = double-or-unknown(json["z"])
   DimensionsCode(x, y, z)
-
-public-when(TESTING) defn SourcingCode (json: JObject) -> SourcingCode :
-  val price = double-or-unknown(json["price"])
-  val minium_quantity = to-int(json["minimum_quantity"] as Double)
-  val stock = to-int(json["stock"] as Double)
-  SourcingCode(price, minium_quantity, stock)
 
 public-when(TESTING) defn TolerancedCode (json: JObject) -> Toleranced :
   val typical = json["typical"] as Double
@@ -461,13 +495,16 @@ defn ColorSpec (json: JObject) -> ColorSpec :
 
 defn PowerPinCode (json: JObject) -> PowerPinCode :
   PowerPinCode(
-    json["pin_name"] as String,
+    PinByTypeCode(json["pin"] as JObject),
     json["min_voltage"] as Double,
     json["max_voltage"] as Double
   )
 
 defn NoConnectCode (json: JObject) -> NoConnectCode :
-  NoConnectCode(json["pin_name"] as String)
+  NoConnectCode(PinByTypeCode(json["pin"] as JObject))
+
+public defmethod to-jitx (part: Part) -> Instantiable :
+  to-jitx $ component(part)
 
 public defn to-jitx (c: ComponentCode) -> Instantiable :
   pcb-component my-component :
@@ -495,13 +532,15 @@ public defn to-jitx (c: ComponentCode) -> Instantiable :
 
     map(to-jitx, properties(c))
 
+    reference-prefix = reference_prefix(c)
+
     val jitx-pads-by-pcb-pad-name = HashTable<String, Pad>()
     for pp in pcb-pads(c) do :
       val jitx-pad = to-jitx(pp)
       val pad-name = name(pp)
       jitx-pads-by-pcb-pad-name[pad-name] = jitx-pad
 
-    val landpattern-def = to-jitx(landpattern(c), jitx-pads-by-pcb-pad-name)
+    val landpattern-def = to-jitx(landpattern(c) as LandPatternCode, jitx-pads-by-pcb-pad-name)
     assign-landpattern(landpattern-def)
 
     assign-symbols(
@@ -558,14 +597,14 @@ defn to-jitx (pin-props: PinPropertiesCode) :
     pin-properties :
       [pin:Ref | pads:Ref ... | side:Dir | electrical-type:String | bank:Int]
       for pin-prop in pins(pin-props) do :
-        val pin-ref = Ref(pin-name(pin-prop))
+        val pin-ref = to-ref(/pin(pin-prop))
         val jitx-pads = map(to-ref, pads(pin-prop))
         [(pin-ref) | (jitx-pads)... | direction(pin-prop) as Dir | electrical-type(pin-prop) | bank(pin-prop) as Int]
     do(to-jitx, power-pins(pin-props))
     do(to-jitx, no-connects(pin-props))
 
     for pin-prop in pins(pin-props) do :
-      val jitx-pin = self.(pin-name(pin-prop))
+      val jitx-pin = self.(to-ref(/pin(pin-prop)))
       set-property(jitx-pin, `direction, direction(pin-prop) as Dir)
 
 defn to-ref (pin-by-type:PinByTypeCode) -> Ref :
@@ -577,15 +616,16 @@ defn to-ref (pin-by-type:PinByTypeCode) -> Ref :
 
 defn to-jitx (power-pin: PowerPinCode) :
   inside pcb-component :
-    val p = dot(self, (Ref(pin-name(power-pin))))
+    val jitx-pin = self.(to-ref(/pin(power-pin)))
     val min = min-voltage(power-pin)
     val max = max-voltage(power-pin)
     val toleranced = ocdb/utils/property-structs/PowerPin(jitx/min-max(min, max))
-    set-property(p, `power-pin, toleranced)
+    set-property(jitx-pin, `power-pin, toleranced)
 
 defn to-jitx (nc: NoConnectCode) :
   inside pcb-component :
-    no-connect(self.(pin-name(nc)))
+    val jitx-pin = self.(to-ref(/pin(nc)))
+    no-connect(jitx-pin)
 
 defn to-jitx (prop: ComponentPropertyCode) :
   inside pcb-component :
@@ -963,7 +1003,7 @@ public-when(TESTING) defstruct SymbolCode :
   layers: Tuple<SymbolLayerCode>
 
 public-when(TESTING) defstruct SymbolPinCode :
-  pin-name: String
+  pin: PinByTypeCode
   point: Point
   direction: Dir
   length: Double
@@ -983,7 +1023,7 @@ public-when(TESTING) defn SymbolCode (json: JObject) -> SymbolCode :
   )
 
 defn SymbolPinCode (json: JObject) -> SymbolPinCode :
-  SymbolPinCode(json["pin_name"] as String,
+  SymbolPinCode(PinByTypeCode(json["pin"] as JObject),
                 Point(json["point"] as JObject),
                 Dir(json["direction"] as String),
                 json["length"] as Double,
@@ -1013,7 +1053,7 @@ defn to-jitx (p: SymbolPinCode) :
   inside pcb-symbol :
     val number-size = number-size(p)
     val name-size = name-size(p)
-    val pin-ref = Ref(pin-name(p))
+    val pin-ref = to-ref(/pin(p))
     match(number-size, name-size) :
       (number-size: Double, name-size: Double) :
         pin (pin-ref) at point(p) with :


### PR DESCRIPTION
## Summary
This goes along with an accompanying [parts-db PR](https://github.com/JITx-Inc/parts-db/pull/36).

The purpose is to allow proper parametric queries, such as:
```
database-part(["category" => "resistor", "resistance" => 7500])
```

### Component Wrapping
In order to achieve this, the top-level parts are category-specific, queryable documents,
containing a `component` (the approach @PhilippeFerreiraDeSousa originally took).

### Migration Backwards-Compability
Additionally, this includes support to transform a parts-db result into one of our existing queryable structs:
- Resistor
- Capacitor
- Inductor

This is for backwards-compatibility, as we migrate the data to the parts-db.

Note that existing queries like `chip-resistor()` are currently unaffected, and still load from the old DB.

We can switch those over as a follow-up.