### PR TITLE
Reduce ocdb Altium symbol size by 254

### DIFF
--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -85,7 +85,7 @@ public pcb-symbol altium-power-bar-sym :
 
   val ex = 3.0 / 2.0 * 0.5
   unit-line([[0.0, 0.0], [ex, 0.0]])
-  unit-line([[ex, 0.5 / 2.0], [ex, 0.5 / 2.0]])
+  unit-line([[ex, -0.5 / 2.0], [ex, 0.5 / 2.0]])
   unit-val([0.2, 0.2])
 
   preferred-orientation = PreferRotation([1])
@@ -122,9 +122,9 @@ public pcb-symbol altium-power-gnd-signal-sym :
   name = "ALTIUM-POWER-GND-SIGNAL"
   pin p[0] at unit-point(0.0, 0.0)
 
-  unit-line([[0.0, 0.0], [0.2, 0.0]])
-  unit-triangle([0.2, 0.0], [1.5 * 1.1, 0.0], 1.5 * 0.6)
-  unit-val([0.4, -0.16])
+  unit-line([[0.0, 0.0], [0.51, 0.0]])
+  unit-triangle([0.51, 0.0], [1.5 * 2.8, 0.0], 1.5 * 1.5)
+  unit-val([1.02, -0.41])
 
   preferred-orientation = PreferRotation([3])
 
@@ -140,7 +140,7 @@ public pcb-symbol altium-power-gnd-earth-sym :
   unit-line([[ex, u], [ex + 0.5 * u, u - 0.5 * u]])
   unit-line([[ex, 0.0], [ex + 0.5 * u, -0.5 * u]])
   unit-line([[ex, -1.0 * u], [ex + 0.5 * u, -1.5 * u]])
-  unit-val([0.5, -0.5])
+  unit-val([0.2, -0.2])
 
   preferred-orientation = PreferRotation([3])
 

--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -63,9 +63,9 @@ public pcb-symbol altium-power-arrow-sym :
   name = "ALTIUM-POWER-ARROW"
   pin p[0] at unit-point(0.0, 0.0)
 
-  unit-line([[0.0, 0.0], [1.27, 0.0]])
-  unit-triangle([1.27, 0.0], [2.794, 0.0], 1.524)
-  unit-val([2.5, -0.5])
+  unit-line([[0.0, 0.0], [0.5, 0.0]])
+  unit-triangle([0.5, 0.0], [1.1, 0.0], 0.6)
+  unit-val([1.0, -0.2])
 
   preferred-orientation = PreferRotation([1])
 
@@ -73,9 +73,9 @@ public pcb-symbol altium-power-circle-sym :
   name = "ALTIUM-POWER-CIRCLE"
   pin p[0] at unit-point(0.0, 0.0)
 
-  unit-circle([3.0 / 2.0 * 1.27, 0.0], 1.27 / 2.0)
-  unit-line([[0.0, 0.0], [1.27, 0.0]])
-  unit-val([2.5, -0.5])
+  unit-circle([3.0 / 2.0 * 0.5, 0.0], 0.5 / 2.0)
+  unit-line([[0.0, 0.0], [0.5, 0.0]])
+  unit-val([1.0, -0.2])
   
   preferred-orientation = PreferRotation([1])
 
@@ -83,10 +83,10 @@ public pcb-symbol altium-power-bar-sym :
   name = "ALTIUM-POWER-BAR"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val ex = 3.0 / 2.0 * 1.27
+  val ex = 3.0 / 2.0 * 0.5
   unit-line([[0.0, 0.0], [ex, 0.0]])
-  unit-line([[ex, -1.27 / 2.0], [ex, 1.27 / 2.0]])
-  unit-val([0.5, 0.5])
+  unit-line([[ex, 0.5 / 2.0], [ex, 0.5 / 2.0]])
+  unit-val([0.2, 0.2])
 
   preferred-orientation = PreferRotation([1])
 
@@ -94,13 +94,13 @@ public pcb-symbol altium-power-wave-sym :
   name = "ALTIUM-POWER-WAVE"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5 * 1.27
+  val u = 0.5 / 2.0
   val ex = 4.0 * u
   unit-line([[0.0, 0.0], [ex, 0.0]])
   unit-line([[ex - u, u], [ex, 0.5 * u]])
   unit-line([[ex, 0.5 * u], [ex, -0.5 * u]])
   unit-line([[ex + u, (- u)], [ex, -0.5 * u]])
-  unit-val([1.5, -0.5])
+  unit-val([0.6, -0.2])
 
   preferred-orientation = PreferRotation([1])
 
@@ -108,13 +108,13 @@ public pcb-symbol altium-power-gnd-power-sym :
   name = "ALTIUM-POWER-GND-POWER"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 1.27 / 2.0
+  val u = 0.5 / 2.0
   unit-line([[0.0, 0.0], [2.0 * u, 0.0]])
-  unit-line(0.1, [[2.00 * u, -1.40], [2.00 * u, 1.40]])
-  unit-line(0.1, [[2.67 * u, -1.08], [2.67 * u, 1.08]])
-  unit-line(0.1, [[3.33 * u, -0.77], [3.33 * u, 0.77]])
-  unit-line(0.1, [[4.00 * u, -0.46], [4.00 * u, 0.46]])
-  unit-val([2.5, -1.0])
+  unit-line(0.1, [[2.00 * u, -0.55], [2.00 * u, 0.55]])
+  unit-line(0.1, [[2.67 * u, -0.43], [2.67 * u, 0.43]])
+  unit-line(0.1, [[3.33 * u, -0.3], [3.33 * u, 0.3]])
+  unit-line(0.1, [[4.00 * u, -0.18], [4.00 * u, 0.18]])
+  unit-val([1.0, -0.4])
 
   preferred-orientation = PreferRotation([3])
 
