### PR TITLE
JITX-5813: Add new 3DModel fields from parts-db

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:2.2.0
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:2.15.0
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -972,8 +972,11 @@ defn Model3D (json: JObject) -> Model3D :
           Vec3D(json["position"] as JObject),
           Vec3D(json["scale"] as JObject),
           Vec3D(json["rotation"] as JObject),
-          get(json, "properties") as Tuple<KeyValue<String, String>>,
-          json["jitx_model_3d_id"] as String)
+          ; Serialization not yet supported for:
+          ;   Tuple<KeyValue<String, String>>
+          [],
+          json["jitx_model_3d_id"] as String,
+          json["comment"] as String)
 
 defn Vec3D (json: JObject) -> Vec3D :
   Vec3D(json["x"] as Double,

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -1008,7 +1008,13 @@ defn to-jitx (lp: LandPatternCode, jitx-pads-by-pcb-pad-name: HashTable<String, 
 
     do(to-jitx, layers(lp))
     do(to-jitx, geometries(lp))
-    do(to-jitx, model3ds(lp))
+    ; TODO: JITX-5895 - Add 3D models for parametric queries
+    ;
+    ;       For now, we don't add 3D models, because we don't know the relative transformations.
+    ;
+    ;       If users want 3D models, they can use "Create component" in component search,
+    ;       which generates Stanza files, that include a comment about the relative transformations.
+    ;do(to-jitx, model3ds(lp))
 
   my-landpattern
 

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -971,12 +971,7 @@ defn Model3D (json: JObject) -> Model3D :
   Model3D(json["filename"] as String,
           Vec3D(json["position"] as JObject),
           Vec3D(json["scale"] as JObject),
-          Vec3D(json["rotation"] as JObject),
-          ; Serialization not yet supported for:
-          ;   Tuple<KeyValue<String, String>>
-          [],
-          json["jitx_model_3d_id"] as String,
-          json["comment"] as String)
+          Vec3D(json["rotation"] as JObject))
 
 defn Vec3D (json: JObject) -> Vec3D :
   Vec3D(json["x"] as Double,

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -971,7 +971,9 @@ defn Model3D (json: JObject) -> Model3D :
   Model3D(json["filename"] as String,
           Vec3D(json["position"] as JObject),
           Vec3D(json["scale"] as JObject),
-          Vec3D(json["rotation"] as JObject))
+          Vec3D(json["rotation"] as JObject),
+          get(json, "properties") as Tuple<KeyValue<String, String>>,
+          json["jitx_model_3d_id"] as String)
 
 defn Vec3D (json: JObject) -> Vec3D :
   Vec3D(json["x"] as Double,


### PR DESCRIPTION
Parse new fields for 3D models from parts-db.

We weren't populating any 3D models before, so it's safe to assume the new fields exist.

## Test Plan
See [parts-db PR](https://github.com/JITx-Inc/parts-db/pull/181).