### PR TITLE
JITX-5377 / JITX-5376: Restore queries after parts-db fix deployed

### DIFF
--- a/designs/doc-examples.stanza
+++ b/designs/doc-examples.stanza
@@ -121,7 +121,7 @@ pcb-module example-instances :
   inst c12 : ceramic-cap(["capacitance" => closest-std-val(test-voltage * 1.0e-6, 20.0) "min-rated-voltage" => 60.0])
 
 ; c13 = the largest value capacitor in case size 0805, 100V minimum rated voltage, and `metadata.applications` matches one of the fields in the `automotive-metadata` value.
-  inst c13 : ceramic-cap(["_sort" => ["-capacitance"] "case" => "0805" "min-rated-voltage" => 30.0 "metadata.applications" => automative-metadata])
+  inst c13 : ceramic-cap(["capacitance" => 68.0e-12 "_sort" => ["-capacitance"] "case" => "0805" "min-rated-voltage" => 30.0 "metadata.applications" => automative-metadata])
 ; ANCHOR_END: capacitor-examples
   schematic-group([c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13]) = ceramic-cap-examples
   layout-group([c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13]) = ceramic-cap-examples

--- a/designs/doc-examples.stanza
+++ b/designs/doc-examples.stanza
@@ -114,18 +114,14 @@ pcb-module example-instances :
 
 ; c11 =  1uF± ceramic capacitor, 60V minimum rated voltage, and `metadata.applications` matches one of the fields in the `automotive-metadata` value.
   val automative-metadata = ["Audio, Automotive" "Automotive" "Automotive, Boardflex Sensitive" "Automotive, Boardflex Sensitive, ESD Protection" "Automotive, Bypass, Decoupling" "Automotive, Bypass, Decoupling, Boardflex Sensitive" "Automotive, Bypass, Decoupling, Boardflex Sensitive, ESD Protection" "Automotive, Bypass, Decoupling, ESD Protection" "Automotive, EMI, RFI Suppression" "Automotive, ESD Protection" "Automotive, High Temperature Reflow" "Automotive, SMPS Filtering" "Automotive, SMPS Filtering, Boardflex Sensitive" "Automotive, SMPS Filtering, Bypass, Decoupling" "Automotive; DC Link, DC Filtering" "Automotive; DC Link, DC Filtering; High Frequency, Switching; High Pulse, DV/DT" "Automotive; DC Link, DC Filtering; High Pulse, DV/DT; Snubber" "Automotive; EMI, RFI Suppression" "Automotive; High Frequency, Switching" "Automotive; High Frequency, Switching; High Pulse, DV/DT" "Automotive; High Frequency, Switching; High Pulse, DV/DT; Snubber" "Automotive; Power Factor Correction (PFC)" "High Reliability, Automotive" "High Reliability, Automotive, Boardflex Sensitive" "RF, Microwave, High Frequency, Automotive" "Safety, Automotive" "Safety, Automotive, Boardflex Sensitive"]
-  ; TODO: JITX-5376 - Restore "metadata.applications" filter.
-  inst c11 : ceramic-cap(["capacitance" => 1.0e-6 "min-rated-voltage" => 60.0])
-  ; inst c11 : ceramic-cap(["capacitance" => 1.0e-6 "min-rated-voltage" => 60.0 "metadata.applications" => automative-metadata])
+  inst c11 : ceramic-cap(["capacitance" => 1.0e-6 "min-rated-voltage" => 60.0 "metadata.applications" => automative-metadata])
 
 ; c12 =  ceramic capacitor who's value is calculated based on a capacitance * a double, then rounded to the nearest 20% standard value, 60V minimum rated voltage.
   val test-voltage = 5.0
   inst c12 : ceramic-cap(["capacitance" => closest-std-val(test-voltage * 1.0e-6, 20.0) "min-rated-voltage" => 60.0])
 
 ; c13 = the largest value capacitor in case size 0805, 100V minimum rated voltage, and `metadata.applications` matches one of the fields in the `automotive-metadata` value.
