### PR TITLE
Box Symbol padding

### DIFF
--- a/utils/box-symbol.stanza
+++ b/utils/box-symbol.stanza
@@ -169,7 +169,7 @@ defn generate-box-symbol-unit (all-entries:Vector<KeyValue<Dir,Pin>>) -> [Schema
                (f:False) : 0.0
                
   ;Compute total width and height
-  val pad = grid(0.0)
+  val pad = grid(1.0)
   val mpn-pad = max(mpnl + 2.0, pad)
   val width =
     if Tp == 0.0 :


### PR DESCRIPTION
Box symbols that do not have pins in all four directions have no padding.
In the examples below, the top-most and bottom-most pins hug the symbol's bounds, and the pin names bleed outside the symbol.
Link to [most recent change](https://github.com/JITx-Inc/open-components-database/commit/cfb02464a471a0753b6d4abd643cc6bb25cce5a9#r114637159)

Was this change intended?

Without this PR:
![Screen Shot 2023-05-23 at 8 51 11 AM](https://github.com/JITx-Inc/open-components-database/assets/23412242/9e121b06-010d-4bd9-9e16-d32cb626d06d)

With this PR:
![Screen Shot 2023-05-23 at 8 51 35 AM](https://github.com/JITx-Inc/open-components-database/assets/23412242/b116291e-6fa5-47f3-9687-6795eb188d36)

