### PR TITLE
JITX-5829/APPROVED-DISTRIBUTOR-LIST

### DIFF
--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -4,8 +4,8 @@
 #use-added-syntax(jitx)
 defpackage ocdb/utils/design-vars:
   import core
-  import collections
   import jitx
+  import jitx/commands
 
 public pcb-enum ocdb/utils/design-vars/DensityLevel:
   DensityLevelA
@@ -48,13 +48,16 @@ public var HOLE-POSITION-TOLERANCE:  Double = 0.0508 ; The tolerance on placing 
 ; export-bom()
 
 ; Set it to false to allow any distributor
-public var APPROVED-DISTRIBUTOR-LIST:Tuple<String> = ["Allied Electronics & Automation"
-                                        "Arrow Electronics"
-                                        "Avnet"
-                                        "Digi-Key"
-                                        "Future Electronics"
-                                        "Mouser"
-                                        "Newark"]
+public var APPROVED-DISTRIBUTOR-LIST : Tuple<String|AuthorizedVendor> = [
+  Arrow
+  Avnet
+  DigiKey
+  Future
+  JLCPCB
+  LCSC
+  Mouser
+  Newark
+]
 
 ; Set it to the number of boards you intend to fabricate. Used to find components in stock when pulling components from the JITX database.
 public var DESIGN-QUANTITY = 100


### PR DESCRIPTION
### Change

* APPROVED-DISTRIBUTOR-LIST will have some defaults vendors in defenum AuthorizedVendor format.
* The variable APROVED-DISTRIBUTOR-LIST itself is still a `var` of `Tuple<String|AuthorizedVendor>` for user expansion.

### NOTE
* this PR will not pass the test until the PR ttps://github.com/JITx-Inc/jitx-client/pull/2990 is merged and a Docker Image is made.