### PR TITLE
replace set-design-directory with set-current-design

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.0.1-physical-develop.32
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.0.1-physical-develop.33
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.0.1-physical-develop.31
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.0.1-physical-develop.32
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.13-rc.31
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.0.1-physical-develop.31
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:0.0.1-physical-develop.33
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.13-rc.58
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.13-rc.58
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.13-rc.60
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -31,7 +31,7 @@ pcb-bundle pms7003-interface :
 
 pcb-module pms7003 :
   port interface : pms7003-interface
-  
+
   inst header : ocdb/components/amphenol/minitek127/component(10)
   place(header) at loc(0.0, 0.0) on Top
   net (interface.vin.gnd interface.vin-mcu.gnd header.p[3] header.p[4])
@@ -46,11 +46,11 @@ pcb-module pms7003 :
   property(header.p[10].digital-output) = DigitalOutput(CMOSOutput(min-max(0.3, 0.5), min-max(2.6, 3.3)), false, header.p[1], header.p[3])
   val vil = typ(0.8)
   val vih = typ(2.0)
-  property(header.p[8].digital-input) = 
+  property(header.p[8].digital-input) =
     DigitalInput(vil, vih, header.p[1], header.p[3], 1.0e-6)
-  property(header.p[6].digital-input) = 
+  property(header.p[6].digital-input) =
     DigitalInput(vil, vih, header.p[1], header.p[3], 1.0e-6)
-  property(header.p[9].digital-input) = 
+  property(header.p[9].digital-input) =
     DigitalInput(vil, vih, header.p[1], header.p[3], 1.0e-6)
 
 pcb-module sensors :
@@ -96,7 +96,7 @@ pcb-module sensors :
   ; Add the particle counter interface and place on bottom, and connect
   public inst particle-counter : pms7003
 
-  net (particle-counter.interface particle-counter-interface) 
+  net (particle-counter.interface particle-counter-interface)
   net (protected-usb.vbus particle-counter.interface.vin)
 
   ; Connect power to sensors
@@ -142,7 +142,7 @@ pcb-module sensors :
 
 pcb-module sensor-system (processor:Instantiable, board-outline:Rectangle):
   inst sensors : sensors
-  
+
   val x = width(board-outline) / 2.0
   val y = height(board-outline) / 2.0
   place(sensors.usb) at loc(4.0 - x, 7.0 - y) on Top
@@ -188,19 +188,19 @@ pcb-module sensor-system (processor:Instantiable, board-outline:Rectangle):
 defn run-design (run-checks?:True|False) :
   val outline = Rectangle(45.0, 30.0)
   val circuit = sensor-system(ocdb/components/espressif/esp32-wroom-32/module(ocdb/components/espressif/esp32-wroom-32/ESP32-WROOM-32E-N16), outline)
-  set-design-directory("ble-mote")
+  set-current-design("ble-mote")
   set-board(ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, outline))
   set-rules(ocdb/manufacturers/rules/jlcpcb-rules)
 
   var main-module = circuit
   if run-checks? :
     main-module = ocdb/utils/generator-utils/run-final-passes(circuit) ; Analyze design with a pass
-  
+
   set-main-module(main-module) ; Treat the provided module as a design, and compile it.
-  
+
   if run-checks? :
     run-checks("checks.txt")
-  else:  
+  else:
     view-board()
     view-schematic()
     view-design-explorer()
@@ -220,10 +220,10 @@ defn check-design () :
 ; ======================
 ; Export a design to CAD
 ; ======================
-defn export-design (module:Instantiable, shape:Rectangle, directory:String) :
-  set-export-backend(`altium)
+defn export-design (module:Instantiable, shape:Rectangle, name:String) :
+  set-export-backend(`kicad)
 
-  set-design-directory(directory)
+  set-current-design(name)
   set-board(ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, shape))
   set-rules(ocdb/manufacturers/rules/jlcpcb-rules)
   set-main-module(module)
@@ -246,12 +246,12 @@ defn export-bill-of-materials () :
 
 ; val pico-shape = Rectangle(35.0, 20.0)
 ; export-design(sensor-system(ocdb/components/espressif/ESP32-PICO-D4/module, pico-shape)
-;               pico-shape, 
+;               pico-shape,
 ;               "air-quality-sensor-pico")
 
 ; val wroom-shape = Rectangle(45.0, 30.0)
 ; export-design(sensor-system(ocdb/components/espressif/esp32-wroom-32/module(ocdb/components/espressif/esp32-wroom-32/ESP32-WROOM-32E-N16), wroom-shape)
-;               wroom-shape, 
+;               wroom-shape,
 ;               "air-quality-sensor-wroom")
 
 run-design(false)

