### PR TITLE
JITX-4209: Update "is-resistor()" to check "category"

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -176,7 +176,10 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
     val rated-temperature = rated-temperature(resistor)
     val tolerance = tolerance(resistor)
     val resistance = resistance(resistor)
+    ; Backwards compatibility
     property(self.resistor) = true
+    ; This is how parts-db does it
+    property(self.category) = "resistor"
     property(self.trust) = trust(resistor)
     property(self.x) = x(resistor)
     property(self.y) = y(resistor)
@@ -430,7 +433,10 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
     val rated-temperature = rated-temperature(capacitor)
     val capacitance = capacitance(capacitor)
     val tolerance = tolerance(capacitor)
+    ; Backwards compatibility
     property(self.capacitor) = true
+    ; This is how parts-db does it
+    property(self.category) = "capacitor"
     property(self.trust) = trust(capacitor)
     property(self.x) = x(capacitor)
     property(self.y) = y(capacitor)
@@ -615,7 +621,10 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
     reference-prefix = "L"
     val rated-temperature = rated-temperature(inductor)
     val tolerance = tolerance(inductor)
+    ; Backwards compatibility
     property(self.inductor) = true
+    ; This is how parts-db does it
+    property(self.category) = "inductor"
     property(self.trust) = trust(inductor)
     property(self.x) = x(inductor)
     property(self.y) = y(inductor)

--- a/utils/generator-utils.stanza
+++ b/utils/generator-utils.stanza
@@ -138,13 +138,19 @@ public defn connect-gnd-pins ():
           net (self.gnd, p)
 
 public defn is-resistor? (i: JITXObject) :
-  has-property?(i.resistance)
+  match(get-property?(i, `category)) :
+    (p:One) : p == "resistor"
+    (p:None) : false
 
 public defn is-capacitor? (i: JITXObject) :
-  has-property?(i.capacitance)
+  match(get-property?(i, `category)) :
+    (p:One) : p == "capacitor"
+    (p:None) : false
 
 public defn is-inductor? (i: JITXObject) :
-  has-property?(i.inductance)
+  match(get-property?(i, `category)) :
+    (p:One) : p == "inductor"
+    (p:None) : false
 
 public defn resistance! (i: JITXObject) :
   property(i.resistance)


### PR DESCRIPTION
The parts-db is includes parts with "resistance", that shouldn't be considered resistors,
for validation/checking purposes.

For example, a potentiometer can have a `resistance`, but can have more than 2 pins.

This changes `is-resistor()` to check by `category` instead (and similar for capacitor/inductor).

## Test Plan
Used one of @CaydenPierce's projects which was failing previously:
```
FATAL ERROR: Resistor, capacitor or inductor amp.vol has 5 pins instead of 2.
  in ocdb/utils/generator-utils/calculate-operating-points
    at open-components-database/utils/generator-utils.stanza:172.4
  in ocdb/utils/generator-utils/calculate-operating-points
    at open-components-database/utils/generator-utils.stanza:175.39
  in ocdb/utils/generator-utils/run-final-passes
    at open-components-database/utils/generator-utils.stanza:291.22
  in helpers/run-check-on-design
    at helpers.stanza:20.20
```

Ran with this branch and confirmed it works.