### PR TITLE
revert-capacitor-test-back-to-cathode-anode

### DIFF
--- a/tests/checks.stanza
+++ b/tests/checks.stanza
@@ -36,11 +36,11 @@ pcb-module checks :
   cap-strap(gnd, single-pin2, 10.0e-9)
   ind-strap(gnd, single-pin3, 2.2e-6)
 
-  net (gnd c1.p[1] c2.P- c3.p[1] c4.c r1.p[1] r2.p[1] d1.c)
+  net (gnd c1.p[1] c2.c c3.p[1] c4.c r1.p[1] r2.p[1] d1.c)
 
-  #EXPECT(connected?([c1.p[1] c2.P- c3.p[1] c4.c r1.p[1] r2.p[1] d1.c]))
+  #EXPECT(connected?([c1.p[1] c2.c c3.p[1] c4.c r1.p[1] r2.p[1] d1.c]))
   #EXPECT(connected?(c1.p[2]) == false)
-  #EXPECT(connected?(c2.P+) == false)
+  #EXPECT(connected?(c2.a) == false)
   #EXPECT(connected?(c3.p[2]) == false)
   #EXPECT(connected?(c4.a) == false)
   #EXPECT(connected?(r1.p[2]) == false)


### PR DESCRIPTION
revert back to c2.c and c2.a

When parts-v3 is installed to app-testing, there will be matching parts using .a and .c in symbols. Re-run CI then 