### PR TITLE
JITX-4034: Remove alpha warnings for parts-db

### DIFF
--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -135,25 +135,18 @@ public defn closest-std-val (v:Double, tol:Double) :
 ; ==================== PartsDB ===========================
 ; ========================================================
 
-; TODO: JITX-4034 - Remove these warnings
-
-; WARNING: This is an alpha feature at the moment.
 public defn database-part (mpn: String) -> Instantiable :
   to-jitx $ PartsDBComponent(["mpn" => mpn])
 
-; WARNING: This is an alpha feature at the moment.
 public defn database-part (mpn: String, manufacturer: String) -> Instantiable :
   to-jitx $ PartsDBComponent(["mpn" => mpn, "manufacturer" => manufacturer])
 
-; WARNING: This is an alpha feature at the moment.
 public defn database-part (user-params:Tuple<KeyValue>) -> Instantiable :
   to-jitx $ PartsDBComponent(user-params)
 
-; WARNING: This is an alpha feature at the moment.
 public defn database-parts (user-params:Tuple<KeyValue>) -> Tuple<Instantiable> :
   map(to-jitx, PartsDBComponents(user-params, 10))
 
-; WARNING: This is an alpha feature at the moment.
 public defn database-parts (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
   map(to-jitx, PartsDBComponents(user-params, limit))
 

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -22,23 +22,18 @@ defpackage ocdb/utils/parts :
 ;============ Public API ==============
 ;======================================
 
-; TODO: JITX-4034 - Remove these warnings
-
-; WARNING: This is an alpha feature at the moment.
 public defn PartsDBComponent (user-properties:Tuple<KeyValue>) -> Component :
   val query-properties = remove-duplicate-keys $ [
     user-properties
   ]
   parse-component $ dbquery-first-allow-non-stock(query-properties) as JObject
 
-; WARNING: This is an alpha feature at the moment.
 public defn PartsDBComponents (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Component> :
   val query-properties = remove-duplicate-keys $ [
     user-properties
   ]
   map{parse-component, _} $ dbquery(query-properties, limit) as Tuple<JObject>
 
-; WARNING: This is an alpha feature at the moment.
 public defstruct Part <: Component :
   component: ComponentCode
   description: String


### PR DESCRIPTION
We're relying on parts-db for most DB calls now.