### PR TITLE
JITX-4967/npth-pad

### DIFF
--- a/components/johnson/142-0761-881.stanza
+++ b/components/johnson/142-0761-881.stanza
@@ -23,25 +23,23 @@ public pcb-component component :
   pin-properties :
     [pin:Ref     | pads:Int ...   | side:Dir]
     [sig | 1 | Left]
-    [gnd | 2 3| Down]
+    [gnd | 2 3 4 5 6 7| Down]
   assign-symbol(coax-sym)
   assign-landpattern(johnson-142-0761-881-pkg)
   reference-prefix = "J"
   property(self.rated-temperature) = min-max(-65.0, 165.0)
 
-  
+
 
 pcb-landpattern johnson-142-0761-881-pkg :
   val w = (8.128 - 0.9144) / 2.0
   pad p[1] : smd-pad(N, 0.4064, 5.53) at loc(0.0, 0.0)
   pad p[2] : smd-pad(N, w, 5.53) at loc(-2.26, 0.0)
   pad p[3] : smd-pad(N, w, 5.53) at loc(2.26, 0.0)
-  layer(Cutout()) = Union([ 
-      Circle(1.2192, -1.7526, 0.5715)
-      Circle(-1.2192, -1.7526, 0.5715)
-      Circle(1.2192, -3.9624, 0.5715)
-      Circle(-1.2192, -3.9624, 0.5715)
-      ])
+  pad p[4] : pth-pad(0.5715, 0.71) at loc(1.2192, -1.7526)
+  pad p[5] : pth-pad(0.5715, 0.71) at loc(-1.2192, -1.7526)
+  pad p[6] : pth-pad(0.5715, 0.71) at loc(1.2192, -3.9624)
+  pad p[7] : pth-pad(0.5715, 0.71) at loc(-1.2192, -3.9624)
 
   layer(Courtyard(Top)) = Rectangle(8.18, 5.54, loc(0.0, -2.769))
   layer(BoardEdge())= Line(0.0, [Point(8.18 / 2.0, 0.0), Point(8.18 / -2.0, 0.0)])


### PR DESCRIPTION
# Background

* DRC Error because of NPTH Pad inside an SMD Pad

# Changes
* Modify the offending component with PTH Pads instead of using Cutouts

# Further Works
There may be more components that need this treatment as well as during import (CAD or parts-db)
