### PR TITLE
JITX-4097: Switch v1 queries over to parts-db

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.7-dev.2
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.13-rc.31
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:latest
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.13-rc.31
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,9 +1,9 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.13-rc.31
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:latest
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 
 RUN apt update
-RUN apt install -y python3.8
+RUN apt install -y python3.10
 
 WORKDIR /app
 COPY ./user.params /root/.jitx/user.params

--- a/.github/jitx-client/scripts/run-ocdb-tests.sh
+++ b/.github/jitx-client/scripts/run-ocdb-tests.sh
@@ -27,7 +27,7 @@ cd ..
 #==============================================
 
 echo "Searching for pcb objects and generating tests..."
-python3.8 scripts/evaluate_pcb_objects.py
+python3.10 scripts/evaluate_pcb_objects.py
 cd test-evaluate/
 echo "Launching pcb object tests..."
 $JITX_RUN_TEST test/evaluate/api

--- a/components/changjiang-electronics-tech/SS8050.stanza
+++ b/components/changjiang-electronics-tech/SS8050.stanza
@@ -13,7 +13,6 @@ defpackage ocdb/components/changjiang-electronics-tech/SS8050 :
   import ocdb/utils/symbols
 
   import ocdb/utils/property-structs
-  import ocdb/utils/generator-utils
   import ocdb/utils/checks
 
 public pcb-component component :

--- a/designs/ethernet-fmc.stanza
+++ b/designs/ethernet-fmc.stanza
@@ -18,6 +18,7 @@ defpackage ocdb/designs/ethernet-fmc :
 
 OPERATING-TEMPERATURE = min-max(-20.0 50.0)
 OPTIMIZE-FOR = ["area"]
+DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
 
 pcb-module my-design :
 

--- a/designs/tutorial.stanza
+++ b/designs/tutorial.stanza
@@ -5,7 +5,10 @@ defpackage ocdb/designs/tutorial :
   import jitx
   import jitx/commands
   import ocdb/utils/checks
+  import ocdb/utils/design-vars
   import ocdb/utils/generic-components
+
+DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
 
 ; ==========================================
 ; Implement other modules used by our design 

--- a/designs/voltage-divider.stanza
+++ b/designs/voltage-divider.stanza
@@ -15,6 +15,7 @@ defpackage ocdb/designs/voltage-divider :
   import ocdb/utils/design-vars
 
 OPERATING-TEMPERATURE = min-max(0.0, 40.0)
+DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
 
 pcb-module demo :
 

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -216,14 +216,11 @@ public defn Resistor (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> R
 
 public defn Resistor (user-properties:Tuple<KeyValue>, exist:Tuple<String>, sort:Tuple<String>, operating-temperature:Toleranced|False) -> Resistor :
   val query-properties = resistor-query-properties(user-properties, exist, sort, operating-temperature)
-  ;Query the database with the given properties
-  Resistor $ dbquery-first-allow-non-stock(query-properties) as JObject
-  ; Resistor("manufacturer", "mpn", "trust", 0.0, 0.0, 0.0, "mounting", false, false, Sourcing(false, 0, 0), [], "type", false, 0.0, false, false, false)
+  PartsDBComponent(query-properties) as Resistor
 
 public defn Resistors (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Resistor> :
   val query-properties = resistor-query-properties(user-properties, [], OPTIMIZE-FOR, OPERATING-TEMPERATURE)
-  ;Query the database with the given properties
-  map{Resistor, _} $ dbquery(query-properties, limit) as Tuple<JObject>
+  PartsDBComponents(query-properties, limit) as Tuple<Resistor>
 
 defn resistor-query-properties (user-properties:Tuple<KeyValue>,
                                 exist:Tuple<String>,
@@ -471,13 +468,11 @@ public defn Capacitor (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> 
 
 public defn Capacitor (user-properties:Tuple<KeyValue>, exist:Tuple<String>, sort:Tuple<String>, operating-temperature:Toleranced|False) -> Capacitor :
   val query-properties = capacitor-query-properties(user-properties, exist, sort, operating-temperature)
-  ;Query the database with the given properties
-  Capacitor $ dbquery-first-allow-non-stock(query-properties) as JObject
+  PartsDBComponent(query-properties) as Capacitor
 
 public defn Capacitors (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Capacitor> :
   val query-properties = capacitor-query-properties(user-properties, [], OPTIMIZE-FOR, OPERATING-TEMPERATURE)
-  ;Query the database with the given properties
-  map{Capacitor, _} $ dbquery(query-properties, limit) as Tuple<JObject>
+  PartsDBComponents(query-properties, limit) as Tuple<Capacitor>
 
 defn capacitor-query-properties (user-properties:Tuple<KeyValue>,
                                 exist:Tuple<String>,
@@ -661,13 +656,11 @@ public defn Inductor (user-properties:Tuple<KeyValue>, exist:Tuple<String>) -> I
 
 public defn Inductor (user-properties:Tuple<KeyValue>, exist:Tuple<String>, sort:Tuple<String>, operating-temperature:Toleranced|False) -> Inductor :
   val query-properties = inductor-query-properties(user-properties, exist, sort, operating-temperature)
-  ;Query the database with the given properties
-  Inductor $ dbquery-first-allow-non-stock(query-properties) as JObject
+  PartsDBComponent(query-properties) as Inductor
 
 public defn Inductors (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Inductor> :
   val query-properties = inductor-query-properties(user-properties, [], OPTIMIZE-FOR, OPERATING-TEMPERATURE)
-  ;Query the database with the given properties
-  map{Inductor, _} $ dbquery(query-properties, limit) as Tuple<JObject>
+  PartsDBComponents(query-properties, limit) as Tuple<Inductor>
 
 ; ========================================================
 ; =============== inductor-query-properties ==============

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -85,7 +85,7 @@ public defstruct Resistor <: Component :
   TCR: TCR|False ; Temperature coefficient of resistance (ohms/ohm*degC)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
-  component: ComponentCode|False
+  component: ComponentCode
   vendor-part-numbers: Tuple<KeyValue<String, String>> with: (as-method => true)
 
 public defn delta-resistance (resistor: Resistor, temperature: Double) -> Double :
@@ -123,7 +123,7 @@ public defn Resistor (raw-json: JObject) -> Resistor :
            resistance-tcr(json),
            parse-sellers(json),
            optional-double(json, "resolved_price"),
-           optional-component(json),
+           ComponentCode(json["component"] as JObject),
            parse-vendor-part-numbers(json))
 
 defn resistance-tcr (json: JObject) -> TCR|False :
@@ -142,67 +142,75 @@ public defstruct TCR :
 ; ========================================================
 
 defmethod to-jitx (resistor: Resistor) -> Instantiable :
-  pcb-component my-resistor :
-    val manufacturer-string = manufacturer(resistor)
-    match(manufacturer-string: String) :
-      manufacturer = manufacturer-string
+  val component = component(resistor)
+  match(landpattern(component)) :
+    (lp:LandPatternCode):
+      ; If the landpattern is included, this part should have everything it needs.
+      to-jitx $ component
+    (c):
+      ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
+      ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
+      pcb-component my-resistor :
+        val manufacturer-string = manufacturer(resistor)
+        match(manufacturer-string: String) :
+          manufacturer = manufacturer-string
 
-    mpn = mpn(resistor)
-    val height = z(resistor)
+        mpn = mpn(resistor)
+        val height = z(resistor)
 
-    val description-string = lookup?(metadata(resistor), "description")
-    match(description-string: String) :
-      description = description-string
+        val description-string = lookup?(metadata(resistor), "description")
+        match(description-string: String) :
+          description = description-string
 
-    port p : pin[1 through 2]
-    val sym = resistor-sym()
-    symbol = sym(p[1] => sym.p[1], p[2] => sym.p[2])
-    val case = case(resistor)
-    match(case: String) :
-      if check-valid-rectangle-pkg-list(case) :
-        val pkg = ipc-two-pin-landpattern(case, height)
-        landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
-      else :  ; example: case = "Axial"
-        val pkg = dummy-landpattern(2, [x(resistor) y(resistor)])
-        landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
-    else :
-      val pkg = dummy-landpattern(2, [x(resistor) y(resistor)])
-      landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+        port p : pin[1 through 2]
+        val sym = resistor-sym()
+        symbol = sym(p[1] => sym.p[1], p[2] => sym.p[2])
+        val case = case(resistor)
+        match(case: String) :
+          if check-valid-rectangle-pkg-list(case) :
+            val pkg = ipc-two-pin-landpattern(case, height)
+            landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+          else :  ; example: case = "Axial"
+            val pkg = dummy-landpattern(2, [x(resistor) y(resistor)])
+            landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+        else :
+          val pkg = dummy-landpattern(2, [x(resistor) y(resistor)])
+          landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
 
-    emodel = EModel-Resistor(resistance(resistor),
-                            emodel-pourcentage-tolerance(tolerance(resistor)),
-                            double-or-unknown(rated-power(resistor)))
-    reference-prefix = "R"
-    val TCR = TCR(resistor)
-    val rated-temperature = rated-temperature(resistor)
-    val tolerance = tolerance(resistor)
-    val resistance = resistance(resistor)
-    ; Backwards compatibility
-    property(self.resistor) = true
-    ; This is how parts-db does it
-    property(self.category) = "resistor"
-    property(self.trust) = trust(resistor)
-    property(self.x) = x(resistor)
-    property(self.y) = y(resistor)
-    property(self.z) = z(resistor)
-    property(self.mounting) = mounting(resistor)
-    match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
-    property(self.case) = /case(resistor)
-    property(self.metadata) = metadata(resistor)
-    property(self.type) = type(resistor)
-    match(tolerance: MinMaxRange):
-      ;[TODO] Current exporter IR crashes unless tolerance is a Double.
-      ;So this feature is commented out until that is fixed.
-      ;property(self.tolerance) = [min(tolerance), max(tolerance)]
-      property(self.tolerance) = max(tolerance)
-    property(self.resistance) = resistance
-    property(self.composition) = composition(resistor)  ; this is the type => "thick-film" in gen-res-cmp
-    property(self.rated-power) = /rated-power(resistor)
-    match(TCR: TCR): property(self.TCR) = [positive(TCR), negative(TCR)]
-    spice :
-      "[R] <p[1]> <p[2]> <resistance>"
-    set-properties-for-vendor-part-numbers(resistor)
-  my-resistor
+        emodel = EModel-Resistor(resistance(resistor),
+                                emodel-pourcentage-tolerance(tolerance(resistor)),
+                                double-or-unknown(rated-power(resistor)))
+        reference-prefix = "R"
+        val TCR = TCR(resistor)
+        val rated-temperature = rated-temperature(resistor)
+        val tolerance = tolerance(resistor)
+        val resistance = resistance(resistor)
+        ; Backwards compatibility
+        property(self.resistor) = true
+        ; This is how parts-db does it
+        property(self.category) = "resistor"
+        property(self.trust) = trust(resistor)
+        property(self.x) = x(resistor)
+        property(self.y) = y(resistor)
+        property(self.z) = z(resistor)
+        property(self.mounting) = mounting(resistor)
+        match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
+        property(self.case) = /case(resistor)
+        property(self.metadata) = metadata(resistor)
+        property(self.type) = type(resistor)
+        match(tolerance: MinMaxRange):
+          ;[TODO] Current exporter IR crashes unless tolerance is a Double.
+          ;So this feature is commented out until that is fixed.
+          ;property(self.tolerance) = [min(tolerance), max(tolerance)]
+          property(self.tolerance) = max(tolerance)
+        property(self.resistance) = resistance
+        property(self.composition) = composition(resistor)  ; this is the type => "thick-film" in gen-res-cmp
+        property(self.rated-power) = /rated-power(resistor)
+        match(TCR: TCR): property(self.TCR) = [positive(TCR), negative(TCR)]
+        spice :
+          "[R] <p[1]> <p[2]> <resistance>"
+        set-properties-for-vendor-part-numbers(resistor)
+      my-resistor
 
 ; ========================================================
 ; ================== Resistor Accessors ==================
@@ -294,7 +302,7 @@ defstruct Capacitor <: Component :
   rated-current-rms: Double|False ; Maximum rms current rating from manufacturer (Amperes)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
-  component: ComponentCode|False
+  component: ComponentCode
   vendor-part-numbers: Tuple<KeyValue<String, String>> with: (as-method => true)
 
 defstruct ESR :
@@ -330,7 +338,7 @@ public defn Capacitor (raw-json: JObject) -> Capacitor :
             optional-double(json, "rated-current-rms"),
             parse-sellers(json),
             optional-double(json, "resolved_price"),
-            optional-component(json),
+           ComponentCode(json["component"] as JObject),
             parse-vendor-part-numbers(json))
 
 defn parse-esr (json: JObject) -> ESR|False :
@@ -348,113 +356,121 @@ defn capacitor-temperature-coefficient (json: JObject) -> String|False :
 ; ========================================================
 
 defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
-  pcb-component my-capacitor :
-    val manufacturer-string = manufacturer(capacitor)
-    match(manufacturer-string: String) :
-      manufacturer = manufacturer-string
+  val component = component(capacitor)
+  match(landpattern(component)):
+    (lp:LandPatternCode):
+      ; If the landpattern is included, this part should have everything it needs.
+      to-jitx $ component
+    (c):
+      ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
+      ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
+      pcb-component my-capacitor :
+        val manufacturer-string = manufacturer(capacitor)
+        match(manufacturer-string: String) :
+          manufacturer = manufacturer-string
 
-    mpn = mpn(capacitor)
+        mpn = mpn(capacitor)
 
-    val description-string = lookup?(metadata(capacitor), "description")
-    match(description-string: String) :
-      description = description-string
+        val description-string = lookup?(metadata(capacitor), "description")
+        match(description-string: String) :
+          description = description-string
 
-    val type-string = type(capacitor)
-    val pol? = not (type-string == "ceramic" or type-string == "film")
-    val esr = esr(capacitor)
-    val case = case(capacitor)
-    val height = match(z(capacitor)):
-      (d:Double) : d
-      (f:False) : 0.4
-    if pol? :
-      pin a
-      pin c
-      val sym = capacitor-sym(CapacitorPolarized)
-      symbol = sym(a => sym.p[1], c => sym.p[2])
+        val type-string = type(capacitor)
+        val pol? = not (type-string == "ceramic" or type-string == "film")
+        val esr = esr(capacitor)
+        val case = case(capacitor)
+        val height = match(z(capacitor)):
+          (d:Double) : d
+          (f:False) : 0.4
+        if pol? :
+          pin a
+          pin c
+          val sym = capacitor-sym(CapacitorPolarized)
+          symbol = sym(a => sym.p[1], c => sym.p[2])
 
-      match(case: String) :
-        if check-valid-rectangle-pkg-list(case) :
-          val pkg = ipc-two-pin-landpattern(case, height, pol?)
-          landpattern = pkg(a => pkg.a, c => pkg.c)
+          match(case: String) :
+            if check-valid-rectangle-pkg-list(case) :
+              val pkg = ipc-two-pin-landpattern(case, height, pol?)
+              landpattern = pkg(a => pkg.a, c => pkg.c)
+            else :
+              val pkg = dummy-landpattern(2, [x(capacitor) y(capacitor)])
+              landpattern = pkg(a => pkg.p[1], c => pkg.p[2])
+          else :
+            val pkg = dummy-landpattern(2, [x(capacitor) y(capacitor)])
+            landpattern = pkg(a => pkg.p[1], c => pkg.p[2])
+
+          match(esr: ESR) :
+            val esr-value = value(esr)
+            spice :
+              "[C] <a> [tmp] <capacitance(capacitor)>"
+              "[R] [tmp] <c> <esr-value>"
+          else :
+            spice :
+              "[C] <a> <c> <capacitance(capacitor)>"
+
         else :
-          val pkg = dummy-landpattern(2, [x(capacitor) y(capacitor)])
-          landpattern = pkg(a => pkg.p[1], c => pkg.p[2])
-      else :
-        val pkg = dummy-landpattern(2, [x(capacitor) y(capacitor)])
-        landpattern = pkg(a => pkg.p[1], c => pkg.p[2])
+          port p : pin[1 through 2]
 
-      match(esr: ESR) :
-        val esr-value = value(esr)
-        spice :
-          "[C] <a> [tmp] <capacitance(capacitor)>"
-          "[R] [tmp] <c> <esr-value>"
-      else :
-        spice :
-          "[C] <a> <c> <capacitance(capacitor)>"
+          val sym = capacitor-sym()
+          symbol = sym(p[1] => sym.p[1], p[2] => sym.p[2])
 
-    else :
-      port p : pin[1 through 2]
+          match(case: String) :
+            if check-valid-rectangle-pkg-list(case) :
+              val pkg = ipc-two-pin-landpattern(case, height)
+              landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+            else :
+              val pkg = dummy-landpattern(2, [x(capacitor) y(capacitor)])
+              landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+          else :
+            val pkg = dummy-landpattern(2, [x(capacitor) y(capacitor)])
+            landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
 
-      val sym = capacitor-sym()
-      symbol = sym(p[1] => sym.p[1], p[2] => sym.p[2])
+          match(esr: ESR) :
+            val esr-value = value(esr)
+            spice :
+              "[C] <p[1]> [tmp] <capacitance(capacitor)>"
+              "[R] tmp <p[2]> <esr-value>"
+          else :
+            spice :
+              "[C] <p[1]> <p[2]> <capacitance(capacitor)>"
 
-      match(case: String) :
-        if check-valid-rectangle-pkg-list(case) :
-          val pkg = ipc-two-pin-landpattern(case, height)
-          landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
-        else :
-          val pkg = dummy-landpattern(2, [x(capacitor) y(capacitor)])
-          landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
-      else :
-        val pkg = dummy-landpattern(2, [x(capacitor) y(capacitor)])
-        landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+        set-properties-for-vendor-part-numbers(capacitor)
 
-      match(esr: ESR) :
-        val esr-value = value(esr)
-        spice :
-          "[C] <p[1]> [tmp] <capacitance(capacitor)>"
-          "[R] tmp <p[2]> <esr-value>"
-      else :
-        spice :
-          "[C] <p[1]> <p[2]> <capacitance(capacitor)>"
+        emodel = EModel-Capacitor(capacitance(capacitor),
+                                emodel-pourcentage-tolerance(tolerance(capacitor)),
+                                double-or-unknown(rated-voltage(capacitor)),
+                                pol?,
+                                UNKNOWN, ; FIXME: define low-esr? as below a certain threshold on the esr ?
+                                string-or-unknown(temperature-coefficient(capacitor)),
+                                UNKNOWN) ; FIXME: find out the dielectric information (look at type and anode?)
+        reference-prefix = "C"
+        val rated-temperature = rated-temperature(capacitor)
+        val capacitance = capacitance(capacitor)
+        val tolerance = tolerance(capacitor)
+        ; Backwards compatibility
+        property(self.capacitor) = true
+        ; This is how parts-db does it
+        property(self.category) = "capacitor"
+        property(self.trust) = trust(capacitor)
+        property(self.x) = x(capacitor)
+        property(self.y) = y(capacitor)
+        property(self.z) = z(capacitor)
+        property(self.mounting) = mounting(capacitor)
+        match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
+        property(self.metadata) = metadata(capacitor)
+        property(self.type) = type(capacitor)
+        match(tolerance: MinMaxRange): property(self.tolerance) = [min(tolerance), max(tolerance)]
+        property(self.capacitance) = capacitance
+        property(self.anode) = anode(capacitor)
+        property(self.electrolyte) = electrolyte(capacitor)
+        property(self.temperature-coefficient) = temperature-coefficient(capacitor)
+        match(esr: ESR): property(self.esr) = value(esr)
+        match(esr: ESR): property(self.esr-frequency) = frequency(esr)
+        property(self.rated-voltage) = /rated-voltage(capacitor)
+        property(self.rated-current-pk) = rated-current-pk(capacitor)
+        property(self.rated-current-rms) = rated-current-rms(capacitor)
 
-    set-properties-for-vendor-part-numbers(capacitor)
-
-    emodel = EModel-Capacitor(capacitance(capacitor),
-                             emodel-pourcentage-tolerance(tolerance(capacitor)),
-                             double-or-unknown(rated-voltage(capacitor)),
-                             pol?,
-                             UNKNOWN, ; FIXME: define low-esr? as below a certain threshold on the esr ?
-                             string-or-unknown(temperature-coefficient(capacitor)),
-                             UNKNOWN) ; FIXME: find out the dielectric information (look at type and anode?)
-    reference-prefix = "C"
-    val rated-temperature = rated-temperature(capacitor)
-    val capacitance = capacitance(capacitor)
-    val tolerance = tolerance(capacitor)
-    ; Backwards compatibility
-    property(self.capacitor) = true
-    ; This is how parts-db does it
-    property(self.category) = "capacitor"
-    property(self.trust) = trust(capacitor)
-    property(self.x) = x(capacitor)
-    property(self.y) = y(capacitor)
-    property(self.z) = z(capacitor)
-    property(self.mounting) = mounting(capacitor)
-    match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
-    property(self.metadata) = metadata(capacitor)
-    property(self.type) = type(capacitor)
-    match(tolerance: MinMaxRange): property(self.tolerance) = [min(tolerance), max(tolerance)]
-    property(self.capacitance) = capacitance
-    property(self.anode) = anode(capacitor)
-    property(self.electrolyte) = electrolyte(capacitor)
-    property(self.temperature-coefficient) = temperature-coefficient(capacitor)
-    match(esr: ESR): property(self.esr) = value(esr)
-    match(esr: ESR): property(self.esr-frequency) = frequency(esr)
-    property(self.rated-voltage) = /rated-voltage(capacitor)
-    property(self.rated-current-pk) = rated-current-pk(capacitor)
-    property(self.rated-current-rms) = rated-current-rms(capacitor)
-
-  my-capacitor
+      my-capacitor
 
 ; ========================================================
 ; ================ Capacitor Accessors ===================
@@ -545,7 +561,7 @@ defstruct Inductor <: Component :
   self-resonant-frequency: Double|False ; Frequency at which inductor impedance becomes very high / open circuit (freq in Hz)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
-  component: ComponentCode|False
+  component: ComponentCode
   vendor-part-numbers: Tuple<KeyValue<String, String>> with: (as-method => true)
 
 public defn Inductor (raw-json: JObject) -> Inductor :
@@ -576,7 +592,7 @@ public defn Inductor (raw-json: JObject) -> Inductor :
            optional-double(json, "self-resonant-frequency"),
            parse-sellers(json),
            optional-double(json, "resolved_price"),
-           optional-component(json),
+           ComponentCode(json["component"] as JObject),
            parse-vendor-part-numbers(json))
 
 ; ========================================================
@@ -584,65 +600,73 @@ public defn Inductor (raw-json: JObject) -> Inductor :
 ; ========================================================
 
 defmethod to-jitx (inductor: Inductor) -> Instantiable :
-  pcb-component my-inductor :
-    val manufacturer-string = manufacturer(inductor)
-    match(manufacturer-string: String) :
-      manufacturer = manufacturer-string
+  val component = component(inductor)
+  match(landpattern(component)):
+    (lp:LandPatternCode):
+      ; If the landpattern is included, this part should have everything it needs.
+      to-jitx $ component
+    (c):
+      ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
+      ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
+      pcb-component my-inductor :
+        val manufacturer-string = manufacturer(inductor)
+        match(manufacturer-string: String) :
+          manufacturer = manufacturer-string
 
-    mpn = mpn(inductor)
+        mpn = mpn(inductor)
 
-    val description-string = lookup?(metadata(inductor), "description")
-    match(description-string: String) :
-      description = description-string
+        val description-string = lookup?(metadata(inductor), "description")
+        match(description-string: String) :
+          description = description-string
 
-    port p : pin[1 through 2]
-    val sym = inductor-sym()
-    symbol = sym(p[1] => sym.p[1], p[2] => sym.p[2])
-    val case = case(inductor)
-    match(case: String) :
-      if all?(digit?, to-seq(case)) :
-        val pkg = ipc-two-pin-landpattern(case)
-        landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
-      else :  ; example: case = "Axial"
-        val pkg = dummy-landpattern(2, [x(inductor) y(inductor)])
-        landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
-    else :
-      val pkg = dummy-landpattern(2, [x(inductor) y(inductor)])
-      landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+        port p : pin[1 through 2]
+        val sym = inductor-sym()
+        symbol = sym(p[1] => sym.p[1], p[2] => sym.p[2])
+        val case = case(inductor)
+        match(case: String) :
+          if all?(digit?, to-seq(case)) :
+            val pkg = ipc-two-pin-landpattern(case)
+            landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+          else :  ; example: case = "Axial"
+            val pkg = dummy-landpattern(2, [x(inductor) y(inductor)])
+            landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
+        else :
+          val pkg = dummy-landpattern(2, [x(inductor) y(inductor)])
+          landpattern = pkg(p[1] => pkg.p[1], p[2] => pkg.p[2])
 
-    val inductance = inductance(inductor)
-    emodel = EModel-Inductor(inductance,
-                             emodel-pourcentage-tolerance(tolerance(inductor)),
-                             double-or-unknown(current-rating(inductor)))
-    reference-prefix = "L"
-    val rated-temperature = rated-temperature(inductor)
-    val tolerance = tolerance(inductor)
-    ; Backwards compatibility
-    property(self.inductor) = true
-    ; This is how parts-db does it
-    property(self.category) = "inductor"
-    property(self.trust) = trust(inductor)
-    property(self.x) = x(inductor)
-    property(self.y) = y(inductor)
-    property(self.z) = z(inductor)
-    property(self.mounting) = mounting(inductor)
-    match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
-    property(self.case) = /case(inductor)
-    property(self.metadata) = metadata(inductor)
-    property(self.type) = type(inductor)
-    match(tolerance: MinMaxRange): property(self.tolerance) = [min(tolerance), max(tolerance)]
-    property(self.inductance) = inductance
-    property(self.material-core) = material-core(inductor)
-    property(self.shielding) = shielding(inductor)
-    property(self.current-rating) = current-rating(inductor)
-    property(self.saturation-current) = saturation-current(inductor)
-    property(self.dc-resistance) = dc-resistance(inductor)
-    property(self.quality-factor) = quality-factor(inductor)
-    property(self.self-resonant-frequency) = self-resonant-frequency(inductor)
-    spice :
-      "[L] <p[1]> <p[2]> <inductance>"
-    set-properties-for-vendor-part-numbers(inductor)
-  my-inductor
+        val inductance = inductance(inductor)
+        emodel = EModel-Inductor(inductance,
+                                emodel-pourcentage-tolerance(tolerance(inductor)),
+                                double-or-unknown(current-rating(inductor)))
+        reference-prefix = "L"
+        val rated-temperature = rated-temperature(inductor)
+        val tolerance = tolerance(inductor)
+        ; Backwards compatibility
+        property(self.inductor) = true
+        ; This is how parts-db does it
+        property(self.category) = "inductor"
+        property(self.trust) = trust(inductor)
+        property(self.x) = x(inductor)
+        property(self.y) = y(inductor)
+        property(self.z) = z(inductor)
+        property(self.mounting) = mounting(inductor)
+        match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
+        property(self.case) = /case(inductor)
+        property(self.metadata) = metadata(inductor)
+        property(self.type) = type(inductor)
+        match(tolerance: MinMaxRange): property(self.tolerance) = [min(tolerance), max(tolerance)]
+        property(self.inductance) = inductance
+        property(self.material-core) = material-core(inductor)
+        property(self.shielding) = shielding(inductor)
+        property(self.current-rating) = current-rating(inductor)
+        property(self.saturation-current) = saturation-current(inductor)
+        property(self.dc-resistance) = dc-resistance(inductor)
+        property(self.quality-factor) = quality-factor(inductor)
+        property(self.self-resonant-frequency) = self-resonant-frequency(inductor)
+        spice :
+          "[L] <p[1]> <p[2]> <inductance>"
+        set-properties-for-vendor-part-numbers(inductor)
+      my-inductor
 
 ; ========================================================
 ; ================= Inductor Accessors ===================
@@ -900,12 +924,6 @@ public defn parse-sellers (json: JObject) -> Tuple<Seller>|False:
             for json-price in json-offer["prices"] as Tuple<JObject> map :
               SellerOfferPrice(int(json-price["quantity"]), json-price["converted_price"] as Double)
 
-defn optional-component (json: JObject) -> ComponentCode|False :
-  match(get?(json, "component")) :
-    (j:JObject) :
-      ComponentCode(j)
-    (_) : false
-
 defn optional-mounting (json: JObject) -> String :
   match(get?(json, "mounting")) :
     (s:String) : s
@@ -956,8 +974,6 @@ public defn query-properties (user-properties:Tuple<KeyValue>,
         yield("max-rated-temperature.min" => min-value(operating-temperature))
         yield("min-rated-temperature.max" => max-value(operating-temperature))
 
-      yield("vendor_part_numbers.digi-key" => exist)
-
   ; `user-properties` override default properties
   to-tuple $ hashtable-union<String, ?> $ [["category" => category],
                                            optional-properties,
@@ -992,9 +1008,9 @@ public defn dbquery-first-allow-non-stock (args: Tuple<KeyValue<String, Tuple<St
 ; Default to a subset of parts while we're vetting an expanded set.
 ; TODO: JITX-4302 - Remove this, once we've built more confidnce in the expanded set.
 defn maybe-insert-default-vendor-part-number (exist:Tuple<String>) -> Tuple<String> :
-  val exist-vector = to-vector<String> $ exist
-  if find({prefix?(_, "vendor_part_numbers.")}, exist-vector) is String:
+  if DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS :
     exist
   else :
+    val exist-vector = to-vector<String> $ exist
     add(exist-vector, "vendor_part_numbers.digi-key")
     to-tuple $ exist-vector

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -227,7 +227,7 @@ defn resistor-query-properties (user-properties:Tuple<KeyValue>,
                                 sort:Tuple<String>,
                                 operating-temperature:Toleranced|False) -> Tuple<KeyValue> :
   query-properties(user-properties,
-                   exist,
+                   maybe-insert-default-vendor-part-number(exist),
                    sort,
                    operating-temperature,
                    "resistor",
@@ -479,7 +479,7 @@ defn capacitor-query-properties (user-properties:Tuple<KeyValue>,
                                 sort:Tuple<String>,
                                 operating-temperature:Toleranced|False) -> Tuple<KeyValue> :
   query-properties(user-properties,
-                   exist,
+                   maybe-insert-default-vendor-part-number(exist),
                    sort,
                    operating-temperature,
                    "capacitor",
@@ -671,7 +671,7 @@ defn inductor-query-properties (user-properties:Tuple<KeyValue>,
                                 sort:Tuple<String>,
                                 operating-temperature:Toleranced|False) -> Tuple<KeyValue> :
   query-properties(user-properties,
-                   exist,
+                   maybe-insert-default-vendor-part-number(exist),
                    sort,
                    operating-temperature,
                    "inductor",
@@ -956,6 +956,8 @@ public defn query-properties (user-properties:Tuple<KeyValue>,
         yield("max-rated-temperature.min" => min-value(operating-temperature))
         yield("min-rated-temperature.max" => max-value(operating-temperature))
 
+      yield("vendor_part_numbers.digi-key" => exist)
+
   ; `user-properties` override default properties
   to-tuple $ hashtable-union<String, ?> $ [["category" => category],
                                            optional-properties,
@@ -987,4 +989,12 @@ public defn dbquery-first-allow-non-stock (args: Tuple<KeyValue<String, Tuple<St
     else :
       throw(e)
 
-
+; Default to a subset of parts while we're vetting an expanded set.
+; TODO: JITX-4302 - Remove this, once we've built more confidnce in the expanded set.
+defn maybe-insert-default-vendor-part-number (exist:Tuple<String>) -> Tuple<String> :
+  val exist-vector = to-vector<String> $ exist
+  if find({prefix?(_, "vendor_part_numbers.")}, exist-vector) is String:
+    exist
+  else :
+    add(exist-vector, "vendor_part_numbers.digi-key")
+    to-tuple $ exist-vector

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -1011,6 +1011,4 @@ defn maybe-insert-default-vendor-part-number (exist:Tuple<String>) -> Tuple<Stri
   if DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS :
     exist
   else :
-    val exist-vector = to-vector<String> $ exist
-    add(exist-vector, "vendor_part_numbers.digi-key")
-    to-tuple $ exist-vector
+    to-tuple $ cat(exist, ["vendor_part_numbers.digi-key"])

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -21,7 +21,7 @@ public var MAX-Z = 500.0
 public var MIN-PKG = "0402"
 public var PREFERRED-MOUNTING = "smd" ; values in ["smd", "through-hole"]
 public var MIN-CAP-VOLTAGE = 10.0 ; Minimum voltage to allow for capacitors
-public var DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
+public var DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = false
 
 ; Landpattern variables
 public var DENSITY-LEVEL: DensityLevel = DensityLevelC

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -21,6 +21,7 @@ public var MAX-Z = 500.0
 public var MIN-PKG = "0402"
 public var PREFERRED-MOUNTING = "smd" ; values in ["smd", "through-hole"]
 public var MIN-CAP-VOLTAGE = 10.0 ; Minimum voltage to allow for capacitors
+public var DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
 
 ; Landpattern variables
 public var DENSITY-LEVEL: DensityLevel = DensityLevelC

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -21,7 +21,7 @@ public var MAX-Z = 500.0
 public var MIN-PKG = "0402"
 public var PREFERRED-MOUNTING = "smd" ; values in ["smd", "through-hole"]
 public var MIN-CAP-VOLTAGE = 10.0 ; Minimum voltage to allow for capacitors
-public var DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = false
+public var DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS:True|False = false
 
 ; Landpattern variables
 public var DENSITY-LEVEL: DensityLevel = DensityLevelC

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -65,20 +65,13 @@ with :
 
 ; Parse parts conditionally, based on their category.
 public defn parse-component (json: JObject) -> Component :
-  val component-code = json["component"] as JObject
-  match(component-code["landpattern"]):
-    (lp:JObject):
-      ; If the landpattern is included, this part should have everything it needs.
-      Part(json)
-    (c):
-      ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
-      ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
-      match(json["category"]):
-        (c:String):
-          switch(c):
-            "capacitor": Capacitor(json)
-            "inductor": Inductor(json)
-            "resistor": Resistor(json)
+  match(json["category"]):
+    (c:String):
+      switch(c):
+        "capacitor": Capacitor(json)
+        "inductor": Inductor(json)
+        "resistor": Resistor(json)
+        else: Part(json)
 
 ;======================================
 ;============= Internals ==============
@@ -895,7 +888,7 @@ public-when(TESTING) defn PCBLayerValue (json: JObject) -> PCBLayerValue :
     Text(json["text"] as JObject),
   )
 
-public-when(TESTING) defstruct LandPatternCode :
+public defstruct LandPatternCode :
   name: String
   pads: Tuple<LandPatternPadCode>
   pcb-layer-reference: PCBLayerReference

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -30,7 +30,7 @@ public defn PartsDBComponent (user-properties:Tuple<KeyValue>) -> Component :
     ["_type" => "parts-db"],
     user-properties
   ]
-  parse-component $ dbquery-first(query-properties) as JObject
+  parse-component $ dbquery-first-allow-non-stock(query-properties) as JObject
 
 ; WARNING: This is an alpha feature at the moment.
 public defn PartsDBComponents (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Component> :

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -72,6 +72,8 @@ public defn parse-component (json: JObject) -> Component :
         "inductor": Inductor(json)
         "resistor": Resistor(json)
         else: Part(json)
+    (c:JNull):
+      Part(json)
 
 ;======================================
 ;============= Internals ==============


### PR DESCRIPTION
This migrates queries off the V1 DB _almost_ entirely (except STM MCUs).

## Procedural Insertion
The V1 parts have their pins/symbols/landpatterns procedurally inserted by the client.

This continues to happen for the V1 parts (missing landpattern), until we move that logic offline as part of JITX-4198.

## Filtering V1 API to V1 parts
We are still evaluating the quality of the data in the extended parts-db.

In the short-term, we limit the V1 API calls (like `chip-resistor()`) to use the previous V1 parts.

This can be overriden by toggling this design-vars variable:
- DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS

We plan to remove this as a follow-up in JITX-4302.

## Test Plan
```
import ocdb/utils/generic-components
view-design-explorer $ chip-resistor(1000.0)
view-design-explorer $ ceramic-cap([])
view-design-explorer $ smd-inductor([])
```

Set `DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS` to true, and verify other part:
```
import ocdb/utils/generic-components
clear-dbquery-cache()
view-design-explorer $ chip-resistor(["resistance" => 1300.0, "vendor_part_numbers.lcsc" => "C1471"])
```