-  ; TODO: JITX-5376 - Restore "metadata.applications" filter.
-  inst c13 : ceramic-cap(["_sort" => ["-capacitance"] "case" => "0805" "min-rated-voltage" => 30.0])
-  ; inst c13 : ceramic-cap(["_sort" => ["-capacitance"] "case" => "0805" "min-rated-voltage" => 30.0 "metadata.applications" => automative-metadata])
+  inst c13 : ceramic-cap(["_sort" => ["-capacitance"] "case" => "0805" "min-rated-voltage" => 30.0 "metadata.applications" => automative-metadata])
 ; ANCHOR_END: capacitor-examples
   schematic-group([c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13]) = ceramic-cap-examples
   layout-group([c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13]) = ceramic-cap-examples
@@ -196,9 +192,7 @@ pcb-module example-instances :
   inst inductor1 : smd-inductor(4.7e-6, 0.05)
 
 ; inductor2 = SMD inductor with the 20% standard value closest to 2µH, tolerance 10%, wirewound, 1210 size or larger, rated to 40° C or above
-; TODO: JITX-5377 - Restore the "type" filter below.
-  inst inductor2 : smd-inductor(["inductance" => closest-std-val(2.0e-6, 20.0) "tolerance" => 0.10 "case" => get-valid-pkg-list("1210") "min-rated-temperature.max" => 40.0])
-  ; inst inductor2 : smd-inductor(["inductance" => closest-std-val(2.0e-6, 20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("1210") "min-rated-temperature.max" => 40.0])
+  inst inductor2 : smd-inductor(["inductance" => closest-std-val(2.0e-6, 20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("1210") "min-rated-temperature.max" => 40.0])
 
 ; inductor3 = inductor with value of 2µH or larger, saturation current of 200mA or larger, current rating oWirewoundf 1A or larger, 1210 size or larger, shielded or semi-shielded, rated to 40° C or above
   inst inductor3 : smd-inductor(["min-inductance" => 2.0e-6 "min-saturation-current" => 0.2 "min-current-rating" => 1.0 "case" => get-valid-pkg-list("1210") "shielding" => ["shielded" "semi-shielded"] "min-rated-temperature.max" => 40.0])
@@ -217,9 +211,7 @@ pcb-module example-instances :
   ind-strap(filter-5v, out-5v, 10.0e-9, 0.2)
 
 ; SMD inductor with the 20% standard value closest to 20nH, tolerance 10%, wirewound, 0603 size or larger, rated to 40° C or above, connected between filter-5v and out-5v
-; TODO: JITX-5377 - Restore the "type" filter below.
-  ind-strap(filter-5v, out-5v, ["inductance" => closest-std-val(20.0e-9, 20.0) "tolerance" => 0.10 "case" => get-valid-pkg-list("0603") "min-rated-temperature.max" => 40.0])
-  ; ind-strap(filter-5v, out-5v, ["inductance" => closest-std-val(20.0e-9, 20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("0603") "min-rated-temperature.max" => 40.0])
+  ind-strap(filter-5v, out-5v, ["inductance" => closest-std-val(20.0e-9, 20.0) "tolerance" => 0.10 "type" => "Wirewound" "case" => get-valid-pkg-list("0603") "min-rated-temperature.max" => 40.0])
 ; ANCHOR_END: inductor-strap
 
 ; Examples of using the generic inductor call


### PR DESCRIPTION
## Summary
We partially disabled some test queries, in order to unblock a PR from merging:
- #404

The root cause was a new version of the parts database, with some bad data:
- stock (zero values incorrectly set to -1)
- metadata.applications (missing)

Those issues have been fixed, so we're now restoring the original queries.

## Test Plan
I expect the OCDB CI to fail initially, as the fixes aren't fully deployed.

The population is running overnight, and I'll re-trigger the CI in the morning, and it should pass.