### PR TITLE
JITX-4867: Allow accessing ComponentCode for all Components

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -30,6 +30,9 @@ public defmulti sellers (component: Component) -> Tuple<Seller>|False
 public defmulti resolved-price (component: Component) -> Double|False
 public defmulti vendor-part-numbers (component: Component) -> Tuple<KeyValue<String, String>>
 public defmulti to-jitx (component: Component) -> Instantiable
+; The top-level Component includes queryable fields used in parametric queries.
+; This inner component represents the actual ESIR-instantiable object, including symbols/landpattern.
+public defmulti component (component: Component) -> ComponentCode
 
 defmethod area (component: Component) -> Double :
   x(component) * y(component)
@@ -85,7 +88,7 @@ public defstruct Resistor <: Component :
   TCR: TCR|False ; Temperature coefficient of resistance (ohms/ohm*degC)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
-  component: ComponentCode
+  component: ComponentCode with: (as-method => true)
   vendor-part-numbers: Tuple<KeyValue<String, String>> with: (as-method => true)
 
 public defn delta-resistance (resistor: Resistor, temperature: Double) -> Double :
@@ -303,7 +306,7 @@ defstruct Capacitor <: Component :
   rated-current-rms: Double|False ; Maximum rms current rating from manufacturer (Amperes)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
-  component: ComponentCode
+  component: ComponentCode with: (as-method => true)
   vendor-part-numbers: Tuple<KeyValue<String, String>> with: (as-method => true)
 
 defstruct ESR :
@@ -563,7 +566,7 @@ defstruct Inductor <: Component :
   self-resonant-frequency: Double|False ; Frequency at which inductor impedance becomes very high / open circuit (freq in Hz)
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
-  component: ComponentCode
+  component: ComponentCode with: (as-method => true)
   vendor-part-numbers: Tuple<KeyValue<String, String>> with: (as-method => true)
 
 public defn Inductor (raw-json: JObject) -> Inductor :

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -35,7 +35,7 @@ public defn PartsDBComponents (user-properties:Tuple<KeyValue>, limit: Int) -> T
   map{parse-component, _} $ dbquery(query-properties, limit) as Tuple<JObject>
 
 public defstruct Part <: Component :
-  component: ComponentCode
+  component: ComponentCode with: (as-method => true)
   description: String
   manufacturer: String
   mpn: String


### PR DESCRIPTION
This enables getting component data for all structs of Component type.

It's for use within an integration test in the Parts DB.