### PR TITLE
JITX-5031: Map "stock" -> "min-stock"

### DIFF
--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -165,9 +165,6 @@ public defn smd-query-properties () -> Tuple<KeyValue<String, ?>> :
    "case" => get-valid-pkg-list()
    "min-stock" => 5 * DESIGN-QUANTITY]
 
-public defn remove-duplicate-keys (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
-  to-tuple $ to-hashtable<String, ?>(cat-all(hs))
-
 ; ========================================================
 ; ========== Handle min/max value searching ==============
 ; ========================================================
@@ -218,7 +215,7 @@ defn find-subs-comp (params:Tuple<KeyValue>, param-name:String) :
 
 ; Generic ceramic capacitor from database (of 600k options)
 public defn ceramic-cap (user-params:Tuple<KeyValue>) -> Instantiable :
-  val params = remove-duplicate-keys $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   val my-params = replace-params(params)
@@ -245,7 +242,7 @@ public defn ceramic-cap (cap:Double|Toleranced, tolerance:Double) -> Instantiabl
   ceramic-cap(["capacitance" => cap "tolerance" => tolerance])
 
 public defn ceramic-caps (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  val params = remove-duplicate-keys $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   map(to-jitx, Capacitors(replace-params(params), limit))
@@ -258,7 +255,7 @@ public defn look-up-ceramic-caps (attribute: String) -> Tuple :
   look-up-ceramic-caps(attribute, [])
 
 public defn look-up-ceramic-caps (attribute: String, filter-properties:Tuple<KeyValue>) -> Tuple :
-  val params = remove-duplicate-keys $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         filter-properties]
   look-up-capacitors(attribute, replace-params(params))
@@ -268,7 +265,7 @@ public defn look-up-ceramic-caps (attribute: String, filter-properties:Tuple<Key
 ; ========================================================
 ; Use for adding an instance of a tantalum cap from the JITX database to your design.
 public defn tantalum-cap (user-params:Tuple<KeyValue>) -> Instantiable :
-  val params = remove-duplicate-keys $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   val my-params = replace-params(params)
@@ -288,7 +285,7 @@ public defn tantalum-cap (cap:Double|Toleranced, tolerance:Double) -> Instantiab
   tantalum-cap(["capacitance" => cap "tolerance" => tolerance])
 
 public defn tantalum-caps (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  val params = remove-duplicate-keys $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   map(to-jitx, Capacitors(replace-params(params), limit))
@@ -301,7 +298,7 @@ public defn look-up-tantalum-caps (attribute: String) -> Tuple :
   look-up-tantalum-caps(attribute, [])
 
 public defn look-up-tantalum-caps (attribute: String, filter-properties:Tuple<KeyValue>) -> Tuple :
-  val params = remove-duplicate-keys $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         filter-properties]
   look-up-capacitors(attribute, replace-params(params))
@@ -312,7 +309,7 @@ public defn look-up-tantalum-caps (attribute: String, filter-properties:Tuple<Ke
 
 ; Generic chip resistor from database (of 600k options)
 public defn chip-resistor (user-params:Tuple<KeyValue>) -> Instantiable :
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
   val my-params = replace-params(params)
   try :
     to-jitx $ Resistor(my-params)
@@ -330,7 +327,7 @@ public defn chip-resistor (resistance:Double|Toleranced, tolerance:Double) -> In
   chip-resistor(["resistance" => resistance "tolerance" => tolerance])
 
 public defn chip-resistors (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
   map(to-jitx, Resistors(replace-params(params), limit))
 
 ; ========================================================
@@ -341,7 +338,7 @@ public defn look-up-chip-resistors (attribute: String) -> Tuple :
   look-up-resistors(attribute, [])
 
 public defn look-up-chip-resistors (attribute: String, filter-properties:Tuple<KeyValue>) -> Tuple :
-  val params = remove-duplicate-keys([smd-query-properties() filter-properties])
+  val params = normalize-params([smd-query-properties() filter-properties])
   look-up-resistors(attribute, replace-params(params))
 
 ;============================================================
@@ -350,7 +347,7 @@ public defn look-up-chip-resistors (attribute: String, filter-properties:Tuple<K
 
 ; Generic inductors from database of standard packages (0402, 0603... 10k options)
 public defn smd-inductor (user-params:Tuple<KeyValue>) -> Instantiable :
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
   val my-params = replace-params(params)
   try :
     to-jitx $ Inductor(my-params)
@@ -368,7 +365,7 @@ public defn smd-inductor (ind:Double|Toleranced, tolerance:Double) -> Instantiab
   smd-inductor(["inductance" => ind "tolerance" => tolerance])
 
 public defn smd-inductors (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
   map(to-jitx, Inductors(replace-params(params), limit))
 
 ; ========================================================
@@ -379,7 +376,7 @@ public defn look-up-smd-inductors (attribute: String) -> Tuple :
   look-up-smd-inductors(attribute, [])
 
 public defn look-up-smd-inductors (attribute: String, filter-properties:Tuple<KeyValue>) -> Tuple :
-  val params = remove-duplicate-keys([smd-query-properties() filter-properties])
+  val params = normalize-params([smd-query-properties() filter-properties])
   look-up-inductors(attribute, replace-params(params))
 
 ; ========================================================

--- a/utils/parametric-components.stanza
+++ b/utils/parametric-components.stanza
@@ -338,7 +338,7 @@ public defn normalize-params (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple
 
 ; Substitute user params to match expectations:
 ;   - https://en.wikipedia.org/wiki/Principle_of_least_astonishment
-defn substitute-params (params: Seqable<KeyValue<String, ?>>) -> Seqable<KeyValue<String, ?>> :
+defn substitute-params (params: Seqable<KeyValue<String, ?>>) -> Tuple<KeyValue<String, ?>> :
   to-tuple $ for kv in params seq :
     switch {key(kv) == _} :
       "minimum_quantity" : "max-minimum_quantity" => value(kv)

--- a/utils/parametric-components.stanza
+++ b/utils/parametric-components.stanza
@@ -102,7 +102,7 @@ public pcb-module parametric-inductor (user-params:Tuple<KeyValue>) :
   property(self.parametric) = true ; property to set so that we know this is a parametric comp.
   property(self.inductor) = true
   property(self.reference-prefix) = "L"
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
 
   ; store the de-duped argument list in a property to retrieve it later
   property(self.user-params) = user-params
@@ -170,7 +170,7 @@ public pcb-module parametric-capacitor (user-params:Tuple<KeyValue>) :
   property(self.parametric) = true ; property to set so that we know this is a parametric comp.
   property(self.capacitor) = true
   property(self.reference-prefix) = "C"
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
 
   ; store the de-duped argument list in a property to retrieve it later
   property(self.user-params) = user-params
@@ -258,7 +258,7 @@ public pcb-module parametric-resistor (user-params:Tuple<KeyValue>) :
   property(self.parametric) = true ; property to set so that we know this is a parametric comp.
   property(self.resistor) = true
   property(self.reference-prefix) = "R"
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
 
   ; store the deduped argument list in a property to retrieve it later
   property(self.user-params) = user-params
@@ -331,6 +331,23 @@ public defn parametric-resistor (res:Double|Toleranced, tol:Double) -> Instantia
 ; ========================================================
 ; ========== parametric part helper functions ============
 ; ========================================================
+
+public defn normalize-params (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
+  seq(substitute-params, hs)
+    $> remove-duplicate-keys
+
+; Substitute user params to match expectations:
+;   - https://en.wikipedia.org/wiki/Principle_of_least_astonishment
+defn substitute-params (params: Seqable<KeyValue<String, ?>>) -> Seqable<KeyValue<String, ?>> :
+  to-tuple $ for kv in params seq :
+    switch {key(kv) == _} :
+      "minimum_quantity" : "max-minimum_quantity" => value(kv)
+      "stock" : "min-stock" => value(kv)
+      else :
+        kv
+
+defn remove-duplicate-keys (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
+  to-tuple $ to-hashtable<String, ?>(cat-all(hs))
 
 ; ----- proposal ----
 public defn between-std-val (v:Toleranced, tol:Double) -> Double :

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -16,6 +16,7 @@ defpackage ocdb/utils/parts :
   import ocdb/utils/bundles
   import ocdb/utils/db-parts
   import ocdb/utils/generic-components
+  import ocdb/utils/parametric-components
   import ocdb/utils/property-structs
 
 ;======================================
@@ -23,13 +24,13 @@ defpackage ocdb/utils/parts :
 ;======================================
 
 public defn PartsDBComponent (user-properties:Tuple<KeyValue>) -> Component :
-  val query-properties = remove-duplicate-keys $ [
+  val query-properties = normalize-params $ [
     user-properties
   ]
   parse-component $ dbquery-first-allow-non-stock(query-properties) as JObject
 
 public defn PartsDBComponents (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Component> :
-  val query-properties = remove-duplicate-keys $ [
+  val query-properties = normalize-params $ [
     user-properties
   ]
   map{parse-component, _} $ dbquery(query-properties, limit) as Tuple<JObject>


### PR DESCRIPTION
If a user's parametric query includes "stock", interpret as "min-stock".

Other changes:
- Move remapping logic from jitx-client to OCDB, so it runs before deduplication.
- Change existing deduplication calls to a wrapping normalization function.

## Test Plan
```
import ocdb/utils/generic-comnponents

; Passes
chip-resistor(["resistance" => 13500.0 "stock" => 5])
chip-resistor(["resistance" => 13500.0 "min-stock" => 5])

; Fails, due to stock
chip-resistor(["resistance" => 13500.0 "stock" => 500000])
chip-resistor(["resistance" => 13500.0 "min-stock" => 500000])
``` 