### PR TITLE
replace with pad-def

### DIFF
--- a/utils/checks.stanza
+++ b/utils/checks.stanza
@@ -194,8 +194,8 @@ public pcb-check connected (p:JITXObject|Tuple<JITXObject>) :
 ; - note: geoms unsupported
 defn copper (lp:LandPattern, side:Side) -> Seqable<Shape> :
   for pad in pads(lp) seq?: 
-    if /side(pad) == side or pad-type(/pad(pad)) == TH:
-      One(pose(pad) * pad-shape(/pad(pad)))
+    if /side(pad) == side or pad-type(pad-def(pad)) == TH:
+      One(pose(pad) * pad-shape(pad-def(pad)))
     else:
       None()
 


### PR DESCRIPTION
Replace `pad` with `pad-def` as part of deprecation process (jitx-client PR 4759)