--- a/designs/checks/checked-design.stanza
+++ b/designs/checks/checked-design.stanza
@@ -32,7 +32,7 @@ pcb-module main-module :
   check-design(self)
 
 defn main () :
-  set-design-directory("checked-design")
+  set-current-design("checked-design")
   run-final-passes(main-module)
   run-checks("checks.txt")
 

--- a/designs/comprehensive-checks.stanza
+++ b/designs/comprehensive-checks.stanza
@@ -1,6 +1,6 @@
 ; This design contains a set of components with explicitly created properties,
 ; intended to drive the pcb-checks run by ocdb/utils/checks/check-design function.
-; 
+;
 ; It is not intended as a meaningful schematic, rather a dummy project that shows
 ; all the properties required to set for passives and actives when running your code.
 ;
@@ -35,7 +35,7 @@ pcb-component resistor :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
-  
+
   assign-landpattern(ipc-two-pin-landpattern("0603"))
   val sym = resistor-sym()
   symbol =
@@ -57,7 +57,7 @@ pcb-component inductor :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
-  
+
   assign-landpattern(ipc-two-pin-landpattern("0603"))
   val sym = inductor-sym()
   symbol =
@@ -79,7 +79,7 @@ pcb-component ceramic-capacitor :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
-  
+
   assign-landpattern(ipc-two-pin-landpattern("0603"))
   val sym = resistor-sym()
   symbol =
@@ -98,7 +98,7 @@ pcb-component electrolytic-cap :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
-  
+
   assign-landpattern(ipc-two-pin-landpattern("0603"))
   val sym = capacitor-sym()
   symbol =
@@ -120,7 +120,7 @@ pcb-component mica-cap :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
-  
+
   assign-landpattern(ipc-two-pin-landpattern("0603"))
   val sym = capacitor-sym()
   symbol =
@@ -139,7 +139,7 @@ pcb-component mylar-cap :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
-  
+
   assign-landpattern(ipc-two-pin-landpattern("0603"))
   val sym = capacitor-sym()
   symbol =
@@ -162,18 +162,18 @@ pcb-component crystal-resonator :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
-  
+
   assign-landpattern(ipc-two-pin-landpattern("0603"))
   val sym = crystal-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
-  
+
   property(self.rated-temperature) = min-max(-55.0, 100.0)
 
   ; Set the crystal resonator properties
-  property(self.crystal-resonator) = 
+  property(self.crystal-resonator) =
     CrystalResonator(
-      load-capacitance, shunt-capacitance, motional-capacitance, 
+      load-capacitance, shunt-capacitance, motional-capacitance,
       ESR, frequency, frequency-tolerance, max-drive-level
     ) where :
       val load-capacitance = 9.0e-12
@@ -189,7 +189,7 @@ pcb-module resonator-module :
   public inst C1 : ceramic-capacitor
   property(C1.tolerance) = [0.99, 1.01]
   val intf = CrystalOscillator(
-    max-critical-gain, drive-level, 
+    max-critical-gain, drive-level,
     c-pin, frequency-tolerance, frequency
   ) where :
     val max-critical-gain = 2.0e-3
@@ -216,7 +216,7 @@ pcb-component component :
     [ p[6]      | 6              | Right ]
     [ p[7]      | 7              | Right ]
     [ p[8]      | 8              | Right ]
-  
+
   assign-landpattern(ocdb/components/st-microelectronics/landpatterns/LQFP32)
   make-box-symbol()
 
@@ -243,7 +243,7 @@ pcb-module passives :
   property(C4.operating-point) = OperatingPoint(typ(5.0), typ(0.5e-6))
   property(R1.operating-point) = OperatingPoint(typ(5.0), typ(0.5e-6))
   property(L1.operating-point) = OperatingPoint(typ(5.0), typ(0.5e-6))
-  
+
   no-connect(C1.p[1])
   no-connect(C1.p[2])
 
@@ -254,12 +254,12 @@ pcb-module passives :
   ; Resonators
   inst res : resonator-module
   property(res.C1.operating-point) = OperatingPoint(typ(5.0), typ(0.5e-6))
- 
+
 ;==============================================================================
 ;============================= I/O Propertiese ================================
 ;==============================================================================
