### PR TITLE
JITX-6927/shorten approved distributor list

### DIFF
--- a/utils/design-vars.stanza
+++ b/utils/design-vars.stanza
@@ -49,12 +49,8 @@ public var HOLE-POSITION-TOLERANCE:  Double = 0.0508 ; The tolerance on placing 
 
 ; Set it to false to allow any distributor
 public var APPROVED-DISTRIBUTOR-LIST : Tuple<String|AuthorizedVendor> = [
-  Arrow
-  Avnet
   DigiKey
-  JLCPCB
   Mouser
-  Newark
 ]
 
 ; Set it to the number of boards you intend to fabricate. Used to find components in stock when pulling components from the JITX database.


### PR DESCRIPTION
### Changes

* remove 4 vendors from APPROVED-DISTRIBUTOR-LIST
* DigiKey is ordered first, followed by Mouser