### PR TITLE
Quickstart updates

### DIFF
--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -24,6 +24,7 @@ defpackage ocdb/utils/generic-components:
   import ocdb/utils/checks
   import ocdb/utils/parts
   import ocdb/utils/parametric-components
+  import ocdb/artwork/board-text
 
 ; ========================================================
 ; ====== Standard packages for the passive solver ========
@@ -696,9 +697,11 @@ public pcb-module banana-plug-module ():
   val pitch = 0.75 / 2.0 * 25.4
   place(vdd-plug) at loc(pitch * -1.0, 0.0) on Top
   place(gnd-plug) at loc(pitch, 0.0) on Top
-  layer(Silkscreen("Pol", Top)) = Text("VIN", 1.5, C, loc(pitch * -1.0, -8.0))
-  layer(Silkscreen("Pol", Top)) = Text("GND", 1.5, C, loc(pitch, -8.0))
 
+  inst vin-label : text("VIN", 1.2, 0.0)
+  inst gnd-label : text("GND", 1.2, 0.0)
+  place(vin-label) at loc(pitch * -1.0, -7.5) on Top
+  place(gnd-label) at loc(pitch, -7.5) on Top
 
 public pcb-component pin-header (n-pin:Int, n-row:Int, pin-pitch:Double, row-pitch:Double) :
   description = "Generic pin-header"


### PR DESCRIPTION
Banana plug labels weren't working - swap to use `text` so they are now working properly. Must get in to align with quickstarts.