### PR TITLE
JITX-5435: Update resonator-checks to work with Toleranced

### DIFF
--- a/designs/comprehensive-checks.stanza
+++ b/designs/comprehensive-checks.stanza
@@ -187,7 +187,7 @@ pcb-component crystal-resonator :
 pcb-module resonator-module :
   public inst X1 : crystal-resonator
   public inst C1 : ceramic-capacitor
-  property(C1.tolerance) = [0.99, 1.01]
+  property(C1.tolerance) = Toleranced(0.99, 1.0, 1.01)
   val intf = CrystalOscillator(
     max-critical-gain, drive-level,
     c-pin, frequency-tolerance, frequency

--- a/designs/comprehensive-checks.stanza
+++ b/designs/comprehensive-checks.stanza
@@ -187,7 +187,7 @@ pcb-component crystal-resonator :
 pcb-module resonator-module :
   public inst X1 : crystal-resonator
   public inst C1 : ceramic-capacitor
-  property(C1.tolerance) = Toleranced(0.99, 1.0, 1.01)
+  property(C1.tolerance) = Toleranced(1.0, 0.01, 0.01)
   val intf = CrystalOscillator(
     max-critical-gain, drive-level,
     c-pin, frequency-tolerance, frequency

--- a/utils/passive-checks/resonator-checks.stanza
+++ b/utils/passive-checks/resonator-checks.stanza
@@ -115,7 +115,13 @@ public pcb-check resonator-pullability-check (o:JITXObject, intf:CrystalOscillat
   val op = property(o.crystal-resonator)
   val pullability = motional-capacitance(op) / (2.0 * pow(shunt-capacitance(op) + load-capacitance(op), 2.0))
   
-  val dC = (property(load-cap.capacitance) as Double) * (property(load-cap.tolerance)[1] as Double)
+  ; Parse in backwards-compatible manner.
+  ; We used to insert as a Double, but updated to a Toleranced.
+  val tolerance = match(property(load-cap.tolerance)) :
+    (toleranced:Toleranced) : typ(toleranced)
+    (tolerance:Double) : tolerance
+
+  val dC = (property(load-cap.capacitance) as Double) * tolerance
   val freq-error = (pullability as Double) * (dC as Double) * frequency(op)
   #CHECK(
     condition = frequency-tolerance(op) + freq-error < frequency-tolerance(intf),


### PR DESCRIPTION
## Summary
The parts-db population has been inserting "tolerance" into ESIR properties as a "Toleranced" defstruct.

It was previously represented as a scalar, using the max value, so we changed it to prevent losing data,
but this broke existing usage in OCDB's `resonator-checks`.

The fix here updates `resonator-checks` to work with either a `Toleranced` or a `Double`.

## Test Plan
### 1. Run the `comprehensive-checks.stanza` design:
- This check actually manually set `tolerance` to a 2-tuple, which may have been another older format.
- Rather than support all 3 formats, this PR updates that check to use a Toleranced instead.

### 2. Test via OCDB's nRF52840 module
Add this to a `main.stanza`, and run:
```
set-main-module(ocdb/components/nordic/nRF52840/module)
run-check-on-design(ocdb/components/nordic/nRF52840/module)
```
- This contains `check-resonator` calls, which use a capacitor from the parts-db (via `add-xtal-caps` -> `cap-strap`).
- This failed without the PR changes, but passes with them.