### PR TITLE
Altium Power Port Resizing

### DIFF
--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -63,8 +63,8 @@ public pcb-symbol altium-power-arrow-sym :
   name = "ALTIUM-POWER-ARROW"
   pin p[0] at unit-point(0.0, 0.0)
 
-  unit-line([[0.0, 0.0], [0.5, 0.0]])
-  unit-triangle([0.5, 0.0], [1.1, 0.0], 0.6)
+  unit-line([[0.0, 0.0], [0.3, 0.0]])
+  unit-triangle([0.3, 0.0], [0.9, 0.0], 0.6)
   unit-val([1.0, -0.2])
 
   preferred-orientation = PreferRotation([1])
@@ -83,9 +83,8 @@ public pcb-symbol altium-power-bar-sym :
   name = "ALTIUM-POWER-BAR"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val ex = 3.0 / 2.0 * 0.5
-  unit-line([[0.0, 0.0], [ex, 0.0]])
-  unit-line([[ex, -0.5 / 2.0], [ex, 0.5 / 2.0]])
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-line([[1.0, 0.5], [1.0, -0.5]])
   unit-val([0.2, 0.2])
 
   preferred-orientation = PreferRotation([1])
@@ -94,13 +93,9 @@ public pcb-symbol altium-power-wave-sym :
   name = "ALTIUM-POWER-WAVE"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5 / 2.0
-  val ex = 4.0 * u
-  unit-line([[0.0, 0.0], [ex, 0.0]])
-  unit-line([[ex - u, u], [ex, 0.5 * u]])
-  unit-line([[ex, 0.5 * u], [ex, -0.5 * u]])
-  unit-line([[ex + u, (- u)], [ex, -0.5 * u]])
-  unit-val([0.6, -0.2])
+  unit-line([[0.0, 0.0], [0.6, 0.0]])
+  unit-approx-arc([1.0, 0.0], 0.4, PI, 3.0 * PI / 2.0)
+  unit-approx-arc([0.2, 0.0], 0.4, PI / 2.0)
 
   preferred-orientation = PreferRotation([1])
 
@@ -108,12 +103,11 @@ public pcb-symbol altium-power-gnd-power-sym :
   name = "ALTIUM-POWER-GND-POWER"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5 / 2.0
-  unit-line([[0.0, 0.0], [2.0 * u, 0.0]])
-  unit-line(0.1, [[2.00 * u, -0.55], [2.00 * u, 0.55]])
-  unit-line(0.1, [[2.67 * u, -0.43], [2.67 * u, 0.43]])
-  unit-line(0.1, [[3.33 * u, -0.3], [3.33 * u, 0.3]])
-  unit-line(0.1, [[4.00 * u, -0.18], [4.00 * u, 0.18]])
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-line(0.1, [[1.0, -1.0], [1.0, 1.0]])
+  unit-line(0.1, [[1.28, -0.72], [1.28, 0.72]])
+  unit-line(0.1, [[1.56, -0.44], [1.56, 0.44]])
+  unit-line(0.1, [[1.84, -0.16], [1.84, 0.16]])
   unit-val([1.0, -0.4])
 
   preferred-orientation = PreferRotation([3])
@@ -122,8 +116,8 @@ public pcb-symbol altium-power-gnd-signal-sym :
   name = "ALTIUM-POWER-GND-SIGNAL"
   pin p[0] at unit-point(0.0, 0.0)
 
-  unit-line([[0.0, 0.0], [0.5, 0.0]])
-  unit-triangle([0.5, 0.0], [1.5 * 0.7, 0.0], 1.5 * 0.6)
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-triangle([1.0, 0.0], [2.0, 0.0], 2.0)
   unit-val([1.0, -0.4])
 
   preferred-orientation = PreferRotation([3])
@@ -132,14 +126,12 @@ public pcb-symbol altium-power-gnd-earth-sym :
   name = "ALTIUM-POWER-GND-EARTH"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5 / 2.0
-  val ex = 4.0 * u
-  unit-line([[0.0, 0.0], [ex, 0.0]])
-  unit-line([[ex, u], [ex, -1.0 * u]])
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-line([[1.0, -1.0], [1.0, 1.0]])
+  unit-line([[1.0, -1.0], [2.0, -1.5]])
+  unit-line([[1.0, 0.0], [2.0, -0.5]])
+  unit-line([[1.0, 1.0], [2.0, 0.5]])
 
-  unit-line([[ex, u], [ex + 0.5 * u, u - 0.5 * u]])
-  unit-line([[ex, 0.0], [ex + 0.5 * u, -0.5 * u]])
-  unit-line([[ex, -1.0 * u], [ex + 0.5 * u, -1.5 * u]])
   unit-val([0.2, -0.2])
 
   preferred-orientation = PreferRotation([3])
