### PR TITLE
Fix opamp and power symbols for supporting multi-opamp packages

### DIFF
--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -581,42 +581,42 @@ public defn fet-sym () :
 
 ; ====== Op-Amps, Logic Gates ==================================================
 
-pcb-symbol power-supply-sym :
-  pin vs+ at unit-point(0.0, 2.0) with:
-    direction = Down
+public pcb-symbol power-supply-sym :
+  pin vs+ at unit-point(1.5, 0.0) with:
+    direction = Right
     length = 0.5 * UNIT-TO-MM
     number-size = 0.3 * UNIT-TO-MM
     name-size = 0.3 * UNIT-TO-MM
 
-  pin vs- at unit-point(0.0, -2.0) with:
-    direction = Up
-    length = 0.5 * UNIT-TO-MM
-    number-size = 0.3 * UNIT-TO-MM
-    name-size = 0.3 * UNIT-TO-MM
-  
-  unit-rectangle("foreground", 1.0, 3.0)
-  
-  unit-ref([0.5, 0.5])
-  unit-val([0.5, -0.5])
-
-pcb-symbol multi-op-amp-sym :
-  pin vi- at unit-point(-2.0, -1.0) with:
-    direction = Right
-    length = 0.5 * UNIT-TO-MM
-    number-size = 0.3 * UNIT-TO-MM
-    name-size = 0.0
- 
-  pin vi+ at unit-point(-2.0, 1.0) with:
-    direction = Right
-    length = 0.5 * UNIT-TO-MM
-    number-size = 0.3 * UNIT-TO-MM
-    name-size = 0.0
-  
-  pin vo at unit-point(2.0, 0.0) with:
+  pin vs- at unit-point(-1.5, 0.0) with:
     direction = Left
     length = 0.5 * UNIT-TO-MM
     number-size = 0.3 * UNIT-TO-MM
-    name-size = 0.0
+    name-size = 0.3 * UNIT-TO-MM
+  
+  unit-rectangle("foreground", 3.0, 1.0)
+  
+  unit-ref([-1.5, 1.0])
+  unit-val([0.0, 1.0])
+
+public pcb-symbol multi-op-amp-sym :
+  pin vi- at unit-point(-1.5, -1.0) with:
+    direction = Left
+    length = 0.5 * UNIT-TO-MM
+    ; number-size = 0.3 * UNIT-TO-MM
+    name-size = 0.3 * UNIT-TO-MM
+ 
+  pin vi+ at unit-point(-1.5, 1.0) with:
+    direction = Left
+    length = 0.5 * UNIT-TO-MM
+    ; number-size = 0.3 * UNIT-TO-MM
+    name-size = 0.3 * UNIT-TO-MM
+  
+  pin vo at unit-point(1.5, 0.0) with:
+    direction = Right
+    length = 0.5 * UNIT-TO-MM
+    ; number-size = 0.3 * UNIT-TO-MM
+    name-size = 0.3 * UNIT-TO-MM
 
   unit-triangle("foreground", [-1.5, 0.0], [1.5, 0.0], 3.0)
   


### PR DESCRIPTION
These symbols were broken - the pins were pointing backwards causing weird artifacts. The pin name/numbers were not configured to show correctly.

I changed the power symbol to use horizontal VEE and VCC pins like one would normally do with packages like this.

Here is what they look like now:

![Screenshot 2023-09-28 at 9 54 35 PM](https://github.com/JITx-Inc/open-components-database/assets/622392/eee30370-4330-4e2a-abea-af8d12f33cd2)
