### PR TITLE
JITX-4374: Datasheet is now top-level component field

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -156,6 +156,7 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
           manufacturer = manufacturer-string
 
         mpn = mpn(resistor)
+        datasheet = datasheet(component)
         val height = z(resistor)
 
         val description-string = lookup?(metadata(resistor), "description")
@@ -370,6 +371,7 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
           manufacturer = manufacturer-string
 
         mpn = mpn(capacitor)
+        datasheet = datasheet(component)
 
         val description-string = lookup?(metadata(capacitor), "description")
         match(description-string: String) :
@@ -614,6 +616,7 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
           manufacturer = manufacturer-string
 
         mpn = mpn(inductor)
+        datasheet = datasheet(component)
 
         val description-string = lookup?(metadata(inductor), "description")
         match(description-string: String) :

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -105,6 +105,7 @@ public defstruct ComponentCode :
   description: String
   manufacturer: String
   mpn: String
+  datasheet: String
   reference_prefix: String
   emodel: EModel|False
   pin-properties: False|PinPropertiesCode
@@ -253,6 +254,7 @@ public defn ComponentCode (json: JObject) -> ComponentCode :
     json["description"] as String,
     json["manufacturer"] as String,
     json["mpn"] as String,
+    json["datasheet"] as String,
     json["reference_prefix"] as String,
     emodel,
     PinPropertiesCode(json["pin_properties"] as JObject),
@@ -514,6 +516,8 @@ public defn to-jitx (c: ComponentCode) -> Instantiable :
     val mpn = mpn(c)
     match(mpn: String) :
       mpn = mpn
+
+    datasheet = datasheet(c)
 
     val emodel = emodel(c)
     match(emodel: EModel) :


### PR DESCRIPTION
Fix a bug where datasheets weren't showing for parts-db components.

Related [parts-db PR](https://github.com/JITx-Inc/parts-db/pull/57).