-; For digital I/O the following properties must be set: 
-; 
+; For digital I/O the following properties must be set:
+;
 ; - digital-output: DigitalOutput. The pin is a digital output (only) pin.
 ; - digital-input: DigitalInput. The pin is a digital input (only) pin.
 ; - digital-io: DigitalIO. The pin functions as either a digital input or
@@ -276,31 +276,31 @@ pcb-component digital-source (io?:True|False,
     [ vdd  | 1 | Up    ]
     [ out  | 2 | Right ]
     [ gnd  | 3 | Down  ]
-  
+
   make-box-symbol()
   assign-landpattern(SOT23())
   val vol = min-max(0.1, 0.5)
   val voh = min-max(3.0, 3.3)
 
-  val driver = 
+  val driver =
     switch(case) :
-      "open-collector": 
+      "open-collector":
         OpenCollector(vol 6.0)
-      "cmos": 
+      "cmos":
         CMOSOutput(vol, voh)
-      "ttl" : 
+      "ttl" :
         TTLOutput(vol, voh)
-  
-  if io? : 
-    property(self.out.digital-io) = 
-      DigitalIO(driver, typ(0.8), typ(2.0), 
-                self.vdd, self.gnd, 10.0e-6) 
+
+  if io? :
+    property(self.out.digital-io) =
+      DigitalIO(driver, typ(0.8), typ(2.0),
+                self.vdd, self.gnd, 10.0e-6)
   else :
-    property(self.out.digital-output) = 
+    property(self.out.digital-output) =
       DigitalOutput(driver, tristateable?, self.vdd, self.gnd)
 
   property(self.rated-temperature) = min-max(-55.0, 100.0)
-  
+
 pcb-component digital-sink (io?:True|False,
                             case:String):
   pin-properties :
@@ -312,21 +312,21 @@ pcb-component digital-sink (io?:True|False,
   make-box-symbol()
   assign-landpattern(SOT23())
 
-  val driver = 
+  val driver =
     switch(case) :
-      "open-collector": 
+      "open-collector":
         OpenCollector(min-max(3.3, 5.0), 6.0)
-      "cmos": 
+      "cmos":
         CMOSOutput(min-max(0.1, 0.5), min-max(4.0, 5.0))
-      "ttl" : 
+      "ttl" :
         TTLOutput(min-max(0.1, 0.5), min-max(4.0, 5.0))
-  
+
   if io? :
-    property(self.in.digital-io) = 
-      DigitalIO(driver, typ(0.8), typ(2.0), 
-                self.vdd, self.gnd, 10.0e-6) 
+    property(self.in.digital-io) =
+      DigitalIO(driver, typ(0.8), typ(2.0),
+                self.vdd, self.gnd, 10.0e-6)
   else :
-    property(self.in.digital-input) = 
+    property(self.in.digital-input) =
       DigitalInput(typ(0.8), typ(2.0), self.vdd, self.gnd, 10.0e-6)
 
   property(self.rated-temperature) = min-max(-55.0, 100.0)
@@ -334,13 +334,13 @@ pcb-component digital-sink (io?:True|False,
 pcb-module digital-io :
   val cases = ["open-collector", "cmos", "ttl"]
 
-  val sink = to-tuple $  
+  val sink = to-tuple $
     for io? in [false, true] seq-cat :
       for case in cases seq :
         inst sink : digital-sink(io?, case)
         sink
 
-  val source = to-tuple $ 
+  val source = to-tuple $
     for io? in [false, true] seq-cat :
       for case in cases seq :
         val name = to-symbol $ string-join([`source, case, io?], "-")
@@ -358,7 +358,7 @@ pcb-module digital-io :
     net (source[n].vdd, sink[n].vdd, VDD, Rpullup.p[1])
     net dat (source[n].out, sink[n].in, Rpullup.p[2])
     property(Rpullup.p[1].voltage) = property(VDD.voltage)
-    property(Rpullup.operating-point) = OperatingPoint(typ(5.2), typ(5.0e-3))  
+    property(Rpullup.operating-point) = OperatingPoint(typ(5.2), typ(5.0e-3))
 
 pcb-component relative-io :
   property(self.rated-temperature) = min-max(-55.0, 100.0)
@@ -372,7 +372,7 @@ pcb-component relative-io :
   assign-landpattern(SOT23())
 
   val gp = GenericPin(FractionalVoltage(0.75, self.vdd), 200.0)
-  val io = 
+  val io =
     DigitalIO(driver, vil, vih, vdd-pin, gnd-pin, leakage-current)
     where :
       val driver = CMOSOutput(min-max(0.1, 0.5), OffsetVoltage(-0.3, self.vdd))
@@ -396,10 +396,10 @@ pcb-module relative-io-module :
 
   property(VDD.voltage) = min-max(0.0, 5.0)
   property(GND.voltage) = typ(0.0)
-  
+
   symbol(VDD) = supply-sym
   symbol(GND) = ground-sym
-  
+
 
 pcb-module realistic-design :
   port source : power
@@ -444,12 +444,12 @@ pcb-module realistic-design :
 
   net (stm[0].mcu.PA[2] stm[2].mcu.PA[4])
   net (stm[0].mcu.PA[3] stm[1].mcu.PA[4])
-  
+
 
 ;==============================================================================
 ;==============================================================================
 ;==============================================================================
-pcb-module main-module : 
+pcb-module main-module :
   inst passives    : passives
   inst digital-io  : digital-io
   inst relative-io : relative-io-module
@@ -463,7 +463,7 @@ pcb-module main-module :
   check-design(self)
 
 defn main () :
-  set-design-directory("comprehensive-checks") 
+  set-current-design("comprehensive-checks")
   set-board(ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, Rectangle(100.0 100.0)))
   set-rules(ocdb/manufacturers/rules/jlcpcb-rules)
   set-main-module(ocdb/utils/generator-utils/run-final-passes(main-module))

--- a/designs/power-state-demo.stanza
+++ b/designs/power-state-demo.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx)
-defpackage ocdb/designs/power-state-demo : 
+defpackage ocdb/designs/power-state-demo :
   import core
   import collections
   import jitx
@@ -12,17 +12,17 @@ defpackage ocdb/designs/power-state-demo :
   import ocdb/utils/property-structs
 
 pcb-landpattern soic127-p8:
-  make-n-pin-soic-landpattern(8, 
-                              1.27, 
-                              tol(6.0, 0.2), 
-                              tol(3.9, 0.1), 
-                              tol(4.9, 0.1), 
-                              min-typ-max(0.4, 1.04, 1.27), 
+  make-n-pin-soic-landpattern(8,
+                              1.27,
+                              tol(6.0, 0.2),
+                              tol(3.9, 0.1),
+                              tol(4.9, 0.1),
+                              min-typ-max(0.4, 1.04, 1.27),
                               min-typ-max(0.28, 0.38, 0.48),
                               false)
 
-pcb-component Microcontroller : 
-  pin-properties : 
+pcb-component Microcontroller :
+  pin-properties :
     [pin: Ref | pads: Ref ... ]
     [vcc      | p[1]          ]
     [gnd      | p[8]          ]
@@ -32,16 +32,16 @@ pcb-component Microcontroller :
 
   make-box-symbol()
   assign-landpattern(soic127-p8)
-  supports i2c : 
+  supports i2c :
     i2c.sda => self.sda
     i2c.scl => self.scl
-  
+
   val io = DigitalIO(logic-family,
                      vil,
                      vih,
-                     vdd-pin, 
+                     vdd-pin,
                      gnd-pin,
-                     leakage-current) where : 
+                     leakage-current) where :
     val logic-family = OpenCollector(tol(5.0, 1.0), 1.0)
     val vil = typ(3.3)
     val vih = typ(5.5)
@@ -53,8 +53,8 @@ pcb-component Microcontroller :
   property(self.sda.digital-io) = io
   property(self.scl.digital-io) = io
 
-pcb-component Peripheral :   
-  pin-properties : 
+pcb-component Peripheral :
+  pin-properties :
     [pin: Ref | pads: Ref ... ]
     [vcc      | p[1]          ]
     [gnd      | p[8]          ]
@@ -63,39 +63,39 @@ pcb-component Peripheral :
 
   make-box-symbol()
   assign-landpattern(soic127-p8)
-  supports i2c : 
+  supports i2c :
     i2c.sda => self.sda
     i2c.scl => self.scl
 
   val io = DigitalIO(logic-family,
                      vil,
                      vih,
-                     vdd-pin, 
+                     vdd-pin,
                      gnd-pin,
-                     leakage-current) where : 
+                     leakage-current) where :
     val logic-family = OpenCollector(tol(5.0, 1.0), 1.0)
     val vil = typ(3.3)
     val vih = typ(5.5)
     val vdd-pin = self.vcc
     val gnd-pin = self.gnd
     val leakage-current = 0.100
-    
-  property(self.vcc.power-pin)  = PowerPin(tol(5.0, 1.0))  
+
+  property(self.vcc.power-pin)  = PowerPin(tol(5.0, 1.0))
   property(self.sda.digital-io) = io
   property(self.scl.digital-io) = io
 
-pcb-component Regulator : 
-  pin-properties : 
+pcb-component Regulator :
+  pin-properties :
     [ pin:Ref | pads:Ref ... ]
     [ vin     | p[1]         ]
     [ vout    | p[2]         ]
     [ active  | p[3]         ]
   assign-landpattern(SOT23-3)
   make-box-symbol()
-  property(self.vin.power-pin)  = PowerPin(tol(5.0, 1.0))  
-  property(self.vout.power-pin) = PowerPin(tol(5.0, 1.0))  
+  property(self.vin.power-pin)  = PowerPin(tol(5.0, 1.0))
+  property(self.vout.power-pin) = PowerPin(tol(5.0, 1.0))
 
-pcb-module sub-module : 
+pcb-module sub-module :
   pin scl
   pin sda
   pin vcc
@@ -108,12 +108,12 @@ pcb-module sub-module :
   net (i2c*.scl, scl)
   net (i2c*.sda, sda)
 
-pcb-module main-module : 
+pcb-module main-module :
   ; Some power supply
   inst vcc : gen-testpad(1.0)
   inst gnd : gen-testpad(1.0)
 
-  ; we have a few components, an MCU, 
+  ; we have a few components, an MCU,
   ; some peripheral, and some regulator
   inst mcu        : Microcontroller
   inst peripheral : sub-module ; note: this is a hierarchical design!
@@ -121,7 +121,7 @@ pcb-module main-module :
 
   require i2c* : i2c from mcu
 
-  ; connect the mcu to the peripheral with 
+  ; connect the mcu to the peripheral with
   ; some digital i/o and power
   net (mcu.sda, peripheral.peripheral.sda)
   net (mcu.scl, peripheral.peripheral.scl)
@@ -132,19 +132,19 @@ pcb-module main-module :
 
   ; Annotate the power states for the MCU, it is powered off (false)
   ; in the "hibernate" state
-  for p in [mcu.sda, mcu.scl] do : 
+  for p in [mcu.sda, mcu.scl] do :
     set-power-states(p, ["wake"      => true,
                          "hibernate" => false])
 
-  ; We notate that this component propagates  
+  ; We notate that this component propagates
   set-property(regulator, `power-supply-component, true)
-  
+
   ; We set the power states of the output regulator.
   set-power-states(regulator.vout, [
     "wake"      => true,
     "hibernate" => true ; this state will cause an expected failure in the check report because of a mismatch
   ])
-  
+
   place(mcu)        on Top
   place(peripheral) on Top
   place(regulator)  on Top
@@ -152,7 +152,7 @@ pcb-module main-module :
   propagate-power-states(self)
   check power-states(self)
 
-set-design-directory("test-design")
+set-current-design("test-design")
 set-main-module(main-module)
 assign-pins()
 run-checks("checks.txt")

--- a/designs/qs3.stanza
+++ b/designs/qs3.stanza
@@ -35,7 +35,7 @@ pcb-module lm317a-regulator (output-voltage:Toleranced) :
   inst output-voltage-divider : ocdb/modules/passive-circuits/voltage-divider(high-voltage, adj-voltage, current) where :
     val high-voltage = tol%(center-value(output-voltage) - est-v-adj-offset, 0.0)
     val adj-voltage = tol%(typ-value(property(lm317a.reference-voltage)),target-variance)
-    val current = divider-current                                                
+    val current = divider-current
 
   net (output-voltage-divider.in lm317a.output)
   net (output-voltage-divider.out lm317a.adj adj)
@@ -57,7 +57,7 @@ pcb-module lm317a-regulator (output-voltage:Toleranced) :
 val board-shape = RoundedRectangle(35.0, 30.0, 0.5)
 pcb-module regulator-fixture :
   val target-voltage = tol%(3.3, 10.0)
-  
+
   inst reg : lm317a-regulator(target-voltage)
 
   inst source : banana-plug-power
@@ -74,7 +74,7 @@ pcb-module regulator-fixture :
   val target-current = 1000.0e-3
   val target-load = closest-std-val(typ-value(target-voltage) / target-current, 5.0)
   inst load : chip-resistor(["resistance" => target-load "min-rated-power" => typ-value(target-voltage) * target-current * 2.0 ])
-  
+
   net (load.p[1] reg.vout)
   net (load.p[2] gnd)
 
@@ -91,19 +91,19 @@ pcb-module regulator-fixture :
 ; Configure the design, then run or check it
 ; ==========================================
 defn run-design (circuit:Instantiable, run-checks?:True|False) :
-  set-design-directory("CAD")
+  set-currrent-design("jitx-design")
   set-board(ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, board-shape))
   set-rules(ocdb/manufacturers/rules/jlcpcb-rules)
 
   var main-module = circuit
   if run-checks? :
     main-module = ocdb/utils/generator-utils/run-final-passes(circuit) ; Analyze design with a pass
-  
+
   set-main-module(main-module) ; Treat the provided module as a design, and compile it.
-  
+
   if run-checks? :
     run-checks("checks.txt")
-  else:  
+  else:
     view-board()
     view-schematic()
 

--- a/designs/tutorial.stanza
+++ b/designs/tutorial.stanza
@@ -11,13 +11,13 @@ defpackage ocdb/designs/tutorial :
 DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
 
 ; ==========================================
-; Implement other modules used by our design 
+; Implement other modules used by our design
 ; ==========================================
 pcb-module lm317a-regulator (output-voltage:Toleranced) :
-  pin vin 
-  pin vout 
-  pin adj 
-  pin gnd 
+  pin vin
+  pin vout
+  pin adj
+  pin gnd
 
   inst lm317a : ocdb/components/unisonic/LM317A/component
   net (lm317a.input, vin)
@@ -43,12 +43,12 @@ pcb-module lm317a-regulator (output-voltage:Toleranced) :
   inst output-voltage-divider : ocdb/modules/passive-circuits/voltage-divider(high-voltage, adj-voltage, current) where :
     val high-voltage = tol%(center-value(output-voltage) - est-v-adj-offset, 0.0)
     val adj-voltage = tol%(typ-value(ref-voltage), target-variance)
-    val current = divider-current                                                
+    val current = divider-current
 
   net (output-voltage-divider.in, lm317a.output)
   net (output-voltage-divider.out, lm317a.adj adj)
   net (output-voltage-divider.lo, gnd)
-  ; inside pcb-module lm317a-regulator 
+  ; inside pcb-module lm317a-regulator
   schematic-group(self) = lm317a
 
   ; Calculate the actual offset now that we know the optimized value of the resistors
@@ -69,7 +69,7 @@ pcb-module lm317a-regulator (output-voltage:Toleranced) :
 val board-shape = RoundedRectangle(35.0, 30.0, 0.5)
 pcb-module regulator-fixture :
   val target-voltage = tol%(3.3, 10.0)
-  
+
   inst reg : lm317a-regulator(target-voltage)
 
   inst source : banana-plug-module() ; shortcut to instantiate and place two `banana-plug`s plus the electrical support
@@ -86,7 +86,7 @@ pcb-module regulator-fixture :
   val target-current = 1000.0e-3
   val target-load = closest-std-val(typ-value(target-voltage) / target-current, 5.0)
   inst load : chip-resistor(["resistance" => target-load "min-rated-power" => typ-value(target-voltage) * target-current * 2.0 ])
-  
+
   net (load.p[1], reg.vout)
   net (load.p[2], gnd)
 
@@ -103,19 +103,19 @@ pcb-module regulator-fixture :
 ; Configure the design, then run or check it
 ; ==========================================
 defn run-design (circuit:Instantiable, run-checks?:True|False) :
-  set-design-directory("CAD")
+  set-current-design("jitx-design")
   set-board(ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, board-shape))
   set-rules(ocdb/manufacturers/rules/jlcpcb-rules)
 
   var main-module = circuit
   if run-checks? :
     main-module = ocdb/utils/generator-utils/run-final-passes(circuit) ; Analyze design with a pass
-  
+
   set-main-module(main-module) ; Treat the provided module as a design, and compile it.
-  
+
   if run-checks? :
     run-checks("checks.txt")
-  else:  
+  else:
     view-board()
     view-schematic()
 

--- a/tests/design.stanza
+++ b/tests/design.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx, tests)
-defpackage ocdb/tests/design : 
+defpackage ocdb/tests/design :
   import core
   import collections
   import jitx
@@ -8,18 +8,18 @@ defpackage ocdb/tests/design :
   import ocdb/utils/defaults
   import ocdb/utils/checks
 
-public defn test-design (case:String, 
+public defn test-design (case:String,
                          main-module:Instantiable
-                         num-layers:Int, 
-                         board-shape:Shape, 
-                         rules:Rules) : 
+                         num-layers:Int,
+                         board-shape:Shape,
+                         rules:Rules) :
   val name = to-string $ "test-board-%_" % [case]
-  pcb-module main-module* : 
+  pcb-module main-module* :
     inst m:main-module
     check-design(self)
 
   deftest(ocdb, design, long) (name) :
-    set-design-directory(name)
+    set-current-design(name)
     set-board(default-board(num-layers, board-shape))
     set-main-module(main-module*)
     set-rules(rules)

--- a/tests/relative-voltages.stanza
+++ b/tests/relative-voltages.stanza
@@ -11,7 +11,7 @@ defpackage ocdb/tests/relative-voltages :
   import ocdb/utils/relative-voltages
 
 ; A digital-io component with a single digital-io pin where :
-; 
+;
 ; vol is a fractional voltage
 ; voh is a PWL voltage
 ; vil is a dual offset voltage
@@ -24,22 +24,22 @@ pcb-component IOComponent :
     [ IO        | 2              | Left ]
     [ GND       | 3              | Down ]
 
-  ; boilerplate 
+  ; boilerplate
   assign-landpattern(ocdb/utils/landpatterns/SOT23())
   ocdb/utils/box-symbol/make-box-symbol()
 
   ; Set up the I/O properties with RelativeVoltages
-  property(self.IO.digital-io) = 
+  property(self.IO.digital-io) =
     DigitalIO(driver, vil, vih, self.VDD, self.GND, leakage-current)
   where :
     val leakage-current = 50.0e-9
 
-    val driver = 
+    val driver =
       CMOSOutput(vol, voh)
     where :
-      ; Example: Given a table of min/max values for 
-      ;          vol, create PWL table for known 
-      ;          supply voltages 
+      ; Example: Given a table of min/max values for
+      ;          vol, create PWL table for known
+      ;          supply voltages
       val vol = PWLVoltage(
         ; min
         PWL([[1.8, 0.06]
@@ -54,8 +54,8 @@ pcb-component IOComponent :
         ; relative to this pin
         self.VDD
       )
-      
-      ; Example: Offset the voltage by -1.1 for 
+
+      ; Example: Offset the voltage by -1.1 for
       ;          voh min, -0.1 for voh max.
       val voh = min-max(-1.1, -0.1) + voltage(self.VDD)
 
@@ -77,10 +77,10 @@ defn relative-voltages (component:JITXObject) -> [RelativeVoltage,RelativeVoltag
   val vil = vil(io) as RelativeVoltage
   val voh = voh(driver) as RelativeVoltage
   val vol = vol(driver) as RelativeVoltage
-  
+
   [vih, vil, voh, vol]
 
-; Helper to print the values of a digital-io's relative voltages 
+; Helper to print the values of a digital-io's relative voltages
 ; after they've been resolved
 defn dump (component:JITXObject) :
   val [vih, vil, voh, vol] = relative-voltages(component)
@@ -105,7 +105,7 @@ deftest(not-implemented-yet) relative-voltage-test :
     property(GND.voltage) = typ(0.0)
 
 
-    eval-when   
+    eval-when
         all?(has-absolute-voltage?, relative-voltages(U1.IO)) and
         all?(has-absolute-voltage?, relative-voltages(U2.IO)) :
       ; Only run once the voltages have been propagated.
@@ -116,11 +116,11 @@ deftest(not-implemented-yet) relative-voltage-test :
 
       val n1 = property(U1.IO.voltage)
       val n2 = property(U2.IO.voltage)
-          
+
       #ASSERT(n1 == n2)
-      
+
   ; Test logic
-  set-design-directory("relative-voltages-test")
+  set-current-design("relative-voltages-test")
   run-final-passes(main-module)
   view-schematic()
   run-checks("checks-test.txt")
@@ -133,17 +133,17 @@ deftest rv-arithmetic :
     let :
       val e1 = 1.0 + voltage(VDD)
       #EXPECT(eval-voltage(e1) == typ(2.0))
-    
+
     let :
       val e1 = min-max(-1.0, 1.0) + voltage(VDD)
       #EXPECT(eval-voltage(e1) == min-max(0.0, 2.0))
-    
+
     let :
       val e1 = 3.1 * voltage(VDD)
       #EXPECT(eval-voltage(e1) == typ(3.1))
-    
+
     let :
       val e1 = min-max(0.12, 3.1) * voltage(VDD)
       #EXPECT(eval-voltage(e1) == min-max(0.12, 3.1))
-    
+
   evaluate(main-module)

--- a/tests/stm32-mcu-props.stanza
+++ b/tests/stm32-mcu-props.stanza
@@ -24,7 +24,7 @@ defpackage ocdb/tests/stm32-mcu-props :
   import ocdb/utils/micro-controllers
   import ocdb/utils/design-vars
 
-  import ocdb/utils/db-parts 
+  import ocdb/utils/db-parts
   import ocdb/components/st-microelectronics/generate-ioc
 
 public pcb-module test-stm32-mcu-props :
@@ -37,10 +37,10 @@ public pcb-module test-stm32-mcu-props :
   net vssa (gnd)
 
   inst mcu : ocdb/components/st-microelectronics/STM32F407ZET6/component
-  
+
   inst cd100n0 : ceramic-cap(["capacitance" => 100.0e-9 "case" => "0603"])[12]
   inst cd4u7 : ceramic-cap(["capacitance" => 4.7e-6 "case" => "0603"])
-  
+
   inst fb : chip-resistor(["resistance" => 10.0, "case" => "0805"])
   inst xtal : ocdb/components/citizen/CMJ206T32768DZBT/component
   inst debug-conn : ocdb/components/tag-connect/TC2030-IDC/component
@@ -55,7 +55,7 @@ public pcb-module test-stm32-mcu-props :
   require mcu-debug : swd() from mcu
 
   ; how to count the number of VDD pins in instance mcu? punt for now
-  ; 
+  ;
   for i in 0 to num-vdd-pins do :
     net (vdd mcu.VDD[i])
   net (vdd mcu.PDR_ON) ; use on-board POR/PDR
@@ -64,36 +64,36 @@ public pcb-module test-stm32-mcu-props :
 
   for i in 0 to num-vss-pins do :
     net (gnd mcu.VSS[i])
-  
+
   public net vcap-1 (mcu.VCAP[1])
   public net vcap-2 (mcu.VCAP[2])
-  
+
   bypass-cap-strap(mcu.VCAP[1], gnd, 2.2e-6)
   bypass-cap-strap(mcu.VCAP[2], gnd, 2.2e-6)
-  
+
   res-strap(mcu.BOOT[0], gnd, 1.0e3)
-  
+
   public net vdda (mcu.VDDA mcu.VREF+)
-    
+
   bypass-cap-strap(mcu.VDDA, gnd, 1.0e-6)
   bypass-cap-strap(mcu.VDDA, gnd, 100.0e-9)
   bypass-cap-strap(mcu.VREF+, gnd, 1.0e-6)
   bypass-cap-strap(mcu.VREF+, gnd, 100.0e-9)
-  
+
   net (vdd fb.p[1])
   net (vdda fb.p[2])
-  
+
   for i in 0 to num-vdd-pins do :
     net (cd100n0[i].p[1] vdd)
     net (cd100n0[i].p[2] gnd)
-    
+
   net (cd4u7.p[1] vdd)
   net (cd4u7.p[2] gnd)
-    
+
   net (vssa mcu.VSSA)
-  
+
   val lf-cb = add-xtal-caps(xtal, gnd, 0.5e-12)
-  
+
   net (lf-osc.in xtal.p[1])
   net (lf-osc.out xtal.p[2])
 
@@ -150,7 +150,7 @@ public pcb-module test-stm32-mcu-props :
 deftest(ocdb, stm32-mcu-props, design) test-mcu-props-in-design :
   println $ get-time-string("%H:%M:%S")
   val final-design = run-final-passes(test-stm32-mcu-props)
-  set-design-directory("test-stm32-mcu-props")
+  set-current-design("test-stm32-mcu-props")
   set-main-module(final-design)
   val assigned-pins = assign-pins()
   val interim = transform-module(generate-ioc-file, assigned-pins)


### PR DESCRIPTION
# Changes
* replace all `set-design-directory` command calls with `set-current-design`
* remove trailing spaces in some cases.

# Notes
* some designs use `altium` some `kicad`. They are left as is.