### PR TITLE
JITX-5504/no-sellers-in-properties

### DIFF
--- a/utils/db-parts.stanza
+++ b/utils/db-parts.stanza
@@ -153,7 +153,7 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
   match(landpattern(component)) :
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx(resistor, component, sellers(resistor))
+      to-jitx(resistor, component)
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -192,7 +192,6 @@ defmethod to-jitx (resistor: Resistor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-property(self, `sellers, sellers(resistor))
         val q = query-properties(resistor)
         match(q:JObject) :
           set-property(self, `query-properties, entries(q))
@@ -352,7 +351,7 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
   match(landpattern(component)):
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx(capacitor, component, sellers(capacitor))
+      to-jitx(capacitor, component)
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -438,7 +437,6 @@ defmethod to-jitx (capacitor: Capacitor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-property(self, `sellers, sellers(capacitor))
         val q = query-properties(capacitor)
         match(q:JObject) :
           set-property(self, `query-properties, entries(q))
@@ -579,7 +577,7 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
   match(landpattern(component)):
     (lp:LandPatternCode):
       ; If the landpattern is included, this part should have everything it needs.
-      to-jitx(inductor, component, sellers(inductor))
+      to-jitx(inductor, component)
     (c):
       ; Otherwise, fall back on the V1 deserializers, which inject everything for 2-pin passives.
       ; We still haven't migrated all the OCDB generative logic to the parts-db population script.
@@ -618,7 +616,6 @@ defmethod to-jitx (inductor: Inductor) -> Instantiable :
 
         ; Include parts-db component properties
         map(to-jitx, properties(component))
-        set-property(self, `sellers, sellers(inductor))
         val q = query-properties(inductor)
         match(q:JObject) :
           set-property(self, `query-properties, entries(q))

--- a/utils/parts.stanza
+++ b/utils/parts.stanza
@@ -497,12 +497,9 @@ defn NoConnectCode (json: JObject) -> NoConnectCode :
   NoConnectCode(PinByTypeCode(json["pin"] as JObject))
 
 public defmethod to-jitx (part: Part) -> Instantiable :
-  to-jitx(part, component(part), sellers(part))
+  to-jitx(part, component(part))
 
-public defn to-jitx (comp: Component, c: ComponentCode) -> Instantiable :
-  to-jitx(comp, c, false)
-
-public defn to-jitx (comp:Component, c: ComponentCode, sellers: Tuple<Seller>|False) -> Instantiable :
+public defn to-jitx (comp:Component, c: ComponentCode) -> Instantiable :
   pcb-component my-component :
     name = name(c)
 
@@ -530,7 +527,6 @@ public defn to-jitx (comp:Component, c: ComponentCode, sellers: Tuple<Seller>|Fa
 
     map(to-jitx, properties(c))
 
-    set-property(self, `sellers, sellers)
     val q = query-properties(comp)
     match(q:JObject) :
       set-property(self, `query-properties, entries(q))


### PR DESCRIPTION
### Changes

* remove `sellers` from being an ESIR property.
* As such, sellers will not show up as one of the component properties

![image](https://github.com/JITx-Inc/open-components-database/assets/107752351/72b16b39-4499-439f-b9dc-03d901a8b5a6)
![image](https://github.com/JITx-Inc/open-components-database/assets/107752351/aab65331-2f5e-4347-9c1d-345397328255)

* if a part is selected in the design, the design-explorer will look like this.
![image](https://github.com/JITx-Inc/open-components-database/assets/107752351/95b42412-b23b-40d4-a10c-46498e05b314)


### NOTE

* Since explorer depends on OCDB, a build with explorer as the target is necessary to be effective