### PR TITLE
JITX-5732/parametric comp sourcing

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -223,7 +223,7 @@ defn resistor-query-properties (user-properties:Tuple<KeyValue>,
                    sort,
                    operating-temperature,
                    "resistor",
-                   false)
+                   true)
 
 ;============================================================
 ;======================== Look-ups ==========================
@@ -461,7 +461,7 @@ defn capacitor-query-properties (user-properties:Tuple<KeyValue>,
                    sort,
                    operating-temperature,
                    "capacitor",
-                   false)
+                   true)
 
 ;============================================================
 ;======================== Look-ups ==========================
@@ -642,7 +642,7 @@ defn inductor-query-properties (user-properties:Tuple<KeyValue>,
                    sort,
                    operating-temperature,
                    "inductor",
-                   false)
+                   true)
 
 ;============================================================
 ;======================== Look-ups ==========================


### PR DESCRIPTION
### Changes

* turn on the sourcing? flags for RLC
* merge from `main` make my local `jitx-client` compilable. The only commit is this 31b0cd6a85f42658c6b4f30575a11f291cae9798

### Note

* Parametric BOM consistency is achieved also along with this PR https://github.com/JITx-Inc/jitx-client/pull/2997
* again, until the next Docker image is available, this PR won't pass the test.