### PR TITLE
Purge Extraneous TRACESWO definition from SWD definition

### DIFF
--- a/components/tag-connect/TC2030-IDC-NL.stanza
+++ b/components/tag-connect/TC2030-IDC-NL.stanza
@@ -49,3 +49,10 @@ public pcb-component component :
     swd-swo().swdio  => self.p[2]
     swd-swo().swdclk => self.p[4]
     swd-swo().swo => self.p[6]
+
+  supports power:
+    power.vdd => self.p[1]
+    power.gnd => self.p[5]
+
+  supports reset:
+    reset.reset => self.p[3]

--- a/components/tag-connect/TC2030-IDC-NL.stanza
+++ b/components/tag-connect/TC2030-IDC-NL.stanza
@@ -45,8 +45,7 @@ public pcb-component component :
   landpattern = TC2030-IDC-NL-footprint(for i in 1 through 6 do : p[i] => TC2030-IDC-NL-footprint.p[i])
   reference-prefix = "J"
 
-  supports swd([SWD-SWO, SWD-TRACESWO]) :
-    swd([SWD-SWO, SWD-TRACESWO]).swdio  => self.p[2]
-    swd([SWD-SWO, SWD-TRACESWO]).swdclk => self.p[4]
-    swd([SWD-SWO, SWD-TRACESWO]).swo => self.p[6]
-    swd([SWD-SWO, SWD-TRACESWO]).traceswo => self.p[1]
+  supports swd-swo() :
+    swd-swo().swdio  => self.p[2]
+    swd-swo().swdclk => self.p[4]
+    swd-swo().swo => self.p[6]

--- a/components/tag-connect/TC2030-IDC.stanza
+++ b/components/tag-connect/TC2030-IDC.stanza
@@ -54,11 +54,10 @@ public pcb-component component :
 
   property(self.rated-temperature) = false
 
-  supports swd([SWD-SWO, SWD-TRACESWO]) :
-    swd([SWD-SWO, SWD-TRACESWO]).swdio  => self.p[2]
-    swd([SWD-SWO, SWD-TRACESWO]).swdclk => self.p[4]
-    swd([SWD-SWO, SWD-TRACESWO]).swo => self.p[6]
-    swd([SWD-SWO, SWD-TRACESWO]).traceswo => self.p[1]
+  supports swd-swo() :
+    swd-swo().swdio  => self.p[2]
+    swd-swo().swdclk => self.p[4]
+    swd-swo().swo => self.p[6]
 
   supports power:
     power.vdd => self.p[1]

--- a/components/tag-connect/TC2050-IDC-NL.stanza
+++ b/components/tag-connect/TC2050-IDC-NL.stanza
@@ -58,11 +58,10 @@ public pcb-component component :
     jtag().tdi => self.p[8]
     jtag().trstn => self.p[10]
 
-  supports swd([SWD-SWO, SWD-TRACESWO]) :
-    swd([SWD-SWO, SWD-TRACESWO]).swdio  => self.p[2]
-    swd([SWD-SWO, SWD-TRACESWO]).swdclk => self.p[4]
-    swd([SWD-SWO, SWD-TRACESWO]).swo => self.p[6]
-    swd([SWD-SWO, SWD-TRACESWO]).traceswo => self.p[8]
+  supports swd-swo() :
+    swd-swo().swdio  => self.p[2]
+    swd-swo().swdclk => self.p[4]
+    swd-swo().swo => self.p[6]
 
   supports power:
     power.vdd => self.p[1]

--- a/components/tag-connect/TC2050-IDC.stanza
+++ b/components/tag-connect/TC2050-IDC.stanza
@@ -65,11 +65,10 @@ public pcb-component component :
     jtag().tdi => self.p[8]
     jtag().trstn => self.p[10]
 
-  supports swd([SWD-SWO, SWD-TRACESWO]) :
-    swd([SWD-SWO, SWD-TRACESWO]).swdio  => self.p[2]
-    swd([SWD-SWO, SWD-TRACESWO]).swdclk => self.p[4]
-    swd([SWD-SWO, SWD-TRACESWO]).swo => self.p[6]
-    swd([SWD-SWO, SWD-TRACESWO]).traceswo => self.p[8]
+  supports swd-swo() :
+    swd-swo().swdio  => self.p[2]
+    swd-swo().swdclk => self.p[4]
+    swd-swo().swo => self.p[6]
 
   supports power:
     power.vdd => self.p[1]

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -77,6 +77,10 @@ public pcb-bundle can-interface :
 
 public pcb-enum ocdb/utils/bundles/SWDPins :
   SWD-SWO
+  ; @NOTE - This option is deprecated. There is only one
+  ;  SWO pin definition for the SWD specification. This
+  ;  was a duplicate name introduced for STM support.
+  ;  DO NOT USE THIS IN OCDB.
   SWD-TRACESWO
 
 public pcb-bundle swd (pins:Tuple<ocdb/utils/bundles/SWDPins>):
@@ -89,7 +93,10 @@ public pcb-bundle swd (pins:Tuple<ocdb/utils/bundles/SWDPins>):
 
 public defn swd ():
   swd([])
-      
+
+public defn swd-swo ():
+  swd([SWD-SWO])
+
 public pcb-enum ocdb/utils/bundles/UARTPins :
   UART-DTR
   UART-CTS

--- a/utils/module-utils.stanza
+++ b/utils/module-utils.stanza
@@ -15,7 +15,7 @@ public defn make-10-pin-debug-connector-module (component:Instantiable) :
     ; the bundles we support out of the module
     val power-bundle  = power
     val reset-bundle  = reset
-    val swd-bundle    = swd([SWD-SWO, SWD-TRACESWO]) 
+    val swd-bundle    = swd-swo() 
     val jtag-bundle = jtag()
 
     ; the module's i/o ports
@@ -53,10 +53,9 @@ public defn make-10-pin-debug-connector-module (component:Instantiable) :
     net (swd.swdio,    conn.p[2])
     net (swd.swdclk,   conn.p[4])
     net (swd.swo,      conn.p[6])
-    net (swd.traceswo, conn.p[8])
 
     supports swd-bundle : 
       swd-bundle.swdio    => swd.swdio
       swd-bundle.swdclk   => swd.swdclk
       swd-bundle.swo      => swd.swo
-      swd-bundle.traceswo => swd.traceswo
+


### PR DESCRIPTION
This updates the SWD bundle to remove an extraneous signal. 

I've checked the cookbook and there are no instances of this there. 

@bhusang  - Is there anywhere else I should check for code that might touch the SWD bundle ? 