@@ -122,9 +122,9 @@ public pcb-symbol altium-power-gnd-signal-sym :
   name = "ALTIUM-POWER-GND-SIGNAL"
   pin p[0] at unit-point(0.0, 0.0)
 
-  unit-line([[0.0, 0.0], [1.27, 0.0]])
-  unit-triangle([1.27, 0.0], [1.5 * 2.794, 0.0], 1.5 * 1.524)
-  unit-val([2.5, -1.0])
+  unit-line([[0.0, 0.0], [0.2, 0.0]])
+  unit-triangle([0.2, 0.0], [1.5 * 1.1, 0.0], 1.5 * 0.6)
+  unit-val([0.4, -0.16])
 
   preferred-orientation = PreferRotation([3])
 
@@ -132,7 +132,7 @@ public pcb-symbol altium-power-gnd-earth-sym :
   name = "ALTIUM-POWER-GND-EARTH"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5 * 1.27
+  val u = 0.5 / 2.0
   val ex = 4.0 * u
   unit-line([[0.0, 0.0], [ex, 0.0]])
   unit-line([[ex, u], [ex, -1.0 * u]])
@@ -148,12 +148,12 @@ public pcb-symbol altium-gost-power-arrow-sym :
   name = "ALTIUM-GOST-POWER-ARROW"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5 * 1.27
+  val u = 0.5 / 2.0
   val ex = 4.0 * u
   unit-line([[0.0, 0.0], [ex + u, 0.0]])
   unit-line([[ex, u], [ex + u, 0.0]])
   unit-line([[ex, -1.0 * u], [ex + u, 0.0]])
-  unit-val([1.5, 0.5])
+  unit-val([0.6, 0.2])
 
   preferred-orientation = PreferRotation([1])
 
@@ -161,12 +161,12 @@ public pcb-symbol altium-gost-gnd-power-sym :
   name = "ALTIUM-GOST-GND-POWER"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 1.27
+  val u = 0.5
   unit-line([[0.0, 0.0], [2.0 * u, 0.0]])
-  unit-line(0.1, [[2.00 * u, -1.40], [2.00 * u, 1.40]])
-  unit-line(0.1, [[2.67 * u, -0.93], [2.67 * u, 0.93]])
-  unit-line(0.1, [[3.33 * u, -0.46], [3.33 * u, 0.46]])
-  unit-val([0.5, -0.5])
+  unit-line(0.1, [[2.00 * u, -0.55], [2.00 * u, 0.55]])
+  unit-line(0.1, [[2.67 * u, -0.37], [2.67 * u, 0.37]])
+  unit-line(0.1, [[3.33 * u, -0.18], [3.33 * u, 0.18]])
+  unit-val([0.2, -0.2])
 
   preferred-orientation = PreferRotation([3])
 
@@ -174,13 +174,13 @@ public pcb-symbol altium-gost-gnd-earth-sym :
   name = "ALTIUM-GOST-GND-EARTH"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 1.27
+  val u = 0.5
   unit-circle([2.0 * u, 0.0], 1.50 * u)
   unit-line([[0.0, 0.0], [2.0 * u, 0.0]])
-  unit-line(0.1, [[2.00 * u, -1.40], [2.00 * u, 1.40]])
-  unit-line(0.1, [[2.47 * u, -0.93], [2.47 * u, 0.93]])
-  unit-line(0.1, [[2.94 * u, -0.46], [2.94 * u, 0.46]])
-  unit-val([1.8, -0.5])
+  unit-line(0.1, [[2.00 * u, -0.55], [2.00 * u, 0.55]])
+  unit-line(0.1, [[2.47 * u, -0.37], [2.47 * u, 0.37]])
+  unit-line(0.1, [[2.94 * u, -0.18], [2.94 * u, 0.18]])
+  unit-val([0.72, -0.2])
 
   preferred-orientation = PreferRotation([3])
 
@@ -188,10 +188,10 @@ public pcb-symbol altium-gost-bar-sym :
   name = "ALTIUM-GOST-BAR"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val ex = 3.0 / 2.0 * 1.27
+  val ex = 3.0 / 2.0 * 0.5
   unit-line([[0.0, 0.0], [ex, 0.0]])
-  unit-line([[ex, -1.27 / 2.0], [ex, 1.27 / 2.0]])
-  unit-val([2.5, -0.5])
+  unit-line([[ex, -0.5 / 2.0], [ex, 0.5 / 2.0]])
+  unit-val([1.0, -0.2])
 
   preferred-orientation = PreferRotation([1])
 


### PR DESCRIPTION
# Before

![](https://user-images.githubusercontent.com/17492851/233763142-58ce67c2-0e6c-43fc-a5a7-39b25d606d49.png)

# After

<img width="960" alt="image" src="https://user-images.githubusercontent.com/17492851/233769712-3a6abd82-036f-4f15-8581-7f98350ec441.png">


# In Altium

The layout is different, run on Erwin's machine

![image](https://user-images.githubusercontent.com/17492851/233769719-dda8694a-d8a3-41ed-bdd2-da9149c9ac82.png)
