### PR TITLE
accept toleranced or false

### DIFF
--- a/modules/solvers/voltage-divider.stanza
+++ b/modules/solvers/voltage-divider.stanza
@@ -72,13 +72,16 @@ public defn voltage-divider-solver (v-in: Toleranced,
         val r-hi-cmp = r-his[0]
         val r-lo-cmp = r-los[0]
         val vo = study-solution(v-in, r-hi-cmp, r-lo-cmp)
+        match(vo:Toleranced) :
 
-        if in-range?(v-out, vo) :
-          println("      Solved: mpn1=%_, mpn2=%_, v-out=(min=%_V, nom=%_V, max=%_V), current=%_A"
-                  % [mpn(r-hi-cmp), mpn(r-lo-cmp), min-value(v-out), typ-value(v-out), max-value(v-out), typ-value(v-out) / low(ratio)])
-          return(VoltageDividerSolution(r-hi-cmp, r-lo-cmp, vo))
+          if in-range?(v-out, vo) :
+            println("      Solved: mpn1=%_, mpn2=%_, v-out=(min=%_V, nom=%_V, max=%_V), current=%_A"
+                    % [mpn(r-hi-cmp), mpn(r-lo-cmp), min-value(v-out), typ-value(v-out), max-value(v-out), typ-value(v-out) / low(ratio)])
+            return(VoltageDividerSolution(r-hi-cmp, r-lo-cmp, vo))
+          else :
+            println("      Ignoring: not a solution when taking into account TCRs.")
         else :
-          println("      Ignoring: not a solution when taking into account TCRs.")
+            println("      Ignoring: resistor does not have TCR property.")
       else :
         println("      Ignoring: there must at least 3 resistors of each type")
 
@@ -158,20 +161,23 @@ defn query-resistors (resistance: Double, tol: Double) -> Tuple<Resistor> :
              "_exist" => ["tcr"]],
             50)
 
-defn study-solution (v-in: Toleranced, r-hi: Resistor, r-lo: Resistor) -> Toleranced :
-  val lo-drs = [compute-tcr-deviation(r-lo, min-value(OPERATING-TEMPERATURE)), 0., compute-tcr-deviation(r-lo, max-value(OPERATING-TEMPERATURE))]
-  val hi-drs = [compute-tcr-deviation(r-hi, min-value(OPERATING-TEMPERATURE)), 0., compute-tcr-deviation(r-hi, max-value(OPERATING-TEMPERATURE))]
+defn study-solution (v-in: Toleranced, r-hi: Resistor, r-lo: Resistor) -> Toleranced|False :
+  val [r-lo-dr-min, r-lo-dr-max] =
+    [compute-tcr-deviation(r-lo, min-value(OPERATING-TEMPERATURE)), compute-tcr-deviation(r-lo, max-value(OPERATING-TEMPERATURE))]
+  val [r-hi-dr-min, r-hi-dr-max] =
+    [compute-tcr-deviation(r-hi, min-value(OPERATING-TEMPERATURE)), compute-tcr-deviation(r-hi, max-value(OPERATING-TEMPERATURE))]
+  match(r-lo-dr-min:Toleranced, r-lo-dr-max:Toleranced, r-hi-dr-min:Toleranced, r-hi-dr-max:Toleranced) :
 
-  ; Calculate worst case.
-  ; TCR can be + or - here. It's a tolerance, not an absolute change in resistance
-  val lo-tolerance = tolerance(r-lo) as MinMaxRange
-  val hi-tolerance = tolerance(r-hi) as MinMaxRange
-  println("      Checking solution for existing components with: tol1=%_, tol2=%_" % [hi-tolerance, lo-tolerance])
+    ; Calculate worst case.
+    ; TCR can be + or - here. It's a tolerance, not an absolute change in resistance
+    val lo-tolerance = tolerance(r-lo) as MinMaxRange
+    val hi-tolerance = tolerance(r-hi) as MinMaxRange
+    println("      Checking solution for existing components with: tol1=%_, tol2=%_" % [hi-tolerance, lo-tolerance])
 
-  compute-output-voltage-range(v-in,
-                               resistance(r-lo),
-                               resistance(r-hi),
-                               min-max(1.0 + min(lo-tolerance), 1.0 + max(lo-tolerance)),
-                               min-max(1.0 + min(hi-tolerance), 1.0 + max(hi-tolerance)),
-                               min-max(1.0 + minimum(lo-drs), 1.0 + maximum(lo-drs)),
-                               min-max(1.0 + minimum(hi-drs), 1.0 + maximum(hi-drs)))
+    compute-output-voltage-range(v-in,
+                                 resistance(r-lo),
+                                 resistance(r-hi),
+                                 min-max(1.0 + min(lo-tolerance), 1.0 + max(lo-tolerance)),
+                                 min-max(1.0 + min(hi-tolerance), 1.0 + max(hi-tolerance)),
+                                 min-max(1.0 + min-value(r-lo-dr-min), 1.0 + max-value(r-lo-dr-max)),
+                                 min-max(1.0 + min-value(r-hi-dr-min), 1.0 + max-value(r-hi-dr-max)))


### PR DESCRIPTION
Replacing `delta-resistance` with `compute-tcr-deviation` accidentally broke the voltage divider computation, since we now get `Toleranced|False` instead of `Double`.
Now, `study-solution` can fail. It should be double-checked by an EE -- had to change the logic a bit to accomodated `Toleranced` values.