### PR TITLE
PRD-52/Altium-GND-symbol

### DIFF
--- a/utils/symbols.stanza
+++ b/utils/symbols.stanza
@@ -103,12 +103,11 @@ public pcb-symbol altium-power-gnd-power-sym :
   name = "ALTIUM-POWER-GND-POWER"
   pin p[0] at unit-point(0.0, 0.0)
 
-  unit-line([[0.0, 0.0], [1.0, 0.0]])
-  unit-line(0.1, [[1.0, -1.0], [1.0, 1.0]])
-  unit-line(0.1, [[1.28, -0.72], [1.28, 0.72]])
-  unit-line(0.1, [[1.56, -0.44], [1.56, 0.44]])
-  unit-line(0.1, [[1.84, -0.16], [1.84, 0.16]])
-  unit-val([1.0, -0.4])
+  unit-line([[0.0, 0.0], [0.5, 0.0]])
+  unit-line(0.1, [[0.5, -0.5], [0.5, 0.5]])
+  unit-line(0.1, [[0.7, -0.3], [0.7, 0.3]])
+  unit-line(0.1, [[0.9, -0.1], [0.9, 0.1]])
+  unit-val([1.0, -1.0])
 
   preferred-orientation = PreferRotation([3])
 


### PR DESCRIPTION
* use JITX symbol for Altium GND in (tick)altium backend.
* Altium export will still shown Altium GND.
![image](https://github.com/JITx-Inc/open-components-database/assets/107752351/b8f13382-a14d-4a61-b1b4-2abeeb469612)

