### PR TITLE
JITX-4238: Hack to insert ">REF" and ">VALUE" for all symbols

### DIFF
--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -1047,6 +1047,13 @@ defn to-jitx (s: SymbolCode) -> SchematicSymbol :
     do(to-jitx, pins(s))
     do(to-jitx, layers(s))
 
+    ; Hack this in, as it's required for replacement by downstream calls.
+    ; For example, we use it to ensure a resistor's "Value" gets set properly in "Symbol Properties".
+    ;
+    ; TODO: JITX-4238 - replace with parts-db offline logic
+    layer("reference") = Text(">REF", 0.7056, W, loc(2.54, 1.27), "", TrueTypeFont)
+    layer("value") = Text(">VALUE", 0.7056, W, loc(2.54, -1.27), "", TrueTypeFont)
+
   my-symbol
 
 defn to-jitx (p: SymbolPinCode) :


### PR DESCRIPTION
The parts-db component symbols aren't inserting ">REF" and ">VALUE" Text symbols.

These are required for:
- Rendering in JITX view
- Exporting to KiCad (so it shows up as "Value" in "Symbol Properties"

In the short term, we're hacking this into OCDB deserialization, but the plan is to
fix it properly by inserting these during parts-db population.