### PR TITLE
JITX-5178: Add sellers data as property for component card

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -189,7 +189,7 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-sellers-as-property(sellers(resistor))
+        set-property(self, `sellers, sellers(resistor))
 
         ; spice :
         ;   "[R] <p[1]> <p[2]> <resistance>"
@@ -430,7 +430,7 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-sellers-as-property(sellers(capacitor))
+        set-property(self, `sellers, sellers(capacitor))
 
       my-capacitor
 
@@ -605,7 +605,7 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-sellers-as-property(sellers(inductor))
+        set-property(self, `sellers, sellers(inductor))
 
         spice :
           "[L] <p[1]> <p[2]> <inductance>"

--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -47,6 +47,7 @@ public defstruct Sourcing :
 ;============================================================
 
 public pcb-struct ocdb/utils/db-parts/Seller :
+  updated-at: String|False
   company-name: String
   resolved-price: Double
   offers: Tuple<SellerOffer>
@@ -149,7 +150,7 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
   match(landpattern(component)) :
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx $ component
+      to-jitx(component, sellers(resistor))
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -188,6 +189,7 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
+        set-sellers-as-property(sellers(resistor))
 
         ; spice :
         ;   "[R] <p[1]> <p[2]> <resistance>"
@@ -342,7 +344,7 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
   match(landpattern(component)):
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx $ component
+      to-jitx(component, sellers(capacitor))
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -428,6 +430,7 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
+        set-sellers-as-property(sellers(capacitor))
 
       my-capacitor
 
@@ -563,7 +566,7 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
   match(landpattern(component)):
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx $ component
+      to-jitx(component, sellers(inductor))
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -602,6 +605,7 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
+        set-sellers-as-property(sellers(inductor))
 
         spice :
           "[L] <p[1]> <p[2]> <inductance>"
@@ -768,6 +772,7 @@ defmethod print (o:OutputStream, s:Sourcing) :
 
 defmethod print (o:OutputStream, s:Seller) :
   val items = [
+    "updated-at = %_" % [updated-at(s)]
     "company-name = %_" % [company-name(s)]
     "resolved-price = %_" % [resolved-price(s)]
     "offers = (%_)" % [indented-list(offers(s))]]
@@ -857,7 +862,10 @@ public defn parse-sellers (json: JObject) -> Tuple<Seller>|False:
 
   if json-sellers is-not False :
     for json-seller in json-sellers as Tuple<JObject> map :
-      Seller{json-seller["company_name"] as String, json-seller["resolved_price"] as Double, _} $
+      val updated-at = match(get?(json-seller, "updated_at")) :
+        (s:String) : s
+        (_) : false
+      Seller{updated-at, json-seller["company_name"] as String, json-seller["resolved_price"] as Double, _} $
         for json-offer in json-seller["offers"] as Tuple<JObject> map :
           SellerOffer{int(json-offer["inventory_level"]), _} $
             for json-price in json-offer["prices"] as Tuple<JObject> map :

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -51,7 +51,7 @@ public defstruct Part <: Component :
   ; Power dissipation limit as rated by manufacturer. One value, or PWL function (W | [degC, W])
   rated-power: Double|False
 
-  ; Optionally appended by jit-backend (does not come from parts-db)
+  ; These may be populated in Parts DB, or updated values may be inserted by the backend.
   sellers: Tuple<Seller>|False with: (as-method => true)
   resolved-price: Double|False with: (as-method => true)
 with :
@@ -495,9 +495,21 @@ defn NoConnectCode (json: JObject) -> NoConnectCode :
   NoConnectCode(PinByTypeCode(json["pin"] as JObject))
 
 public defmethod to-jitx (part: Part) -> Instantiable :
-  to-jitx $ component(part)
+  to-jitx(component(part), sellers(part))
 
 public defn to-jitx (c: ComponentCode) -> Instantiable :
+  to-jitx(c, false)
+
+; Set sellers as a property so they show up in the component card.
+public defn set-sellers-as-property (sellers: Tuple<Seller>|False) :
+  match(sellers:Tuple<Seller>) :
+    inside pcb-component :
+      var sellers-str = ""
+      for seller in sellers do :
+        sellers-str = append-all([sellers-str, "\n", to-string(seller)])
+      set-property(self, `sellers, sellers-str)
+
+public defn to-jitx (c: ComponentCode, sellers: Tuple<Seller>|False) -> Instantiable :
   pcb-component my-component :
     name = name(c)
 
@@ -524,6 +536,8 @@ public defn to-jitx (c: ComponentCode) -> Instantiable :
       to-jitx(pin-props)
 
     map(to-jitx, properties(c))
+
+    set-sellers-as-property(sellers)
 
     reference-prefix = reference_prefix(c)
 

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -500,15 +500,6 @@ public defmethod to-jitx (part: Part) -> Instantiable :
 public defn to-jitx (c: ComponentCode) -> Instantiable :
   to-jitx(c, false)
 
-; Set sellers as a property so they show up in the component card.
-public defn set-sellers-as-property (sellers: Tuple<Seller>|False) :
-  match(sellers:Tuple<Seller>) :
-    inside pcb-component :
-      var sellers-str = ""
-      for seller in sellers do :
-        sellers-str = append-all([sellers-str, "\n", to-string(seller)])
-      set-property(self, `sellers, sellers-str)
-
 public defn to-jitx (c: ComponentCode, sellers: Tuple<Seller>|False) -> Instantiable :
   pcb-component my-component :
     name = name(c)
@@ -537,7 +528,7 @@ public defn to-jitx (c: ComponentCode, sellers: Tuple<Seller>|False) -> Instanti
 
     map(to-jitx, properties(c))
 
-    set-sellers-as-property(sellers)
+    set-property(self, `sellers, sellers)
 
     reference-prefix = reference_prefix(c)
 


### PR DESCRIPTION
Ensure that sellers data displays in component cards.

This allows users to see offers, where the data comes from either Parts DB, or Octopart.

## Test Plan
```
import ocdb/utils/generic-components

; Including "_stock" causes fresh data to be fetched from Octopart
view-design-explorer $ database-part(["mpn" => "RP2040", "_stock" => 0])
```