### PR TITLE
remove LCSC from default APPROVED-DISTRIBUTOR-LIST

### DIFF
--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -12,7 +12,7 @@ public pcb-enum ocdb/utils/design-vars/DensityLevel:
   DensityLevelB
   DensityLevelC
 
-public var OPERATING-TEMPERATURE : Toleranced 
+public var OPERATING-TEMPERATURE : Toleranced
 OPERATING-TEMPERATURE = min-max(0.0 25.0)
 
 ; Part selection parameters
@@ -53,7 +53,6 @@ public var APPROVED-DISTRIBUTOR-LIST : Tuple<String|AuthorizedVendor> = [
   Avnet
   DigiKey
   JLCPCB
-  LCSC
   Mouser
   Newark
 ]


### PR DESCRIPTION
Remove LCSC as one of the APPROVED-DISTRIBUTOR-LIST as we don't carry them as vendor.