@@ -148,11 +140,9 @@ public pcb-symbol altium-gost-power-arrow-sym :
   name = "ALTIUM-GOST-POWER-ARROW"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5 / 2.0
-  val ex = 4.0 * u
-  unit-line([[0.0, 0.0], [ex + u, 0.0]])
-  unit-line([[ex, u], [ex + u, 0.0]])
-  unit-line([[ex, -1.0 * u], [ex + u, 0.0]])
+  unit-line([[0.0, 0.0], [1.0, 0.0]])
+  unit-line([[1.0, 0.0], [0.4, 0.3]])
+  unit-line([[1.0, 0.0], [0.4, -0.3]])
   unit-val([0.6, 0.2])
 
   preferred-orientation = PreferRotation([1])
@@ -161,11 +151,10 @@ public pcb-symbol altium-gost-gnd-power-sym :
   name = "ALTIUM-GOST-GND-POWER"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5
-  unit-line([[0.0, 0.0], [2.0 * u, 0.0]])
-  unit-line(0.1, [[2.00 * u, -0.55], [2.00 * u, 0.55]])
-  unit-line(0.1, [[2.67 * u, -0.37], [2.67 * u, 0.37]])
-  unit-line(0.1, [[3.33 * u, -0.18], [3.33 * u, 0.18]])
+  unit-line([[0.0, 0.0], [1.5, 0.0]])
+  unit-line(0.1, [[1.5, -1.0], [1.5, 1.0]])
+  unit-line(0.1, [[1.9, -0.6], [1.9, 0.6]])
+  unit-line(0.1, [[2.3, -0.2], [2.3, 0.2]])
   unit-val([0.2, -0.2])
 
   preferred-orientation = PreferRotation([3])
@@ -174,12 +163,11 @@ public pcb-symbol altium-gost-gnd-earth-sym :
   name = "ALTIUM-GOST-GND-EARTH"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val u = 0.5
-  unit-circle([2.0 * u, 0.0], 1.50 * u)
-  unit-line([[0.0, 0.0], [2.0 * u, 0.0]])
-  unit-line(0.1, [[2.00 * u, -0.55], [2.00 * u, 0.55]])
-  unit-line(0.1, [[2.47 * u, -0.37], [2.47 * u, 0.37]])
-  unit-line(0.1, [[2.94 * u, -0.18], [2.94 * u, 0.18]])
+  unit-circle([1.5, 0.0], 1.25)
+  unit-line([[0.0, 0.0], [1.5, 0.0]])
+  unit-line(0.1, [[1.5, -1.0], [1.5, 1.0]])
+  unit-line(0.1, [[1.9, -0.6], [1.9, 0.6]])
+  unit-line(0.1, [[2.3, -0.2], [2.3, 0.2]])
   unit-val([0.72, -0.2])
 
   preferred-orientation = PreferRotation([3])
@@ -188,9 +176,8 @@ public pcb-symbol altium-gost-bar-sym :
   name = "ALTIUM-GOST-BAR"
   pin p[0] at unit-point(0.0, 0.0)
 
-  val ex = 3.0 / 2.0 * 0.5
-  unit-line([[0.0, 0.0], [ex, 0.0]])
-  unit-line([[ex, -0.5 / 2.0], [ex, 0.5 / 2.0]])
+  unit-line([[0.0, 0.0], [2.0, 0.0]])
+  unit-line([[2.0, -0.8], [2.0, 0.8]])
   unit-val([1.0, -0.2])
 
   preferred-orientation = PreferRotation([1])


### PR DESCRIPTION
Observe that this PR matches the sizes of JITX's Altium symbols and Altium's power ports.
Changes to all symbols except POWER-CIRCLE.

Before PR
JITX             |  Altium
:-------------------------:|:-------------------------:
![](https://github.com/JITx-Inc/open-components-database/assets/23412242/7cebd4de-c495-4527-b13c-3599cc474f2d) |  ![](https://github.com/JITx-Inc/open-components-database/assets/23412242/64dd5fc6-139b-4f61-8c0b-48c0a06cc3d1)

With PR
JITX             |  Altium
:-------------------------:|:-------------------------:
![](https://github.com/JITx-Inc/open-components-database/assets/23412242/fa31cb48-3e38-46e6-81db-ac09618f6736) |  ![](https://github.com/JITx-Inc/open-components-database/assets/23412242/242b5d3a-2bb9-4c00-8e5b-483f0ffc22c0)

Liang recently updated power port text size, but my Altium extension didn't yet have the changes.
Updated text sizes and matching symbol sizes should limit schematic group overflow.
