### PR TITLE
JITX-4302: Remove DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS

### DIFF
--- a/designs/ethernet-fmc.stanza
+++ b/designs/ethernet-fmc.stanza
@@ -18,7 +18,6 @@ defpackage ocdb/designs/ethernet-fmc :
 
 OPERATING-TEMPERATURE = min-max(-20.0 50.0)
 OPTIMIZE-FOR = ["area"]
-DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
 
 pcb-module my-design :
 

--- a/designs/tutorial.stanza
+++ b/designs/tutorial.stanza
@@ -8,8 +8,6 @@ defpackage ocdb/designs/tutorial :
   import ocdb/utils/design-vars
   import ocdb/utils/generic-components
 
-DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
-
 ; ==========================================
 ; Implement other modules used by our design
 ; ==========================================

--- a/designs/voltage-divider.stanza
+++ b/designs/voltage-divider.stanza
@@ -15,7 +15,6 @@ defpackage ocdb/designs/voltage-divider :
   import ocdb/utils/design-vars
 
 OPERATING-TEMPERATURE = min-max(0.0, 40.0)
-DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS = true
 
 pcb-module demo :
 

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -236,7 +236,7 @@ defn resistor-query-properties (user-properties:Tuple<KeyValue>,
                                 sort:Tuple<String>,
                                 operating-temperature:Toleranced|False) -> Tuple<KeyValue> :
   query-properties(user-properties,
-                   maybe-insert-default-vendor-part-number(exist),
+                   exist,
                    sort,
                    operating-temperature,
                    "resistor",
@@ -497,7 +497,7 @@ defn capacitor-query-properties (user-properties:Tuple<KeyValue>,
                                 sort:Tuple<String>,
                                 operating-temperature:Toleranced|False) -> Tuple<KeyValue> :
   query-properties(user-properties,
-                   maybe-insert-default-vendor-part-number(exist),
+                   exist,
                    sort,
                    operating-temperature,
                    "capacitor",
@@ -698,7 +698,7 @@ defn inductor-query-properties (user-properties:Tuple<KeyValue>,
                                 sort:Tuple<String>,
                                 operating-temperature:Toleranced|False) -> Tuple<KeyValue> :
   query-properties(user-properties,
-                   maybe-insert-default-vendor-part-number(exist),
+                   exist,
                    sort,
                    operating-temperature,
                    "inductor",
@@ -1007,11 +1007,3 @@ public defn dbquery-first-allow-non-stock (args: Tuple<KeyValue<String, Tuple<St
       dbquery-first(args2)
     else :
       throw(e)
-
-; Default to a subset of parts while we're vetting an expanded set.
-; TODO: JITX-4302 - Remove this, once we've built more confidnce in the expanded set.
-defn maybe-insert-default-vendor-part-number (exist:Tuple<String>) -> Tuple<String> :
-  if DEFAULT-ALLOW-ALL-VENDOR-PART-NUMBERS :
-    exist
-  else :
-    to-tuple $ cat(exist, ["vendor_part_numbers.digi-key"])


### PR DESCRIPTION
This flag was added as a safety check while we validated a new class of parts in the DB.

We've kicked the tires and are ready to expand the candidate pool.

Also, the naming of this flag was confusing!