### PR TITLE
Consistent interfaces for `cap-strap` and `bypass-cap-strap`

### DIFF
--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -585,11 +585,17 @@ public defn gen-led-cmp (pkg-name:String) :
 ; ========================================================
 ; These functions attach a passive component between two pins. e.g. strap a pull up resistor between an IO and VDD
 
-public defn bypass-cap-strap (power-pin:JITXObject, gnd-pin:JITXObject, capacitance:Double|Toleranced):
+public defn bypass-cap-strap (power-pin:JITXObject, gnd-pin:JITXObject, params:Tuple<KeyValue>):
   inside pcb-module:
-    val cap = cap-strap(gnd-pin, power-pin, capacitance)
+    val cap = cap-strap(gnd-pin, power-pin, params)
     short-trace(cap.p[2], power-pin)
     cap
+
+public defn bypass-cap-strap (power-pin:JITXObject, gnd-pin:JITXObject, capacitance:Double|Toleranced, tol:Double):
+  bypass-cap-strap(power-pin, gnd-pin, ["capacitance" => capacitance, "tolerance" => tol])
+
+public defn bypass-cap-strap (power-pin:JITXObject, gnd-pin:JITXObject, capacitance:Double|Toleranced):
+  bypass-cap-strap(power-pin, gnd-pin, ["capacitance" => capacitance])
 
 public defn bypass-caps (power-pin:JITXObject|Symbol, gnd-pin:JITXObject|Symbol, voltage:Double, caps:Tuple<Double|Toleranced>, name:Symbol) :
   inside pcb-module:


### PR DESCRIPTION
This adds a new interface to `bypass-cap-strap` to allow the user to pass `KeyValuePair` parameters similar to the base method for `cap-strap`.