### PR TITLE
Dev to main

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:2.2.0
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:2.16.1
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -4,8 +4,8 @@
 #use-added-syntax(jitx)
 defpackage ocdb/utils/design-vars:
   import core
-  import collections
   import jitx
+  import jitx/commands
 
 public pcb-enum ocdb/utils/design-vars/DensityLevel:
   DensityLevelA
@@ -48,13 +48,15 @@ public var HOLE-POSITION-TOLERANCE:  Double = 0.0508 ; The tolerance on placing 
 ; export-bom()
 
 ; Set it to false to allow any distributor
-public var APPROVED-DISTRIBUTOR-LIST:Tuple<String> = ["Allied Electronics & Automation"
-                                        "Arrow Electronics"
-                                        "Avnet"
-                                        "Digi-Key"
-                                        "Future Electronics"
-                                        "Mouser"
-                                        "Newark"]
+public var APPROVED-DISTRIBUTOR-LIST : Tuple<String|AuthorizedVendor> = [
+  Arrow
+  Avnet
+  DigiKey
+  JLCPCB
+  LCSC
+  Mouser
+  Newark
+]
 
 ; Set it to the number of boards you intend to fabricate. Used to find components in stock when pulling components from the JITX database.
 public var DESIGN-QUANTITY = 100


### PR DESCRIPTION
APPROVED-DISTRIBUTOR-LIST in `defenum` goes to `main` from `dev`.
This is supported by `2.16.1` published.