### PR TITLE
reroute to ocdb/utils/fonts

### DIFF
--- a/utils/box-symbol.stanza
+++ b/utils/box-symbol.stanza
@@ -6,7 +6,7 @@ defpackage ocdb/utils/box-symbol :
   import lang-utils
   import jitx
   import jitx/commands
-  import jitx/fonts
+  import ocdb/utils/fonts
 
 ;============================================================
 ;========== Definition of a Parameterized Box Symbol ========

--- a/utils/debug-utils.stanza
+++ b/utils/debug-utils.stanza
@@ -4,7 +4,7 @@ defpackage ocdb/utils/debug-utils :
   import collections
   import math
   import jitx
-  import jitx/fonts
+  import ocdb/utils/fonts
   import jitx/commands
   import ocdb/utils/defaults
 

--- a/utils/fonts.stanza
+++ b/utils/fonts.stanza
@@ -1,0 +1,151 @@
+defpackage ocdb/utils/fonts :
+  import core
+  import collections
+
+
+; Unused package, except 1 occurrence in ocdb/utils/box-symbol, was replaced by (mono font) string-length in jitx/schematic/analysis
+
+;<GENERATOR>
+Use the following JitPCB generator to create a KiCad file to measure the font width:
+pcb-symbol mysymbol :
+  ;Buffer
+  val buf = StringBuffer()
+  defn char-string (c:Char) :
+    clear(buf)
+    for i in 0 to 100 do :
+      add(buf, c)
+    add(buf, '|')
+    to-string(buf)
+    
+  var y-offset = 0.0  
+  for ci in 0 to 256 do :
+    val index-str = to-string("%_)" % [ci])
+    val str = char-string(to-char(ci))
+    layer(symbol) = text(index-str, Courier, 5.0, SW, loc(0.0, y-offset))
+    layer(symbol) = text(str, Courier, 5.0, SW, loc(20.0,y-offset))
+    y-offset = y-offset + 5.0
+;<GENERATOR>
+
+;The following measurements are in inches (1000 mils) and measures the
+;coordinate of a pipe (|) character after 100 repetitions of the given
+;character. The characters are assumed to start at 0.787 inches. The
+;characters have a height of 5.0mm.
+val PIPE-OFFSET = 0.884
+val KICAD-MEASUREMENT-TABLE = [
+  33 => 10.180 ;[!]
+  34 => 15.781 ;[']
+  35 => 20.476 ;[#]
+  36 => 19.579 ;[$]
+  37 => 23.280 ;[%]
+  38 => 25.179 ;[&]
+  39 => 8.331 ;[']
+  40 => 13.981 ;[(]
+  41 => 13.981 ;[)]
+  42 => 15.781 ;[*]
+  43 => 25.180 ;[+]
+  44 => 10.180 ;[,]
+  45 => 25.180 ;[-]
+  46 => 10.180 ;[.]
+  47 => 21.381 ;[/]
+  48 => 19.581 ;[0]
+  49 => 19.581 ;[1]
+  50 => 19.581 ;[2]
+  51 => 19.581 ;[3]
+  52 => 19.581 ;[4]
+  53 => 19.581 ;[5]
+  54 => 19.581 ;[6]
+  55 => 19.581 ;[7]
+  56 => 19.581 ;[8]
+  57 => 19.581 ;[9]
+  58 => 10.181 ;[:]
+  59 => 10.181 ;[;]
+  60 => 25.181 ;[<]
+  61 => 25.181 ;[=]
+  62 => 25.181 ;[>]
+  63 => 17.680 ;[?]
+  64 => 26.080 ;[@]
+  65 => 17.680 ;[A]
+  66 => 20.481 ;[B]
+  67 => 20.481 ;[C]
+  68 => 20.481 ;[D]
+  69 => 18.580 ;[E]
+  70 => 17.680 ;[F]
+  71 => 20.481 ;[G]
+  72 => 21.380 ;[H]
+  73 => 10.181 ;[I]
+  74 => 15.780 ;[J]
+  75 => 20.480 ;[K]
+  76 => 16.781 ;[L]
+  77 => 23.281 ;[M]
+  78 => 21.380 ;[N]
+  79 => 21.380 ;[O]
+  80 => 20.480 ;[P]
+  81 => 21.380 ;[Q]
+  82 => 20.480 ;[R]
+  83 => 19.580 ;[S]
+  84 => 15.781 ;[T]
+  85 => 21.380 ;[U]
+  86 => 17.680 ;[V]
+  87 => 23.280 ;[W]
+  88 => 19.580 ;[X]
+  89 => 17.680 ;[Y]
+  90 => 19.580 ;[Z]
+  91 => 13.980 ;[[]
+  92 => 27.081 ;[\]
+  93 => 13.980 ;[]]
+  94 => 12.081 ;[^]
+  95 => 15.780 ;[_]
+  96 => 8.381 ;[`]
+  97 => 18.581 ;[a]
+  98 => 18.581 ;[b]
+  99 => 17.681 ;[c]
+  100 => 18.581 ;[d]
+  101 => 17.681 ;[e]
+  102 => 12.080 ;[f]
+  103 => 18.581 ;[g]
+  104 => 18.581 ;[h]
+  105 => 10.181 ;[i]
+  106 => 10.181 ;[j]
+  107 => 16.781 ;[k]
+  108 => 11.180 ;[l]
+  109 => 26.981 ;[m]
+  110 => 18.580 ;[n]
+  111 => 18.580 ;[o]
+  112 => 18.580 ;[p]
+  113 => 18.580 ;[q]
+  114 => 12.981 ;[r]
+  115 => 16.781 ;[s]
+  116 => 12.080 ;[t]
+  117 => 18.580 ;[u]
+  118 => 15.780 ;[v]
+  119 => 21.381 ;[w]
+  120 => 16.780 ;[x]
+  121 => 15.780 ;[y]
+  122 => 16.780 ;[z]
+  123 => 13.981 ;[{]
+  124 => 19.583 ;[|]
+  125 => 13.981 ;[}]
+  126 => 7.880 ;[~]
+  127 => 23.280 ;[BOX]
+]
+
+val KICAD-CHARACTER-SPACING = Array<Double|False>(256, false)
+for entry in KICAD-MEASUREMENT-TABLE do :
+  ;x - Starting point
+  ;th - Distance between start of | character and line.
+  ;b - Ending point
+  ;l - Length (mm) of character for an assumed 1.0mm height.
+  val x = 0.787
+  val th = PIPE-OFFSET - x
+  val [index, b] = [key(entry), value(entry)]
+  val l = (b - th - x) * 25.4 / (100.0 * 5.0)
+  KICAD-CHARACTER-SPACING[index] = l
+
+defn kicad-char-width (c:Char, height:Double) :
+  match(KICAD-CHARACTER-SPACING[to-int(c)]) :
+    (w:Double) : w * height
+    (w:False) : (KICAD-CHARACTER-SPACING[127] as Double) * height
+
+; FIXME: Still used in ocdb/utils/box-symbol. Removing it would be a breaking change of people's designs as it would break their ocdb
+public defn kicad-string-length (s:String, height:Double) :
+  sum(seq(kicad-char-width{_, height}, s))

--- a/utils/landpatterns.stanza
+++ b/utils/landpatterns.stanza
@@ -5,7 +5,7 @@ defpackage ocdb/utils/landpatterns :
   import lang-utils
   import math
   import jitx
-  import jitx/fonts
+
   import jitx/commands with:
     prefix(pad) => def-
   import ocdb/utils/design-vars

--- a/utils/mechanical.stanza
+++ b/utils/mechanical.stanza
@@ -6,7 +6,7 @@ defpackage ocdb/utils/mechanical :
   import lang-utils
   import jitx
   import jitx/commands
-  import jitx/fonts
+  import ocdb/utils/fonts
   import ocdb/manufacturers/rules
   import ocdb/utils/box-symbol
   import ocdb/utils/landpatterns

--- a/utils/symbol-utils.stanza
+++ b/utils/symbol-utils.stanza
@@ -4,7 +4,7 @@ defpackage ocdb/utils/symbol-utils :
   import collections
   import math
   import jitx
-  import jitx/fonts
+
 ; ====== Unit Conversion Functions =======
 ; The following functions expect sizes and coordinates in "Symbol Units" which 
 ; is the expected grid size in schematics. For Kicad this is 50 mil, or 1.27 mm


### PR DESCRIPTION
* kicad-string-length should not be called by OCDB into jitx-client
* it is moved to OCDB now.