### PR TITLE
Reduce ocdb altium symbol size by 254 - adjustments

### DIFF
--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -123,7 +123,7 @@ public pcb-symbol altium-power-gnd-signal-sym :
   pin p[0] at unit-point(0.0, 0.0)
 
   unit-line([[0.0, 0.0], [0.5, 0.0]])
-  unit-triangle([0.5, 0.0], [1.5 * 1.1, 0.0], 1.5 * 0.6)
+  unit-triangle([0.5, 0.0], [1.5 * 0.7, 0.0], 1.5 * 0.6)
   unit-val([1.0, -0.4])
 
   preferred-orientation = PreferRotation([3])

--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -122,9 +122,9 @@ public pcb-symbol altium-power-gnd-signal-sym :
   name = "ALTIUM-POWER-GND-SIGNAL"
   pin p[0] at unit-point(0.0, 0.0)
 
-  unit-line([[0.0, 0.0], [0.51, 0.0]])
-  unit-triangle([0.51, 0.0], [1.5 * 2.8, 0.0], 1.5 * 1.5)
-  unit-val([1.02, -0.41])
+  unit-line([[0.0, 0.0], [0.5, 0.0]])
+  unit-triangle([0.5, 0.0], [1.5 * 1.1, 0.0], 1.5 * 0.6)
+  unit-val([1.0, -0.4])
 
   preferred-orientation = PreferRotation([3])
 


### PR DESCRIPTION
See change in `altium-power-gnd-signal-sym`

# Before

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/17492851/234070668-a0d286aa-fe86-485b-9439-968359a4b866.png">

# After

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/17492851/234072779-c5ba60bb-e3c3-48f9-abcb-e15591a65d28.png">

Here is the Altium reference
![image](https://user-images.githubusercontent.com/17492851/234073141-7e0f58d4-77c0-4ec2-ab7c-373c04b38dff.png)
