### PR TITLE
added dnp to text & logo plus small design test

### DIFF
--- a/artwork/board-text.stanza
+++ b/artwork/board-text.stanza
@@ -20,6 +20,7 @@ defpackage ocdb/artwork/board-text :
   import ocdb/utils/defaults
   import ocdb/utils/landpatterns
   import ocdb/utils/generic-components
+  import ocdb/utils/generator-utils
   import ocdb/utils/symbols
 
 pcb-landpattern text-lp (text:String, size:Double, outline-size:Double) :
@@ -52,7 +53,10 @@ public pcb-component text (title:String, size:Double, outline-size:Double) :
   symbol = sym()
   reference-prefix = "TXT"
   property(self.rated-temperature) = false
-  
+
 public defn version-silkscreen (title:String) :
-  text(title, 1.5, 0.1)
+  inside pcb-module :
+    inst my-text : text(title, 1.5, 0.1)
+    dnp(my-text)
+    my-text
   

--- a/artwork/jitx-logo.stanza
+++ b/artwork/jitx-logo.stanza
@@ -23,6 +23,7 @@ defpackage ocdb/artwork/jitx-logo :
   import ocdb/utils/landpatterns
   import ocdb/utils/generic-components
   import ocdb/utils/symbols
+  import ocdb/utils/generator-utils
   import jitx/geometry/shapes/arc-utils
 
 pcb-symbol JITX-symbol (show-symbol:True|False) :
@@ -69,11 +70,22 @@ pcb-landpattern jitx-sm-lp (lyr:LayerSpecifier|LayerIndex, side:Side|False, heig
   ; ===========================================================================
 ; Defaults
 public defn small () :
-  small(Silkscreen("artwork", Top), true, Top)
+  inside pcb-module:
+    inst my-logo : small(Silkscreen("artwork", Top), true, Top)
+    dnp(my-logo)
+    my-logo
+
 public defn small (layer:LayerSpecifier|LayerIndex) :
-  small(layer, true, Top)
+  inside pcb-module:
+    inst my-logo : small(layer, true, Top)
+    dnp(my-logo)
+    my-logo
+
 public defn small (layer:LayerSpecifier|LayerIndex, show-symbol:True|False) :
-  small(layer, show-symbol, Top)
+  inside pcb-module:
+    inst my-logo : small(layer, show-symbol, Top)
+    dnp(my-logo)
+    my-logo
 
 public pcb-component small (layer:LayerSpecifier|LayerIndex, show-symbol:True|False, side:Side|False) :
   name = "JITX"
@@ -98,11 +110,22 @@ pcb-landpattern jitx-sm-lp (lyr:LayerSpecifier|LayerIndex, side:Side|False) :
   ; ===========================================================================
 ; Defaults
 public defn large () :
-  large(Silkscreen("artwork", Top), true, Top)
+  inside pcb-module:
+    inst my-logo : large(Silkscreen("artwork", Top), true, Top)
+    dnp(my-logo)
+    my-logo
+
 public defn large (layer:LayerSpecifier|LayerIndex) :
-  large(layer, true, Top)
+  inside pcb-module:
+    inst my-logo : large(layer, true, Top)
+    dnp(my-logo)
+    my-logo
+
 public defn large (layer:LayerSpecifier|LayerIndex, show-symbol:True|False) :
-  large(layer, show-symbol, Top)
+  inside pcb-module:
+    inst my-logo : large(layer, show-symbol, Top)
+    dnp(my-logo)
+    my-logo
 
 public pcb-component large (layer:LayerSpecifier|LayerIndex, show-symbol:True|False, side:Side|False) :
   name = "JITX"

--- a/designs/usb-light.stanza
+++ b/designs/usb-light.stanza
@@ -12,6 +12,7 @@ defpackage ocdb/designs/usb-light :
   import ocdb/utils/symbols
   import ocdb/utils/property-structs
   import ocdb/utils/checks
+  import ocdb/artwork/board-text
   import jitx/geometry/shapes/arc-utils
 
 val BOARD-SHAPE = RoundedRectangle(25.0, 25.0, 0.25)
@@ -110,6 +111,7 @@ pcb-module main-board:
 
   inst logo : ocdb/artwork/jitx-logo/logo(10.0)
   place(logo) at loc(7.0, -5.0, 0.0) on Bottom
+  version-silkscreen("USB-LIGHT 1.0")
   println("Calculated Resistance = %_, Standard Value Resistance = %_" % [exact-resistance property(res[0].resistance)])
   check-design(self)
 


### PR DESCRIPTION
To remove the logo and text from the BOM, set dnp() on those components. 