### PR TITLE
Hash Locals instead of JITXObjects

### DIFF
--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -928,7 +928,7 @@ public pcb-module test-points (count:Int, method:ocdb/utils/generic-components/T
 
 public defn add-testpoint (rs:Tuple<JITXObject>, method:ocdb/utils/generic-components/Testpoint|Instantiable) :
   inside pcb-module :
-    val unique-id = symbol-join([`TP- to-int(hash(local(rs)))])
+    val unique-id = symbol-join([`TP- to-int(hash(map(local, rs)))])
     val tp-inst = make-inst(unique-id, test-points(length(rs), method), true)
     for (r in rs, i in 0 to false) do :
       net (tp-inst.tp[i] r)

--- a/utils/generic-components.stanza
+++ b/utils/generic-components.stanza
@@ -928,7 +928,7 @@ public pcb-module test-points (count:Int, method:ocdb/utils/generic-components/T
 
 public defn add-testpoint (rs:Tuple<JITXObject>, method:ocdb/utils/generic-components/Testpoint|Instantiable) :
   inside pcb-module :
-    val unique-id = symbol-join([`TP- to-int(hash(rs))])
+    val unique-id = symbol-join([`TP- to-int(hash(local(rs)))])
     val tp-inst = make-inst(unique-id, test-points(length(rs), method), true)
     for (r in rs, i in 0 to false) do :
       net (tp-inst.tp[i] r)


### PR DESCRIPTION
A recent object core change ([linked here](https://github.com/JITx-Inc/jitx-client/pull/3983/files#r1543790951)) removes Hashable from JITXObject.
`ble-mote` crashes during runtime because it calls `add-testpoint`. I changed `hash` call to operate on the JITXObject's locals.

Also double checking @tjknoth did we want to remove Hashable?