### PR TITLE
JITX-4750: Fully migrate V1 properties to parts-db

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -182,35 +182,13 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
                                 emodel-pourcentage-tolerance(tolerance(resistor)),
                                 double-or-unknown(rated-power(resistor)))
         reference-prefix = "R"
-        val TCR = TCR(resistor)
-        val rated-temperature = rated-temperature(resistor)
-        val tolerance = tolerance(resistor)
-        val resistance = resistance(resistor)
-        ; Backwards compatibility
-        property(self.resistor) = true
-        ; This is how parts-db does it
-        property(self.category) = "resistor"
-        property(self.trust) = trust(resistor)
-        property(self.x) = x(resistor)
-        property(self.y) = y(resistor)
-        property(self.z) = z(resistor)
-        property(self.mounting) = mounting(resistor)
-        match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
-        property(self.case) = /case(resistor)
-        property(self.metadata) = metadata(resistor)
-        property(self.type) = type(resistor)
-        match(tolerance: MinMaxRange):
-          ;[TODO] Current exporter IR crashes unless tolerance is a Double.
-          ;So this feature is commented out until that is fixed.
-          ;property(self.tolerance) = [min(tolerance), max(tolerance)]
-          property(self.tolerance) = max(tolerance)
-        property(self.resistance) = resistance
-        property(self.composition) = composition(resistor)  ; this is the type => "thick-film" in gen-res-cmp
-        property(self.rated-power) = /rated-power(resistor)
-        match(TCR: TCR): property(self.TCR) = [positive(TCR), negative(TCR)]
+
+        ; Include parts-db component properties
+        map(to-jitx, properties(component))
+
         ; spice :
         ;   "[R] <p[1]> <p[2]> <resistance>"
-        set-properties-for-vendor-part-numbers(resistor)
+
       my-resistor
 
 ; ========================================================
@@ -339,7 +317,7 @@ public defn Capacitor (raw-json: JObject) -> Capacitor :
             optional-double(json, "rated-current-rms"),
             parse-sellers(json),
             optional-double(json, "resolved_price"),
-           ComponentCode(json["component"] as JObject),
+            ComponentCode(json["component"] as JObject),
             parse-vendor-part-numbers(json))
 
 defn parse-esr (json: JObject) -> ESR|False :
@@ -436,8 +414,6 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
           ;   spice :
           ;     "[C] <p[1]> <p[2]> <capacitance(capacitor)>"
 
-        set-properties-for-vendor-part-numbers(capacitor)
-
         emodel = EModel-Capacitor(capacitance(capacitor),
                                 emodel-pourcentage-tolerance(tolerance(capacitor)),
                                 double-or-unknown(rated-voltage(capacitor)),
@@ -446,31 +422,9 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
                                 string-or-unknown(temperature-coefficient(capacitor)),
                                 UNKNOWN) ; FIXME: find out the dielectric information (look at type and anode?)
         reference-prefix = "C"
-        val rated-temperature = rated-temperature(capacitor)
-        val capacitance = capacitance(capacitor)
-        val tolerance = tolerance(capacitor)
-        ; Backwards compatibility
-        property(self.capacitor) = true
-        ; This is how parts-db does it
-        property(self.category) = "capacitor"
-        property(self.trust) = trust(capacitor)
-        property(self.x) = x(capacitor)
-        property(self.y) = y(capacitor)
-        property(self.z) = z(capacitor)
-        property(self.mounting) = mounting(capacitor)
-        match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
-        property(self.metadata) = metadata(capacitor)
-        property(self.type) = type(capacitor)
-        match(tolerance: MinMaxRange): property(self.tolerance) = [min(tolerance), max(tolerance)]
-        property(self.capacitance) = capacitance
-        property(self.anode) = anode(capacitor)
-        property(self.electrolyte) = electrolyte(capacitor)
-        property(self.temperature-coefficient) = temperature-coefficient(capacitor)
-        match(esr: ESR): property(self.esr) = value(esr)
-        match(esr: ESR): property(self.esr-frequency) = frequency(esr)
-        property(self.rated-voltage) = /rated-voltage(capacitor)
-        property(self.rated-current-pk) = rated-current-pk(capacitor)
-        property(self.rated-current-rms) = rated-current-rms(capacitor)
+
+        ; Include parts-db component properties
+        map(to-jitx, properties(component))
 
       my-capacitor
 
@@ -642,33 +596,12 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
                                 emodel-pourcentage-tolerance(tolerance(inductor)),
                                 double-or-unknown(current-rating(inductor)))
         reference-prefix = "L"
-        val rated-temperature = rated-temperature(inductor)
-        val tolerance = tolerance(inductor)
-        ; Backwards compatibility
-        property(self.inductor) = true
-        ; This is how parts-db does it
-        property(self.category) = "inductor"
-        property(self.trust) = trust(inductor)
-        property(self.x) = x(inductor)
-        property(self.y) = y(inductor)
-        property(self.z) = z(inductor)
-        property(self.mounting) = mounting(inductor)
-        match(rated-temperature: Toleranced): property(self.rated-temperature) = rated-temperature
-        property(self.case) = /case(inductor)
-        property(self.metadata) = metadata(inductor)
-        property(self.type) = type(inductor)
-        match(tolerance: MinMaxRange): property(self.tolerance) = [min(tolerance), max(tolerance)]
-        property(self.inductance) = inductance
-        property(self.material-core) = material-core(inductor)
-        property(self.shielding) = shielding(inductor)
-        property(self.current-rating) = current-rating(inductor)
-        property(self.saturation-current) = saturation-current(inductor)
-        property(self.dc-resistance) = dc-resistance(inductor)
-        property(self.quality-factor) = quality-factor(inductor)
-        property(self.self-resonant-frequency) = self-resonant-frequency(inductor)
+
+        ; Include parts-db component properties
+        map(to-jitx, properties(component))
+
         spice :
           "[L] <p[1]> <p[2]> <inductance>"
-        set-properties-for-vendor-part-numbers(inductor)
       my-inductor
 
 ; ========================================================

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -619,7 +619,7 @@ defn to-jitx (nc: NoConnectCode) :
     val jitx-pin = self.(to-ref(/pin(nc)))
     no-connect(jitx-pin)
 
-defn to-jitx (prop: ComponentPropertyCode) :
+public defn to-jitx (prop: ComponentPropertyCode) :
   inside pcb-component :
     val prop-name = name(prop)
     val prop-value = value(prop)


### PR DESCRIPTION
The properties are now all generated offline as part of Parts DB.

This makes it easier to make updates without client-side changes.

## Test Plan
See Parts DB PR:
- [JITX-4750: Fully migrate V1 properties to parts-db #91](https://github.com/JITx-Inc/parts-db/pull/91)