### PR TITLE
Prototype: allow setting local 3d model for Parts DB parts

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:2.3.0
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:2.2.0
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:1.1.13-rc.60
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:2.3.0
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/scripts/run-ocdb-tests.sh
+++ b/.github/jitx-client/scripts/run-ocdb-tests.sh
@@ -49,14 +49,24 @@ cd ..
 echo "Launching ocdb designs..."
 cd open-components-database/designs
 # tutorial.stanza and mcu.stanza use part sourcing more
-designs=(tutorial.stanza
-         ble-mote.stanza
-         mcu.stanza
+designs=(ble-mote.stanza
+         can-stm32.stanza
          class-a.stanza
+         comprehensive-checks.stanza
+         doc-examples.stanza
          ethernet-fmc.stanza
+         grid-resistors.stanza
+         lp-examples.stanza
+         mcu.stanza
+         power-monitor.stanza
+         # power-state-demo.stanza       # fails
          smd-landpatterns.stanza
          test-component-checks.stanza
-         voltage-divider.stanza)
+         tutorial.stanza
+         usb-accel.stanza
+         usb-light.stanza          # no board?
+         voltage-divider.stanza
+         run-checks/checked-design.stanza)
 
 for filename in "${designs[@]}"; do
     echo "Running $filename..."

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.sw*
 /.vscode/*
-/.DS_Store
+.DS_Store
 pending*dat
+voltage-propagation-iteration*
+designs/output-*

--- a/components/johnson/142-0761-881.stanza
+++ b/components/johnson/142-0761-881.stanza
@@ -23,25 +23,23 @@ public pcb-component component :
   pin-properties :
     [pin:Ref     | pads:Int ...   | side:Dir]
     [sig | 1 | Left]
-    [gnd | 2 3| Down]
+    [gnd | 2 3 4 5 6 7| Down]
   assign-symbol(coax-sym)
   assign-landpattern(johnson-142-0761-881-pkg)
   reference-prefix = "J"
   property(self.rated-temperature) = min-max(-65.0, 165.0)
 
-  
+
 
 pcb-landpattern johnson-142-0761-881-pkg :
   val w = (8.128 - 0.9144) / 2.0
   pad p[1] : smd-pad(N, 0.4064, 5.53) at loc(0.0, 0.0)
   pad p[2] : smd-pad(N, w, 5.53) at loc(-2.26, 0.0)
   pad p[3] : smd-pad(N, w, 5.53) at loc(2.26, 0.0)
-  layer(Cutout()) = Union([ 
-      Circle(1.2192, -1.7526, 0.5715)
-      Circle(-1.2192, -1.7526, 0.5715)
-      Circle(1.2192, -3.9624, 0.5715)
-      Circle(-1.2192, -3.9624, 0.5715)
-      ])
+  pad p[4] : pth-pad(0.5715, 0.71) at loc(1.2192, -1.7526)
+  pad p[5] : pth-pad(0.5715, 0.71) at loc(-1.2192, -1.7526)
+  pad p[6] : pth-pad(0.5715, 0.71) at loc(1.2192, -3.9624)
+  pad p[7] : pth-pad(0.5715, 0.71) at loc(-1.2192, -3.9624)
 
   layer(Courtyard(Top)) = Rectangle(8.18, 5.54, loc(0.0, -2.769))
   layer(BoardEdge())= Line(0.0, [Point(8.18 / 2.0, 0.0), Point(8.18 / -2.0, 0.0)])

--- a/components/korean-hroparts-elec/TYPE-C-31-M-23.stanza
+++ b/components/korean-hroparts-elec/TYPE-C-31-M-23.stanza
@@ -1,0 +1,34 @@
+#use-added-syntax(jitx)
+defpackage ocdb/components/korean-hroparts-elec/TYPE-C-31-M-23:
+  import core
+  import collections
+  import jitx
+  import jitx/commands
+
+  import ocdb/utils/defaults
+  import ocdb/utils/landpatterns
+  import ocdb/utils/box-symbol
+  import ocdb/utils/bundles
+  import ocdb/utils/generic-components
+  import ocdb/utils/generator-utils
+  import ocdb/utils/property-structs
+
+public pcb-module module (configuration:USB-C-ConfigurationChannel|False):
+  port usb-c : usb-c
+  pin SHIELD
+  ;public inst conn : ocdb/components/korean-hroparts-elec/TYPE-C-31-M-12/component
+  public inst conn : database-part(["mpn" => "TYPE-C-31-M-23", "manufacturer" => "Korean Hroparts Elec"])
+  place(conn) at loc(0.0, 0.0) on Top
+  net (SHIELD conn.SHELL0 conn.SHELL1 conn.SHELL2 conn.SHELL3)
+  net (usb-c.data[1].N conn.D-0)
+  net (usb-c.data[2].N conn.D-1)
+  net (usb-c.data[1].P conn.D+0)
+  net (usb-c.data[2].P conn.D+1)
+  net (usb-c.vbus.gnd conn.GND0 conn.GND1)
+  net (usb-c.vbus.vdd conn.VBUS0 conn.VBUS1)
+  net (usb-c.cc[1] conn.CC1)
+  net (usb-c.cc[2] conn.CC2)
+  net (usb-c.sbu[1] conn.SBU1)
+  net (usb-c.sbu[2] conn.SBU2)
+
+  match(configuration:USB-C-ConfigurationChannel) : ocdb/utils/generator-utils/usb-c-configuration-channel(usb-c, configuration) 

--- a/designs/ble-mote.stanza
+++ b/designs/ble-mote.stanza
@@ -264,7 +264,7 @@ val wroom-shape = Rectangle(32.0, 22.0)
 ; You can try these 3 different calls to create your design.
 
 ; The first call instantiates a WROOM module with default board sizing 
-run-design(false, design-name = "barfo")
+run-design(false, design-name = "output-barfo")
 
 ; This call instantiates a WROOM module with the board sizing listed above.
 ; run-design(false, module = ocdb/components/espressif/esp32-wroom-32/module(ocdb/components/espressif/esp32-wroom-32/ESP32-WROOM-32E-N16, true), shape = wroom-shape, design-name = "ble-mote")

--- a/designs/can-stm32.stanza
+++ b/designs/can-stm32.stanza
@@ -67,6 +67,8 @@ pcb-module first-design :
   ; Run the schematic review
   check-design(self)
 
+set-current-design("output-can-stm32")
+
 val powered-design = run-final-passes(transform-module(generate-power, first-design))
 make-default-board(powered-design, 4, board-shape)
 

--- a/designs/class-a.stanza
+++ b/designs/class-a.stanza
@@ -64,6 +64,8 @@ pcb-module demo :
   ;   ".temp 80.0"
   ;   ".tran 0.01ms 5m"
 
+set-current-design("output-class-a")
+
 make-default-board(demo, 4, Rectangle(30.0, 20.0))
 
 ;Export design to Kicad

--- a/designs/comprehensive-checks.stanza
+++ b/designs/comprehensive-checks.stanza
@@ -463,7 +463,7 @@ pcb-module main-module :
   check-design(self)
 
 defn main () :
-  set-current-design("comprehensive-checks")
+  set-current-design("output-comprehensive-checks")
   set-board(ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, Rectangle(100.0 100.0)))
   set-rules(ocdb/manufacturers/rules/jlcpcb-rules)
   set-main-module(ocdb/utils/generator-utils/run-final-passes(main-module))

--- a/designs/doc-examples.stanza
+++ b/designs/doc-examples.stanza
@@ -249,6 +249,9 @@ pcb-module example-instances :
   inst ind : to-jitx(inductor)
   println(inductor)
 ; ANCHOR_END: inductor-struct 
+
+set-current-design("output-doc-examples")
+
 make-default-board(example-instances, 2, Rectangle(25.0, 25.0))
 
 ; Export CAD with default options
@@ -257,6 +260,6 @@ make-default-board(example-instances, 2, Rectangle(25.0, 25.0))
 ; Show the Schematic and PCB for the design
 view-board()
 view-schematic()
-
+view-design-explorer()
 ; Print the MPN of the resistor from the design
 ; println(mpn?(my-design.r))

--- a/designs/ethernet-fmc.stanza
+++ b/designs/ethernet-fmc.stanza
@@ -51,6 +51,8 @@ pcb-module my-design :
   place(ethernet-jack[0]) at loc(15.0, 22.0, 270.0) on Top
   place(ethernet-jack[1]) at loc(15.0, -22.0, 270.0) on Top
 
+set-current-design("output-ethernet-fmc")
+
 val my-design* = transform-module(generate-power, my-design)
 make-default-board(my-design*, 4, Rectangle(60.0, 69.0))
 export-cad()

--- a/designs/grid-resistors.stanza
+++ b/designs/grid-resistors.stanza
@@ -43,6 +43,7 @@ pcb-module grid-resistors (s-count: Int, p-count: Int) :
     net (b s.b)
 
 defn run-design (circuit: Instantiable) :
+  set-current-design("output-grid-resistors")
   make-default-board(circuit, 2, board-shape)
 
   view-board()

--- a/designs/lp-examples.stanza
+++ b/designs/lp-examples.stanza
@@ -269,6 +269,7 @@ pcb-module example-instances :
     reference-designator(dot(self, append("led", to-string(i + 200)))) = append("D", to-string(i + 200))
     place(dot(self, append("led", to-string(i + 200)))) at loc(15.0 * to-double(i) - 100.0, -40.0, 180.0) on Top
 
+set-current-design("output-lp-examples")
 
 make-default-board(example-instances, 2, Rectangle(200.0, 200.0))
 
@@ -278,6 +279,5 @@ make-default-board(example-instances, 2, Rectangle(200.0, 200.0))
 ; Show the Schematic and PCB for the design
 view-board()
 view-schematic()
-run-design-verification()
 ; Print the MPN of the resistor from the design
 ; println(mpn?(my-design.r))

--- a/designs/mcu.stanza
+++ b/designs/mcu.stanza
@@ -10,17 +10,19 @@ defpackage ocdb/designs/mcu :
   import ocdb/utils/design-vars
   import ocdb/utils/micro-controllers
 
+set-current-design("output-mcu")
+
 val BOARD-SHAPE = RoundedRectangle(25.0, 25.0, 0.25)
 DESIGN-QUANTITY = 0
 OPTIMIZE-FOR = ["area"]
 
-val mcu-parameters = ["series" => "STM32F4"]
+val mcu-parameters = ["series" => "STM32F4" "mpn" => "STM32F410RBI6"] ; "mpn" => "STM32F410TBY6"]
 val module-parameters = [`debug-interface => jtag()]
 
 pcb-module mcu-design (mcu:Instantiable):
   inst stm32 : mcu
   require leds : gpio[3] from stm32.mcu
-  require usart : usart([])[3] from stm32.mcu
+  require usart : usart([UART-RX UART-TX])[3] from stm32.mcu
   require spi : spi-controller()[3] from stm32.mcu
   require i2s : i2s() from stm32.mcu
   ; require i2c : i2c[3] from stm32.mcu
@@ -32,6 +34,6 @@ val best-mcu = find-micro-controller(mcu-parameters, module-parameters, mcu-desi
 match(value?(best-mcu)):
   (mcu:Instantiable):
     make-default-board(mcu-design(mcu), 4, BOARD-SHAPE)
-    view-board()
+    ; view-board()
     view-schematic()
   (_:False) : println("No mcu fits this design.")

--- a/designs/power-monitor.stanza
+++ b/designs/power-monitor.stanza
@@ -62,6 +62,7 @@ pcb-module power-monitor :
     check-design(self)
 
 defn run-design (module:Instantiable) :
+  set-current-design("output-power-monitor")
   val powered-design = run-final-passes(transform-module(generate-power, module))
   make-default-board(powered-design, 4, board-shape)
 

--- a/designs/power-state-demo.stanza
+++ b/designs/power-state-demo.stanza
@@ -10,6 +10,8 @@ defpackage ocdb/designs/power-state-demo :
   import ocdb/utils/generic-components
   import ocdb/utils/landpatterns
   import ocdb/utils/property-structs
+  import ocdb/utils/netlist-checks/all
+  import ocdb/utils/netlist-checks/utils
 
 pcb-landpattern soic127-p8:
   make-n-pin-soic-landpattern(8,
@@ -152,7 +154,7 @@ pcb-module main-module :
   propagate-power-states(self)
   check power-states(self)
 
-set-current-design("test-design")
+set-current-design("output-power-state-demo")
 set-main-module(main-module)
 assign-pins()
 run-checks("checks.txt")

--- a/designs/run-checks/capacitors.stanza
+++ b/designs/run-checks/capacitors.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx)
-defpackage ocdb/designs/checks/capacitors :
+defpackage ocdb/designs/run-checks/capacitors :
   import core
   import collections
   import jitx

--- a/designs/run-checks/checked-design.stanza
+++ b/designs/run-checks/checked-design.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx)
-defpackage ocdb/designs/checks/checked-design :
+defpackage ocdb/designs/run-checks/checked-design :
   import core
   import collections
   import jitx
@@ -8,10 +8,10 @@ defpackage ocdb/designs/checks/checked-design :
   import ocdb/utils/defaults
   import ocdb/utils/generator-utils
   import ocdb/utils/property-structs
-  import ocdb/designs/checks/capacitors
-  import ocdb/designs/checks/digital-io
-  import ocdb/designs/checks/inductors
-  import ocdb/designs/checks/resistors
+  import ocdb/designs/run-checks/capacitors
+  import ocdb/designs/run-checks/digital-io
+  import ocdb/designs/run-checks/inductors
+  import ocdb/designs/run-checks/resistors
 
 pcb-module main-module :
   inst rs: resistors
@@ -32,7 +32,7 @@ pcb-module main-module :
   check-design(self)
 
 defn main () :
-  set-current-design("checked-design")
+  set-current-design("output-checked-design")
   run-final-passes(main-module)
   run-checks("checks.txt")
 

--- a/designs/run-checks/digital-io.stanza
+++ b/designs/run-checks/digital-io.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx)
-defpackage ocdb/designs/checks/digital-io :
+defpackage ocdb/designs/run-checks/digital-io :
   import core
   import collections
   import jitx

--- a/designs/run-checks/inductors.stanza
+++ b/designs/run-checks/inductors.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx)
-defpackage ocdb/designs/checks/resistors :
+defpackage ocdb/designs/run-checks/inductors :
   import core
   import collections
   import jitx
@@ -16,61 +16,65 @@ defpackage ocdb/designs/checks/resistors :
   import ocdb/utils/design-vars
   import ocdb/utils/generic-components
 
-pcb-component resistor-pass :
-  reference-prefix = "R"
+pcb-component inductor-pass :
+  reference-prefix = "L"
+
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = resistor-sym()
+  val sym = inductor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.resistor)    = true
-  property(self.resistance)  = 1.0e3
-  property(self.rated-power) = 1.0
+  property(self.inductor)       = true
+  property(self.dc-resistance)  = 16.0
+  property(self.rated-power)    = 5.0
+  property(self.inductance)     = 1.0e-6
   property(self.rated-temperature) = min-max(-55.0, 100.0)
 
-pcb-component resistor-fail :
-  reference-prefix = "R"
+pcb-component inductor-fail :
+  reference-prefix = "L"
+
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = resistor-sym()
+  val sym = inductor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.resistor)    = true
-  property(self.resistance)  = 1.0  ; 1 ohm
-  property(self.rated-power) = 0.25 ; .25 W
+  property(self.inductor)       = true
+  property(self.dc-resistance)  = 16.0
+  property(self.rated-power)    = 0.25
+  property(self.inductance)     = 1.0e-6
   property(self.rated-temperature) = min-max(-55.0, 100.0)
 
-pcb-component resistor-info :
-  reference-prefix = "R"
+pcb-component inductor-info :
+  reference-prefix = "L"
+
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = resistor-sym()
+  val sym = inductor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.resistor) = true
+  property(self.inductor)       = true
 
-public pcb-module resistors :
+public pcb-module inductors :
   port power : ocdb/utils/bundles/power
-
-  inst Rreal : chip-resistor(1.0e3)
-  inst Rfail : resistor-fail
-  inst Rpass : resistor-pass
-  inst Rinfo : resistor-info
-  
-  net (power.vdd, Rreal.p[1], Rfail.p[1], Rpass.p[1], Rinfo.p[1])
-  net (power.gnd, Rreal.p[2], Rfail.p[2], Rpass.p[2], Rinfo.p[2])
+  val answer = dbquery(["category" => "inductor", "inductance" => 1.0e-6], 1)
+  inst Lreal : smd-inductor(1.0e-6)
+  inst Lpass : inductor-pass
+  inst Lfail : inductor-fail
+  inst Linfo : inductor-info
+  net VDD (power.vdd, Lreal.p[1], Lpass.p[1], Lfail.p[1], Linfo.p[1])
+  net GND (power.gnd, Lreal.p[2], Lpass.p[2], Lfail.p[2], Linfo.p[2])

--- a/designs/run-checks/resistors.stanza
+++ b/designs/run-checks/resistors.stanza
@@ -1,5 +1,5 @@
 #use-added-syntax(jitx)
-defpackage ocdb/designs/checks/inductors :
+defpackage ocdb/designs/run-checks/resistors :
   import core
   import collections
   import jitx
@@ -16,65 +16,61 @@ defpackage ocdb/designs/checks/inductors :
   import ocdb/utils/design-vars
   import ocdb/utils/generic-components
 
-pcb-component inductor-pass :
-  reference-prefix = "L"
-
+pcb-component resistor-pass :
+  reference-prefix = "R"
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = inductor-sym()
+  val sym = resistor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.inductor)       = true
-  property(self.dc-resistance)  = 16.0
-  property(self.rated-power)    = 5.0
-  property(self.inductance)     = 1.0e-6
+  property(self.resistor)    = true
+  property(self.resistance)  = 1.0e3
+  property(self.rated-power) = 1.0
   property(self.rated-temperature) = min-max(-55.0, 100.0)
 
-pcb-component inductor-fail :
-  reference-prefix = "L"
-
+pcb-component resistor-fail :
+  reference-prefix = "R"
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = inductor-sym()
+  val sym = resistor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.inductor)       = true
-  property(self.dc-resistance)  = 16.0
-  property(self.rated-power)    = 0.25
-  property(self.inductance)     = 1.0e-6
+  property(self.resistor)    = true
+  property(self.resistance)  = 1.0  ; 1 ohm
+  property(self.rated-power) = 0.25 ; .25 W
   property(self.rated-temperature) = min-max(-55.0, 100.0)
 
-pcb-component inductor-info :
-  reference-prefix = "L"
-
+pcb-component resistor-info :
+  reference-prefix = "R"
   pin-properties :
     [ pin : Ref | pads : Int ... ]
     [ p[1]      | 1              ]
     [ p[2]      | 2              ]
   
   assign-landpattern(ipc-two-pin-landpattern("0603"))
-  val sym = inductor-sym()
+  val sym = resistor-sym()
   symbol =
     sym(self.p[1] => sym.p[1], self.p[2] => sym.p[2])
 
-  property(self.inductor)       = true
+  property(self.resistor) = true
 
-public pcb-module inductors :
+public pcb-module resistors :
   port power : ocdb/utils/bundles/power
-  val answer = dbquery(["category" => "inductor", "inductance" => 1.0e-6], 1)
-  inst Lreal : smd-inductor(1.0e-6)
-  inst Lpass : inductor-pass
-  inst Lfail : inductor-fail
-  inst Linfo : inductor-info
-  net VDD (power.vdd, Lreal.p[1], Lpass.p[1], Lfail.p[1], Linfo.p[1])
-  net GND (power.gnd, Lreal.p[2], Lpass.p[2], Lfail.p[2], Linfo.p[2])
+
+  inst Rreal : chip-resistor(1.0e3)
+  inst Rfail : resistor-fail
+  inst Rpass : resistor-pass
+  inst Rinfo : resistor-info
+  
+  net (power.vdd, Rreal.p[1], Rfail.p[1], Rpass.p[1], Rinfo.p[1])
+  net (power.gnd, Rreal.p[2], Rfail.p[2], Rpass.p[2], Rinfo.p[2])

--- a/designs/smd-landpatterns.stanza
+++ b/designs/smd-landpatterns.stanza
@@ -32,5 +32,7 @@ pcb-module main-module:
   inst smd-cmp:  my-component(true)
   inst nsmd-cmp: my-component(false)
 
+set-current-design("output-smd-landpatterns")
+
 make-default-board(main-module, 4, Rectangle(10.0, 10.0))
 view-board()

--- a/designs/test-component-checks.stanza
+++ b/designs/test-component-checks.stanza
@@ -193,6 +193,8 @@ pcb-board B :
   boundary = brd-outline
   signal-boundary = brd-outline
 
+set-current-design("output-test-component-checks")
+
 set-main-module(checks)
 set-board(B)
 set-rules(sierra-adv-rules)

--- a/designs/tutorial.stanza
+++ b/designs/tutorial.stanza
@@ -101,7 +101,7 @@ pcb-module regulator-fixture :
 ; Configure the design, then run or check it
 ; ==========================================
 defn run-design (circuit:Instantiable, run-checks?:True|False) :
-  set-current-design("jitx-design")
+  set-current-design("output-tutorial")
   set-board(ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, board-shape))
   set-rules(ocdb/manufacturers/rules/jlcpcb-rules)
 

--- a/designs/usb-accel.stanza
+++ b/designs/usb-accel.stanza
@@ -42,6 +42,8 @@ pcb-module accel:
   symbol(P3V3) = ocdb/utils/symbols/supply-sym
   symbol(gnd) = ocdb/utils/symbols/ground-sym  
 
+set-current-design("output-usb-accel")
+
 make-default-board(accel, 4, BOARD-SHAPE)
 view-board()
 view-schematic()

--- a/designs/usb-light.stanza
+++ b/designs/usb-light.stanza
@@ -39,7 +39,7 @@ pcb-module main-board:
   net gnd (vbus.gnd conn.GND conn.SHIELD)
   symbol(p5v) = ocdb/utils/symbols/supply-sym
   symbol(gnd) = ocdb/utils/symbols/ground-sym
-  val vbus-voltage = (nom-value(recommended-voltage(property(conn.VCC.power-pin)))) as Double
+  val vbus-voltage = (nom-value(recommended-voltage(property(conn.VCC.power-pin)) as Toleranced)) as Double
   val exact-resistance = led-circuit-resistance(vbus-voltage, property(led[0].forward-voltage), property(led[0].test-current), 2)
   inst res : gen-res-cmp(closest-std-val(exact-resistance, 5.0), "0603")[4]
   val trace-thickness = 0.254
@@ -112,6 +112,9 @@ pcb-module main-board:
   place(logo) at loc(7.0, -5.0, 0.0) on Bottom
   println("Calculated Resistance = %_, Standard Value Resistance = %_" % [exact-resistance property(res[0].resistance)])
   check-design(self)
+
+set-current-design("output-usb-light")
+
 make-default-board(main-board, 4, BOARD-SHAPE)
 view-board()
 view-schematic()

--- a/manufacturers/stackups.stanza
+++ b/manufacturers/stackups.stanza
@@ -49,6 +49,22 @@ public pcb-stackup jlcpcb-jlc2313 :
   layer(0.035, copper) 
   layer(0.019, soldermask) ; 0.5mil over conductor
 
+public pcb-stackup jlcpcb-jlc2313-6layer :
+  name = "JLCPCB 6-layer 1.6mm"
+  layer(0.019, soldermask) ; 0.5mil over conductor
+  layer(0.035, copper)
+  layer(0.1, prepreg-2313)
+  layer(0.0175, copper)
+  layer(0.565, core)
+  layer(0.0175, copper)
+  layer(0.127, prepreg-2313)
+  layer(0.0175, copper)
+  layer(0.565, core)
+  layer(0.0175, copper)
+  layer(0.1, prepreg-2313)
+  layer(0.035, copper)
+  layer(0.019, soldermask) ; 0.5mil over conductor
+
 public pcb-stackup bay-area-circuits-4-layer-62-mil :
   name = "Bay Area Circuits 4-layer 0.062in"
   layer(0.01778, soldermask) ; 0.7mil over conductor

--- a/ocdb.stanza
+++ b/ocdb.stanza
@@ -70,6 +70,7 @@ defpackage ocdb :
   import ocdb/components/korean-hroparts-elec/DC-182-25A
   import ocdb/components/korean-hroparts-elec/K2-1102SP-C4SC-04
   import ocdb/components/korean-hroparts-elec/TYPE-C-31-M-12
+  import ocdb/components/korean-hroparts-elec/TYPE-C-31-M-23
   import ocdb/components/kyocera/KC2520B
   import ocdb/components/labjack/T7
   import ocdb/components/laird/LI0805H151R-10

--- a/tests/parametric-components.stanza
+++ b/tests/parametric-components.stanza
@@ -123,6 +123,7 @@ pcb-module para-components-0 :
 
   ; total resistor count = 3 + num-r + 3 + num-r + num-r * (3 + num-r)
   ; = 6 + 5 * num-r + num-r * num-r
+  inst r5 : chip-resistor(["resistance" => 13.5e3, "tolerance" => 0.01])
 
   net connA (r1d0.p[1] r1t0.p[1] c1d0.p[1] c1t0.p[1] l1d0.p[1] l1t0.p[1] hierA.io[1] hierC.io[1] hierE.io[1])
   net connB (r1t1.p[1] c1t1.p[1] l1t1.p[1])

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -208,12 +208,76 @@ public pcb-bundle usb-c-full-bundle :
   pin SSTXN2
   
 public pcb-bundle rgmii :
-  port txd : pin[4]
+  port txd : pin[4] 
   port rxd : pin[4]
+  pin tx-clk  ; should be txc
+  pin tx-ctrl ; tx-ctl
+  pin rx-clk  ; rxc
+  pin rx-ctrl ; rx-ctl
+
+public pcb-bundle miim :
+  pin mdc
+  pin mdio
+
+; Gigabit Media Independent Interface (GMII)
+; https://en.wikipedia.org/wiki/Media-independent_interface#GMII
+public pcb-bundle mii (): 
+  pin gtxclk
+  pin txclk
+  port txd : pin[8]
+  pin txen
+  pin txer
+  pin rxclk
+  port rxd : pin[8]
+  pin rxdv
+  pin rxer
+  pin col
+  pin cs
+
+
+public pcb-enum ocdb/utils/bundles/MIIPins-Extra:
+  ; Optional on MII
+  MII-TX-ER  
+
+; Standard Media Independent Interface (MII)
+; https://en.wikipedia.org/wiki/Media-independent_interface#Standard_MII
+public pcb-bundle mii (pins:Tuple<MIIPins-Extra>): 
   pin tx-clk
-  pin tx-ctrl
+  pin tx-en
+  port txd : pin[4]
   pin rx-clk
-  pin rx-ctrl
+  port rxd : pin[4]
+  pin rx-dv
+  pin rx-er
+  pin crs
+  pin col
+  for p in pins do:
+    switch(p):
+      MII-TX-ER : make-pin(`tx-er)
+
+public defn mii () : 
+  ; Without tx error
+  mii([])
+
+public pcb-enum ocdb/utils/bundles/RMIIPins-Extra:
+  ; Optional on RMII
+  RMII-RX-ER  
+
+; Reduced Media Independent Interface (RMII)
+; https://en.wikipedia.org/wiki/Media-independent_interface#RMII
+public pcb-bundle rmii (pins:Tuple<RMIIPins-Extra>) :
+  pin ref-clk
+  port txd : pin[2]
+  pin tx-en
+  port rxd : pin[2]
+  pin crs-dv  
+  for p in pins do:
+    switch(p):
+      RMII-RX-ER : make-pin(`rx-er)
+
+; Default implementation with no rx-er
+public defn rmii ():
+  rmii([])
 
 public pcb-bundle ethernet-1000 :
   port mdi : diff-pair[4]
@@ -343,6 +407,26 @@ public defn get-bundle-by-name (name:String, options:Tuple<String>) -> Bundle | 
       spi-controller()
     else :
       fatal("Bundle '%_' is not supported." % [name])
+
+
+public pcb-enum ocdb/utils/bundles/ULPIBusMode:
+  ULPI-SDR-8x
+  ULPI-DDR-4x
+
+defn ULPI-PortArray (cnt:Int) -> PortArray : 
+  PortArray(SinglePin(), to-tuple $ 0 to cnt)
+
+public pcb-bundle ulpi (mode:ULPIBusMode) :
+  pin dir
+  pin stp
+  pin nxt
+  pin clk
+  switch(mode):
+    ULPI-SDR-8x: make-port(`d, ULPI-PortArray(8))
+    ULPI-DDR-4x: make-port(`d, ULPI-PortArray(4))
+
+public defn ulpi () :
+  ulpi(ULPI-SDR-8x)
 
 public defn get-bundle-by-name (name:String) -> Bundle | [Bundle, Bundle] :
   get-bundle-by-name(name, [])

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -30,6 +30,7 @@ public defmulti sellers (component: Component) -> Tuple<Seller>|False
 public defmulti resolved-price (component: Component) -> Double|False
 public defmulti vendor-part-numbers (component: Component) -> Tuple<KeyValue<String, String>>
 public defmulti to-jitx (component: Component) -> Instantiable
+public defmulti to-jitx (component: Component, model-3d:Model3D|False) -> Instantiable
 ; The top-level Component includes queryable fields used in parametric queries.
 ; This inner component represents the actual ESIR-instantiable object, including symbols/landpattern.
 public defmulti component (component: Component) -> ComponentCode

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -149,6 +149,9 @@ public defn database-part (mpn: String, manufacturer: String) -> Instantiable :
 public defn database-part (user-params:Tuple<KeyValue>) -> Instantiable :
   to-jitx $ PartsDBComponent(user-params)
 
+public defn database-part (user-params:Tuple<KeyValue>, model3d: Model3D|False) -> Instantiable :
+  to-jitx(PartsDBComponent(user-params), model3d)
+
 public defn database-parts (user-params:Tuple<KeyValue>) -> Tuple<Instantiable> :
   map(to-jitx, PartsDBComponents(user-params, 10))
 

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -168,9 +168,6 @@ public defn smd-query-properties () -> Tuple<KeyValue<String, ?>> :
    "case" => get-valid-pkg-list()
    "min-stock" => 5 * DESIGN-QUANTITY]
 
-public defn remove-duplicate-keys (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
-  to-tuple $ to-hashtable<String, ?>(cat-all(hs))
-
 ; ========================================================
 ; ========== Handle min/max value searching ==============
 ; ========================================================
@@ -221,7 +218,7 @@ defn find-subs-comp (params:Tuple<KeyValue>, param-name:String) :
 
 ; Generic ceramic capacitor from database (of 600k options)
 public defn ceramic-cap (user-params:Tuple<KeyValue>) -> Instantiable :
-  val params = remove-duplicate-keys $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   val my-params = replace-params(params)
@@ -248,7 +245,7 @@ public defn ceramic-cap (cap:Double|Toleranced, tolerance:Double) -> Instantiabl
   ceramic-cap(["capacitance" => cap "tolerance" => tolerance])
 
 public defn ceramic-caps (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  val params = remove-duplicate-keys $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   map(to-jitx, Capacitors(replace-params(params), limit))
@@ -261,7 +258,7 @@ public defn look-up-ceramic-caps (attribute: String) -> Tuple :
   look-up-ceramic-caps(attribute, [])
 
 public defn look-up-ceramic-caps (attribute: String, filter-properties:Tuple<KeyValue>) -> Tuple :
-  val params = remove-duplicate-keys $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["type" => "ceramic" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         filter-properties]
   look-up-capacitors(attribute, replace-params(params))
@@ -271,7 +268,7 @@ public defn look-up-ceramic-caps (attribute: String, filter-properties:Tuple<Key
 ; ========================================================
 ; Use for adding an instance of a tantalum cap from the JITX database to your design.
 public defn tantalum-cap (user-params:Tuple<KeyValue>) -> Instantiable :
-  val params = remove-duplicate-keys $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   val my-params = replace-params(params)
@@ -291,7 +288,7 @@ public defn tantalum-cap (cap:Double|Toleranced, tolerance:Double) -> Instantiab
   tantalum-cap(["capacitance" => cap "tolerance" => tolerance])
 
 public defn tantalum-caps (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  val params = remove-duplicate-keys $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         user-params]
   map(to-jitx, Capacitors(replace-params(params), limit))
@@ -304,7 +301,7 @@ public defn look-up-tantalum-caps (attribute: String) -> Tuple :
   look-up-tantalum-caps(attribute, [])
 
 public defn look-up-tantalum-caps (attribute: String, filter-properties:Tuple<KeyValue>) -> Tuple :
-  val params = remove-duplicate-keys $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
+  val params = normalize-params $ [["anode" => "tantalum" "min-rated-voltage" => MIN-CAP-VOLTAGE]
                                         smd-query-properties()
                                         filter-properties]
   look-up-capacitors(attribute, replace-params(params))
@@ -315,7 +312,7 @@ public defn look-up-tantalum-caps (attribute: String, filter-properties:Tuple<Ke
 
 ; Generic chip resistor from database (of 600k options)
 public defn chip-resistor (user-params:Tuple<KeyValue>) -> Instantiable :
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
   val my-params = replace-params(params)
   try :
     to-jitx $ Resistor(my-params)
@@ -333,7 +330,7 @@ public defn chip-resistor (resistance:Double|Toleranced, tolerance:Double) -> In
   chip-resistor(["resistance" => resistance "tolerance" => tolerance])
 
 public defn chip-resistors (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
   map(to-jitx, Resistors(replace-params(params), limit))
 
 ; ========================================================
@@ -344,7 +341,7 @@ public defn look-up-chip-resistors (attribute: String) -> Tuple :
   look-up-resistors(attribute, [])
 
 public defn look-up-chip-resistors (attribute: String, filter-properties:Tuple<KeyValue>) -> Tuple :
-  val params = remove-duplicate-keys([smd-query-properties() filter-properties])
+  val params = normalize-params([smd-query-properties() filter-properties])
   look-up-resistors(attribute, replace-params(params))
 
 ;============================================================
@@ -353,7 +350,7 @@ public defn look-up-chip-resistors (attribute: String, filter-properties:Tuple<K
 
 ; Generic inductors from database of standard packages (0402, 0603... 10k options)
 public defn smd-inductor (user-params:Tuple<KeyValue>) -> Instantiable :
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
   val my-params = replace-params(params)
   try :
     to-jitx $ Inductor(my-params)
@@ -371,7 +368,7 @@ public defn smd-inductor (ind:Double|Toleranced, tolerance:Double) -> Instantiab
   smd-inductor(["inductance" => ind "tolerance" => tolerance])
 
 public defn smd-inductors (user-params:Tuple<KeyValue>, limit: Int) -> Tuple<Instantiable> :
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
   map(to-jitx, Inductors(replace-params(params), limit))
 
 ; ========================================================
@@ -382,7 +379,7 @@ public defn look-up-smd-inductors (attribute: String) -> Tuple :
   look-up-smd-inductors(attribute, [])
 
 public defn look-up-smd-inductors (attribute: String, filter-properties:Tuple<KeyValue>) -> Tuple :
-  val params = remove-duplicate-keys([smd-query-properties() filter-properties])
+  val params = normalize-params([smd-query-properties() filter-properties])
   look-up-inductors(attribute, replace-params(params))
 
 ; ========================================================
@@ -768,7 +765,7 @@ public defn  usb2-on-a-usb-c-connector ():
 public pcb-module usb2-on-a-usb-c-connector (conref:Instantiable):
   port usb-2 : usb-2
   port usb-c : usb-c
-  inst con : conref
+  public inst con : conref
   place(con) at loc(0.0, 0.0) on Top
   net (usb-c con.usb-c)
   net (usb-2.data.N con.usb-c.data[1].N con.usb-c.data[2].N)

--- a/utils/parametric-components.stanza
+++ b/utils/parametric-components.stanza
@@ -102,7 +102,7 @@ public pcb-module parametric-inductor (user-params:Tuple<KeyValue>) :
   property(self.parametric) = true ; property to set so that we know this is a parametric comp.
   property(self.inductor) = true
   property(self.reference-prefix) = "L"
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
 
   ; store the de-duped argument list in a property to retrieve it later
   property(self.user-params) = user-params
@@ -170,7 +170,7 @@ public pcb-module parametric-capacitor (user-params:Tuple<KeyValue>) :
   property(self.parametric) = true ; property to set so that we know this is a parametric comp.
   property(self.capacitor) = true
   property(self.reference-prefix) = "C"
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
 
   ; store the de-duped argument list in a property to retrieve it later
   property(self.user-params) = user-params
@@ -258,7 +258,7 @@ public pcb-module parametric-resistor (user-params:Tuple<KeyValue>) :
   property(self.parametric) = true ; property to set so that we know this is a parametric comp.
   property(self.resistor) = true
   property(self.reference-prefix) = "R"
-  val params = remove-duplicate-keys([smd-query-properties() user-params])
+  val params = normalize-params([smd-query-properties() user-params])
 
   ; store the deduped argument list in a property to retrieve it later
   property(self.user-params) = user-params
@@ -331,6 +331,23 @@ public defn parametric-resistor (res:Double|Toleranced, tol:Double) -> Instantia
 ; ========================================================
 ; ========== parametric part helper functions ============
 ; ========================================================
+
+public defn normalize-params (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
+  seq(substitute-params, hs)
+    $> remove-duplicate-keys
+
+; Substitute user params to match expectations:
+;   - https://en.wikipedia.org/wiki/Principle_of_least_astonishment
+defn substitute-params (params: Seqable<KeyValue<String, ?>>) -> Tuple<KeyValue<String, ?>> :
+  to-tuple $ for kv in params seq :
+    switch {key(kv) == _} :
+      "minimum_quantity" : "max-minimum_quantity" => value(kv)
+      "stock" : "min-stock" => value(kv)
+      else :
+        kv
+
+defn remove-duplicate-keys (hs:Seqable<Seqable<KeyValue<String, ?>>>) -> Tuple<KeyValue<String, ?>> :
+  to-tuple $ to-hashtable<String, ?>(cat-all(hs))
 
 ; ----- proposal ----
 public defn between-std-val (v:Toleranced, tol:Double) -> Double :

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -18,6 +18,18 @@ defpackage ocdb/utils/parts :
   import ocdb/utils/generic-components
   import ocdb/utils/property-structs
 
+; HACK: prototype to allow injecting local 3d model files
+public defn create-model-3d (filename: String) -> Model3D :
+  ; Relative to "open-components-database/utils"
+  val path = to-string("../../%_" % [filename])
+  Model3D(
+    path,
+    Vec3D(0.0, 0.0, 0.0),
+    ; Pat: Has to be non-zero to show up in Kicad (not sure why?)
+    Vec3D(1.0, 1.0, 1.0),
+    Vec3D(0.0, 0.0, 0.0),
+  )
+
 ;======================================
 ;============ Public API ==============
 ;======================================
@@ -494,9 +506,15 @@ defn NoConnectCode (json: JObject) -> NoConnectCode :
   NoConnectCode(PinByTypeCode(json["pin"] as JObject))
 
 public defmethod to-jitx (part: Part) -> Instantiable :
-  to-jitx $ component(part)
+  to-jitx(part, false)
+
+public defmethod to-jitx (part: Part, model-3d: Model3D|False) -> Instantiable :
+  to-jitx(component(part), model-3d)
 
 public defn to-jitx (c: ComponentCode) -> Instantiable :
+  to-jitx(c, false)
+
+public defn to-jitx (c: ComponentCode, model-3d: Model3D|False) -> Instantiable :
   pcb-component my-component :
     name = name(c)
 
@@ -532,7 +550,7 @@ public defn to-jitx (c: ComponentCode) -> Instantiable :
       val pad-name = name(pp)
       jitx-pads-by-pcb-pad-name[pad-name] = jitx-pad
 
-    val landpattern-def = to-jitx(landpattern(c) as LandPatternCode, jitx-pads-by-pcb-pad-name)
+    val landpattern-def = to-jitx(landpattern(c) as LandPatternCode, jitx-pads-by-pcb-pad-name, model-3d)
     assign-landpattern(landpattern-def)
 
     assign-symbols(
@@ -982,7 +1000,7 @@ defn Side (s: String) -> Side :
     "Top": Top
     "Bottom": Bottom
 
-defn to-jitx (lp: LandPatternCode, jitx-pads-by-pcb-pad-name: HashTable<String, Pad>) -> LandPattern :
+defn to-jitx (lp: LandPatternCode, jitx-pads-by-pcb-pad-name: HashTable<String, Pad>, model-3d:Model3D|False) -> LandPattern :
   pcb-landpattern my-landpattern :
     name = name(lp)
     for p in /pads(lp) do :
@@ -998,6 +1016,9 @@ defn to-jitx (lp: LandPatternCode, jitx-pads-by-pcb-pad-name: HashTable<String, 
     do(to-jitx, layers(lp))
     do(to-jitx, geometries(lp))
     do(to-jitx, model3ds(lp))
+
+    match(model-3d:Model3D) :
+      to-jitx(model-3d)
 
   my-landpattern
 

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -16,6 +16,7 @@ defpackage ocdb/utils/parts :
   import ocdb/utils/bundles
   import ocdb/utils/db-parts
   import ocdb/utils/generic-components
+  import ocdb/utils/parametric-components
   import ocdb/utils/property-structs
 
 ; HACK: prototype to allow injecting local 3d model files
@@ -35,13 +36,13 @@ public defn create-model-3d (filename: String) -> Model3D :
 ;======================================
 
 public defn PartsDBComponent (user-properties:Tuple<KeyValue>) -> Component :
-  val query-properties = remove-duplicate-keys $ [
+  val query-properties = normalize-params $ [
     user-properties
   ]
   parse-component $ dbquery-first-allow-non-stock(query-properties) as JObject
 
 public defn PartsDBComponents (user-properties:Tuple<KeyValue>, limit: Int) -> Tuple<Component> :
-  val query-properties = remove-duplicate-keys $ [
+  val query-properties = normalize-params $ [
     user-properties
   ]
   map{parse-component, _} $ dbquery(query-properties, limit) as Tuple<JObject>


### PR DESCRIPTION
Experimental change to inject 3d model into part when loaded into ESIR.

## Test Plan
Run Cofactr design, `export-design()`, open in Kicad, and confirm models show up in 3d view.

The model locations/rotation/scale are wrong, but for testing purposes, we can adjust in Cad tooling.