### PR TITLE
fixed spice substitutions

### DIFF
--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -307,8 +307,8 @@ public pcb-component gen-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg-name
   emodel = Capacitor(cap, tol, max-v)
   reference-prefix = "C"
   spice :
-    "[C] {p[1]} tmp {cap}"
-    "[R] tmp {p[2]} 0.01"
+    "[C] <p[1]> [tmp] <cap>"
+    "[R] [tmp] <p[2]> 0.01"
   property(self.capacitor) = true
   property(self.type) = "ceramic"
   property(self.capacitance) = cap
@@ -346,8 +346,8 @@ public pcb-component gen-tant-cap-cmp (cap:Double, tol:Double, max-v:Double, pkg
     else : fatal("Incorrect capacitor package %_." % [pkg])
   reference-prefix = "C"
   spice :
-    "[C] {a} tmp {cap}"
-    "[R] tmp {c} 2.0"
+    "[C] <a> [tmp] <cap>"
+    "[R] [tmp] <c> 2.0"
   property(self.capacitor) = true
   property(self.type) = "electrolytic"
   property(self.anode) = "tantalum"
@@ -395,7 +395,7 @@ public pcb-component gen-res-cmp (r-type:ResistorSymbolType, res:Double, tol:Dou
   property(self.resistance) = res
   property(self.resistor) = true
   spice :
-    "[R] {p[1]} {p[2]} {res}"
+    "[R] <p[1]> <p[2]> <res>"
 
 public defn gen-res-cmp (res:Double, tol:Double, pkg:String) :
   gen-res-cmp(ResistorStd, res, tol, 0.0625, pkg)


### PR DESCRIPTION
Just a small tweak to the spice substitution for future support. This way ocdb `dev` will be compliant with the future spice syntax.