### PR TITLE
JITX-5504: Remove "sellers" ESIR property

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -150,7 +150,7 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
   match(landpattern(component)) :
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx(component, sellers(resistor))
+      to-jitx(component)
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -189,7 +189,6 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-property(self, `sellers, sellers(resistor))
 
         ; spice :
         ;   "[R] <p[1]> <p[2]> <resistance>"
@@ -344,7 +343,7 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
   match(landpattern(component)):
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx(component, sellers(capacitor))
+      to-jitx(component)
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -430,7 +429,6 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-property(self, `sellers, sellers(capacitor))
 
       my-capacitor
 
@@ -566,7 +564,7 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
   match(landpattern(component)):
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx(component, sellers(inductor))
+      to-jitx(component)
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -605,7 +603,6 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-property(self, `sellers, sellers(inductor))
 
         spice :
           "[L] <p[1]> <p[2]> <inductance>"

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -495,12 +495,9 @@ defn NoConnectCode (json: JObject) -> NoConnectCode :
   NoConnectCode(PinByTypeCode(json["pin"] as JObject))
 
 public defmethod to-jitx (part: Part) -> Instantiable :
-  to-jitx(component(part), sellers(part))
+  to-jitx(component(part))
 
 public defn to-jitx (c: ComponentCode) -> Instantiable :
-  to-jitx(c, false)
-
-public defn to-jitx (c: ComponentCode, sellers: Tuple<Seller>|False) -> Instantiable :
   pcb-component my-component :
     name = name(c)
 
@@ -527,8 +524,6 @@ public defn to-jitx (c: ComponentCode, sellers: Tuple<Seller>|False) -> Instanti
       to-jitx(pin-props)
 
     map(to-jitx, properties(c))
-
-    set-property(self, `sellers, sellers)
 
     reference-prefix = reference_prefix(c)
 


### PR DESCRIPTION
This pairs with a parts-db PR:
- [JITX-5504: Remove non-useful ESIR properties #142](https://github.com/JITx-Inc/parts-db/pull/142)

The "sellers" property was being inserted here in OCDB, since it may have been updated by `jit-backend`.

This is no longer required, as `sellers` will only be on the defstructs.

## Test Plan
See parts-db PR.