### PR TITLE
added SPI RDY

### DIFF
--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:3.4.0
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:3.5.0
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/.github/jitx-client/Dockerfile
+++ b/.github/jitx-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:2.36.0
+FROM 657302324634.dkr.ecr.us-west-2.amazonaws.com/jitx-client:3.4.0
 # To pull this image locally, you need to authenticate with JITX's ECR assuming you have a jitx profile with credentials:
 # aws ecr --profile jitx get-login-password --region us-west-2 | docker login --username AWS --password-stdin 657302324634.dkr.ecr.us-west-2.amazonaws.com
 

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -153,17 +153,19 @@ public pcb-enum ocdb/utils/bundles/SPIPins :
   SPI-CIPO
   SPI-COPI
   SPI-SDIO
+  SPI-RDY
 
 public pcb-bundle spi  (pins:Tuple<SPIPins>):
   pin sck
   for p in pins do :
     switch(p) :
-      SPI-SDI : make-pin(`sdi)
-      SPI-SDO : make-pin(`sdo)
-      SPI-CS  : make-pin(`cs)
+      SPI-SDI   : make-pin(`sdi)
+      SPI-SDO   : make-pin(`sdo)
+      SPI-CS    : make-pin(`cs)
       SPI-CIPO  : make-pin(`cipo)
       SPI-COPI  : make-pin(`copi)
       SPI-SDIO  : make-pin(`sdio)
+      SPI-RDY   : make-pin(`rdy)
 
 ; Most common spi bundle
 public defn spi-peripheral () :

--- a/utils/bundles.stanza
+++ b/utils/bundles.stanza
@@ -409,12 +409,13 @@ public defn get-bundle-by-name (name:String, options:Tuple<String>) -> Bundle | 
     "spi" : spi $
       for option in options map :
         switch(option) :
-          "SPI-SDO" : SPI-SDO
-          "SPI-SDI" : SPI-SDI
-          "SPI-CS" : SPI-CS
+          "SPI-SDO"  : SPI-SDO
+          "SPI-SDI"  : SPI-SDI
+          "SPI-CS"   : SPI-CS
           "SPI-CIPO" : SPI-CIPO
           "SPI-COPI" : SPI-COPI
           "SPI-SDIO" : SPI-SDIO
+          "SPI-RDY"  : SPI-RDY
     "spi-controller" :
       spi-controller()
     else :


### PR DESCRIPTION
A new extension (maybe proprietary to STM?) is to add a RDY pin for the slave to indicate status. 

https://www.st.com/resource/en/application_note/an5543-guidelines-for-enhanced-spi-communication-on-stm32-mcus-and-mpus-stmicroelectronics.pdf